### PR TITLE
Improve English keyboard autocap behavior

### DIFF
--- a/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
@@ -1142,6 +1142,7 @@ final class KeyboardViewController: UIInputViewController {
                 }
             }
         }
+        updateShiftForAutoCap()
     }
 
     // MARK: - Character Handling (spec §5 handleCharacter / Character Acceptance Rules)
@@ -1241,6 +1242,7 @@ final class KeyboardViewController: UIInputViewController {
         isSelfUpdate = false
         updateEnglishPrediction()
         consumeShiftAfterCharacter()
+        updateShiftForAutoCap()
     }
 
     // MARK: - Backspace Handling (spec §5 handleBackspace — 6 cases)
@@ -1398,6 +1400,8 @@ final class KeyboardViewController: UIInputViewController {
         // auto-shifting them to uppercase breaks all DB lookups.
         guard mEnglishOnly else { return }
         guard !isShiftOn, !mCapsLock else { return }
+        // User-toggleable per §8.7 英文鍵盤 → 首字自動大寫
+        guard LIMEPreferenceManager.shared.autoCap else { return }
         // iOS provides autocapitalizationType directly (spec §2 iOS note)
         guard let capType = textDocumentProxy.autocapitalizationType,
               capType == .sentences || capType == .allCharacters || capType == .words else { return }

--- a/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
@@ -1406,11 +1406,70 @@ final class KeyboardViewController: UIInputViewController {
         guard let capType = textDocumentProxy.autocapitalizationType,
               capType == .sentences || capType == .allCharacters || capType == .words else { return }
         let before = textDocumentProxy.documentContextBeforeInput ?? ""
-        let atStart = before.isEmpty || before.hasSuffix(". ") || before.hasSuffix("! ") || before.hasSuffix("? ")
-        if atStart {
+        if shouldAutoCapitalize(before: before) {
             isShiftOn = true
             applyShiftState()
         }
+    }
+
+    /// LatinIME-style sentence-boundary detection (see docs/ENGLISH_KB.md §1).
+    /// Fires at start-of-document, after a newline/paragraph, or after
+    /// `. ` / `! ` / `? `, allowing trailing closing quotes/parens before the
+    /// space, and skipping `(\w\.){2,}` patterns ("U.S.", "e.g.") plus a small
+    /// allowlist of common single-word abbreviations ("Mr.", "Dr.", …).
+    internal func shouldAutoCapitalize(before: String) -> Bool {
+        if before.isEmpty { return true }
+
+        // American-typography rule: drop trailing closing quotes/parens so
+        // `She said "Hello." |` still triggers sentence-cap.
+        var s = Substring(before)
+        let closers: Set<Character> = [
+            "\"", "'", ")", "]", "}",
+            "\u{201D}",  // right double quotation mark
+            "\u{2019}",  // right single quotation mark
+        ]
+        while let last = s.last, closers.contains(last) {
+            s = s.dropLast()
+        }
+
+        // Newline / paragraph trigger.
+        if let last = s.last, last == "\n" || last == "\r" { return true }
+
+        // Must end with "<terminator><space>".
+        guard s.count >= 2, s.last == " " else { return false }
+        let term = s[s.index(s.endIndex, offsetBy: -2)]
+        guard term == "." || term == "!" || term == "?" else { return false }
+
+        // Abbreviation guard applies only to ".".
+        if term == ".", isAbbreviationBeforeDot(s.dropLast(2)) {
+            return false
+        }
+        return true
+    }
+
+    /// True if `beforeDot` looks like the tail of an abbreviation, i.e. the
+    /// trailing `.` is part of an abbreviation rather than a sentence end.
+    /// Matches LatinIME's `(\w\.){2,}` (covers "U.S.", "e.g.", "i.e.") plus a
+    /// small allowlist of common single-word abbreviations.
+    internal func isAbbreviationBeforeDot(_ beforeDot: Substring) -> Bool {
+        guard let last = beforeDot.last, last.isLetter else { return false }
+
+        // `(\w\.){2,}` tail: previous char is itself a `.` — covers "U.S",
+        // "e.g", "i.e", "a.m", "p.m" before the trailing dot.
+        if beforeDot.dropLast().last == "." { return true }
+
+        // Trailing word run (allowlist match).
+        var idx = beforeDot.endIndex
+        while idx > beforeDot.startIndex {
+            let prev = beforeDot.index(before: idx)
+            if beforeDot[prev].isLetter { idx = prev } else { break }
+        }
+        let word = String(beforeDot[idx..<beforeDot.endIndex])
+        let allowList: Set<String> = [
+            "Mr", "Mrs", "Ms", "Dr", "Prof", "Jr", "Sr", "St",
+            "etc", "vs", "Ltd", "Inc", "Co", "Mt", "Ft",
+        ]
+        return allowList.contains(word)
     }
 
     // MARK: - iOS Composing Simulation (spec §12)

--- a/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
@@ -1129,7 +1129,15 @@ final class KeyboardViewController: UIInputViewController {
             if !isEnter, !mEnglishOnly, isPhonetic, !mComposing.isEmpty {
                 handleCharacter(LimeKeyCode.space.rawValue)  // space as tone mark
             } else {
-                textDocumentProxy.insertText(isEnter ? "\n" : " ")
+                if !isEnter,
+                   mEnglishOnly,
+                   LIMEPreferenceManager.shared.autoCap,
+                   shouldInsertPeriodForDoubleSpace(before: textDocumentProxy.documentContextBeforeInput ?? "") {
+                    textDocumentProxy.deleteBackward()
+                    textDocumentProxy.insertText(". ")
+                } else {
+                    textDocumentProxy.insertText(isEnter ? "\n" : " ")
+                }
                 // Space or enter in English mode: word boundary crossed — reset prediction.
                 if mEnglishOnly {
                     resetTempEnglishWord()
@@ -1418,33 +1426,7 @@ final class KeyboardViewController: UIInputViewController {
     /// space, and skipping `(\w\.){2,}` patterns ("U.S.", "e.g.") plus a small
     /// allowlist of common single-word abbreviations ("Mr.", "Dr.", …).
     internal func shouldAutoCapitalize(before: String) -> Bool {
-        if before.isEmpty { return true }
-
-        // American-typography rule: drop trailing closing quotes/parens so
-        // `She said "Hello." |` still triggers sentence-cap.
-        var s = Substring(before)
-        let closers: Set<Character> = [
-            "\"", "'", ")", "]", "}",
-            "\u{201D}",  // right double quotation mark
-            "\u{2019}",  // right single quotation mark
-        ]
-        while let last = s.last, closers.contains(last) {
-            s = s.dropLast()
-        }
-
-        // Newline / paragraph trigger.
-        if let last = s.last, last == "\n" || last == "\r" { return true }
-
-        // Must end with "<terminator><space>".
-        guard s.count >= 2, s.last == " " else { return false }
-        let term = s[s.index(s.endIndex, offsetBy: -2)]
-        guard term == "." || term == "!" || term == "?" else { return false }
-
-        // Abbreviation guard applies only to ".".
-        if term == ".", isAbbreviationBeforeDot(s.dropLast(2)) {
-            return false
-        }
-        return true
+        EnglishKeyboardPolicy.shouldAutoCapitalize(before: before)
     }
 
     /// True if `beforeDot` looks like the tail of an abbreviation, i.e. the
@@ -1452,24 +1434,11 @@ final class KeyboardViewController: UIInputViewController {
     /// Matches LatinIME's `(\w\.){2,}` (covers "U.S.", "e.g.", "i.e.") plus a
     /// small allowlist of common single-word abbreviations.
     internal func isAbbreviationBeforeDot(_ beforeDot: Substring) -> Bool {
-        guard let last = beforeDot.last, last.isLetter else { return false }
+        !EnglishKeyboardPolicy.shouldAutoCapitalize(before: "\(beforeDot). ")
+    }
 
-        // `(\w\.){2,}` tail: previous char is itself a `.` — covers "U.S",
-        // "e.g", "i.e", "a.m", "p.m" before the trailing dot.
-        if beforeDot.dropLast().last == "." { return true }
-
-        // Trailing word run (allowlist match).
-        var idx = beforeDot.endIndex
-        while idx > beforeDot.startIndex {
-            let prev = beforeDot.index(before: idx)
-            if beforeDot[prev].isLetter { idx = prev } else { break }
-        }
-        let word = String(beforeDot[idx..<beforeDot.endIndex])
-        let allowList: Set<String> = [
-            "Mr", "Mrs", "Ms", "Dr", "Prof", "Jr", "Sr", "St",
-            "etc", "vs", "Ltd", "Inc", "Co", "Mt", "Ft",
-        ]
-        return allowList.contains(word)
+    internal func shouldInsertPeriodForDoubleSpace(before: String) -> Bool {
+        EnglishKeyboardPolicy.shouldInsertPeriodForDoubleSpace(before: before)
     }
 
     // MARK: - iOS Composing Simulation (spec §12)

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_abc_ipad.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_abc_ipad.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "lime_abc_ipad",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -906,14 +906,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_abc_ipad_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_abc_ipad_shift.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "lime_abc_ipad_shift",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -906,14 +906,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_english_ipad.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_english_ipad.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "lime_english_ipad",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -906,14 +906,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_english_ipad_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_english_ipad_shift.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "lime_english_ipad_shift",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -906,14 +906,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_english_number_ipad.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_english_number_ipad.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "lime_english_number_ipad",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -906,14 +906,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_english_number_ipad_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_english_number_ipad_shift.json
@@ -906,14 +906,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_number_ipad.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_number_ipad.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "lime_number_ipad",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -906,14 +906,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_number_ipad_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_number_ipad_shift.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "lime_number_ipad_shift",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -906,14 +906,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_shift_ipad.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_shift_ipad.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "lime_shift_ipad",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -906,14 +906,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/symbols1_ipad.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/symbols1_ipad.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "symbols1_ipad",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -938,14 +938,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/symbols2_ipad.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/symbols2_ipad.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "symbols2_ipad",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -938,14 +938,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/symbols3_ipad.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/symbols3_ipad.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "id": "symbols3_ipad",
   "defaultWidthPercent": 7.15,
   "rows": [
@@ -938,14 +938,14 @@
           "popupCharacters": ""
         },
         {
-          "code": -99,
+          "code": -201,
           "codes": [
-            -99
+            -201
           ],
           "label": "",
           "sublabel": "",
           "widthPercent": 7.0,
-          "icon": "mic",
+          "icon": "face.smiling",
           "isModifier": true,
           "isRepeatable": false,
           "isSticky": false,

--- a/LimeIME-iOS/LimeSettings/LimeSettingsView.swift
+++ b/LimeIME-iOS/LimeSettings/LimeSettingsView.swift
@@ -1,4 +1,4 @@
-// LimeSettingsView.swift
+﻿// LimeSettingsView.swift
 // LimeIME-iOS
 //
 // Root 5-tab TabView. Hosted via UIHostingController from MainViewController.
@@ -138,11 +138,12 @@ private extension View {
 struct ConstrainedDetailLayout<Trailing: View>: ViewModifier {
     let title: String
     let trailing: () -> Trailing
+    private let titleSectionHeight: CGFloat = 60
     @Environment(\.dismiss) private var dismiss
 
     func body(content: Content) -> some View {
         VStack(spacing: 0) {
-            HStack(spacing: 12) {
+            HStack {
                 Button {
                     dismiss()
                 } label: {
@@ -151,17 +152,19 @@ struct ConstrainedDetailLayout<Trailing: View>: ViewModifier {
                         .foregroundStyle(.tint)
                 }
                 Spacer()
-                trailing()
             }
             .padding(.horizontal, 20)
             .padding(.top, 12)
 
-            Text(title)
-                .font(.largeTitle.bold())
-                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(alignment: .center, spacing: 12) {
+                Text(title)
+                    .font(.largeTitle.bold())
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                trailing()
+            }
+                .frame(height: titleSectionHeight)
                 .padding(.horizontal, 20)
-                .padding(.top, 4)
-                .padding(.bottom, 8)
 
             content
         }
@@ -172,6 +175,19 @@ struct ConstrainedDetailLayout<Trailing: View>: ViewModifier {
 }
 
 extension View {
+    /// Match SetupTabView's white page with gray grouped blocks for
+    /// settings/list-style screens that use SwiftUI List or Form.
+    func setupMatchedGroupedSurface() -> some View {
+        self
+            .scrollContentBackground(.hidden)
+            .background(Color(.systemBackground))
+    }
+
+    /// Apply SetupTabView's gray block fill to rows inside a List/Form.
+    func setupMatchedSectionBlock() -> some View {
+        self.listRowBackground(Color(.secondarySystemBackground))
+    }
+
     /// Apply the standard constrained-detail layout (chevron + static title
     /// + 560pt column + hidden system nav bar). No trailing toolbar items.
     func constrainedDetailLayout(_ title: String) -> some View {

--- a/LimeIME-iOS/LimeSettings/Views/IMDetailView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/IMDetailView.swift
@@ -92,6 +92,7 @@ struct IMDetailView: View {
                 }
                 LabeledContent("筆數", value: totalRecord)
             }
+            .setupMatchedSectionBlock()
 
             if im.tableNick != "related" {
                 Section(header: Text("軟鍵盤配置")) {
@@ -99,6 +100,7 @@ struct IMDetailView: View {
                         LabeledContent("鍵盤佈局", value: keyboardName.isEmpty ? "—" : keyboardName)
                     }
                 }
+                .setupMatchedSectionBlock()
             }
 
             // Phonetic keyboard type (§5.2.2 — moved here because the pref only
@@ -114,6 +116,7 @@ struct IMDetailView: View {
                         updatePhoneticKeyboard(type: newType)
                     }
                 }
+                .setupMatchedSectionBlock()
             }
 
             // Array10 phone-numpad auto-commit setting
@@ -131,6 +134,7 @@ struct IMDetailView: View {
                         }
                     }
                 }
+                .setupMatchedSectionBlock()
             }
 
             // §13.3 — shown only for the user-built custom IM
@@ -151,6 +155,7 @@ struct IMDetailView: View {
                         }
                     }
                 }
+                .setupMatchedSectionBlock()
             }
 
             Section(header: Text(im.tableNick == "related" ? "關聯字庫" : "字根資料表")) {
@@ -165,6 +170,7 @@ struct IMDetailView: View {
                     }
                 }
             }
+            .setupMatchedSectionBlock()
 
             if im.tableNick == "related" {
                 Section {
@@ -178,12 +184,14 @@ struct IMDetailView: View {
                         }
                     }
                 }
+                .setupMatchedSectionBlock()
             }
 
             if im.tableNick != "related" {
                 Section(header: Text("選項")) {
                     Toggle("刪除時備份已學習記錄", isOn: backupOnDeleteBinding)
                 }
+                .setupMatchedSectionBlock()
             }
 
             if im.tableNick != "related" {
@@ -203,18 +211,19 @@ struct IMDetailView: View {
                     }
                     .disabled(isRemoving)
                 }
+                .setupMatchedSectionBlock()
             }
         }
-        .constrainedDetailLayout(im.label)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    showSharePicker = true
-                } label: {
-                    Image(systemName: "square.and.arrow.up")
-                }
-                .disabled(isExporting)
+        .setupMatchedGroupedSurface()
+        .constrainedDetailLayout(im.label) {
+            Button {
+                showSharePicker = true
+            } label: {
+                Image(systemName: "square.and.arrow.up")
+                    .font(.title2.weight(.semibold))
+                    .frame(width: 44, height: 44)
             }
+            .disabled(isExporting)
         }
         .confirmationDialog("匯出格式", isPresented: $showSharePicker, titleVisibility: .visible) {
             if im.tableNick != "related" {

--- a/LimeIME-iOS/LimeSettings/Views/IMInstallView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/IMInstallView.swift
@@ -81,6 +81,7 @@ struct IMInstallView: View {
                     }
                 }
             }
+            .setupMatchedSectionBlock()
 
             // MARK: Status
             if !statusMessage.isEmpty {
@@ -89,6 +90,7 @@ struct IMInstallView: View {
                         .font(.footnote)
                         .foregroundColor(.secondary)
                 }
+                .setupMatchedSectionBlock()
             }
 
             // MARK: Per-IM DisclosureGroups (§5.3 / §13.3)
@@ -151,8 +153,10 @@ struct IMInstallView: View {
                     }
                 }
             }
+            .setupMatchedSectionBlock()
         }
         .listStyle(.insetGrouped)
+        .setupMatchedGroupedSurface()
         .constrainedDetailLayout("下載 / 匯入輸入法") {
             Button {
                 downloadManager.refreshInstalledTables()

--- a/LimeIME-iOS/LimeSettings/Views/IMListView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/IMListView.swift
@@ -1,4 +1,4 @@
-// IMListView.swift
+﻿// IMListView.swift
 // LimeIME-iOS
 //
 // IM Manager tab — list of installed IMs with enable/disable and reorder.
@@ -131,12 +131,14 @@ struct IMListView: View {
                             .onMove(perform: moveIMs)
                         }
                     }
+                    .setupMatchedSectionBlock()
 
                     Section(header: Text("關聯字庫")) {
                         NavigationLink(value: DetailSelection.related) {
                             Label("關聯字庫", systemImage: "text.bubble")
                         }
                     }
+                    .setupMatchedSectionBlock()
                 }
                 .overlay(alignment: .bottomTrailing) {
                     Button {
@@ -153,6 +155,7 @@ struct IMListView: View {
                     .padding([.bottom, .trailing], 20)
                 }
                 .listStyle(.insetGrouped)
+                .setupMatchedGroupedSurface()
             }
         }
     }

--- a/LimeIME-iOS/LimeSettings/Views/KeyboardPickerView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/KeyboardPickerView.swift
@@ -1,4 +1,4 @@
-// KeyboardPickerView.swift
+﻿// KeyboardPickerView.swift
 // LimeIME-iOS
 //
 // Soft keyboard layout selection for a given IM.
@@ -41,7 +41,9 @@ struct KeyboardPickerView: View {
                     selectKeyboard(kb)
                 }
             }
+            .setupMatchedSectionBlock()
         }
+        .setupMatchedGroupedSurface()
         .constrainedDetailLayout("選擇鍵盤佈局")
         .task { await loadKeyboards() }
     }

--- a/LimeIME-iOS/LimeSettings/Views/PreferencesTabView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/PreferencesTabView.swift
@@ -127,6 +127,7 @@ struct PreferencesTabView: View {
                         }
                     }
                 }
+                .setupMatchedSectionBlock()
 
                 // MARK: §8.2
                 Section(header: Text("鍵盤回饋")) {
@@ -139,6 +140,7 @@ struct PreferencesTabView: View {
                     .disabled(!vibrateOnKeypress)
                     Toggle("打字音效", isOn: $soundOnKeypress)
                 }
+                .setupMatchedSectionBlock()
 
                 // MARK: §8.4
                 Section(header: Text("輸入法行為")) {
@@ -161,6 +163,7 @@ struct PreferencesTabView: View {
                         Label("字根反查設定", systemImage: "magnifyingglass")
                     }
                 }
+                .setupMatchedSectionBlock()
 
                 // §5.2.2 — 鍵盤類型 lives in IMDetailView for the phonetic IM, not here.
 
@@ -173,6 +176,7 @@ struct PreferencesTabView: View {
                     }
                     .pickerStyle(.segmented)
                 }
+                .setupMatchedSectionBlock()
 
                 // MARK: §8.6
                 Section(header: Text("關聯字與學習")) {
@@ -181,14 +185,17 @@ struct PreferencesTabView: View {
                     Toggle(isOn: $learnPhrase) { prefRow("自動學習新詞", "從常用關聯字學習新詞") }
                     Toggle(isOn: $learningSwitch) { prefRow("啟動選取排序", "依選取次數排序選字清單") }
                 }
+                .setupMatchedSectionBlock()
 
                 // MARK: §8.7
                 Section(header: Text("英文鍵盤")) {
                     Toggle(isOn: $englishDictEnable) { prefRow("啟用英文字典", "當使用 英文 輸入模式時，顯示英文建議字") }
                     Toggle(isOn: $autoCap) { prefRow("首字自動大寫", "在英文模式下，句首字母自動轉為大寫") }
                 }
+                .setupMatchedSectionBlock()
 
                 }
+                .setupMatchedGroupedSurface()
             }
             // iPad / wide-screen reading-width cap. Same 560pt width that
             // SetupTabView and DBManagerView use so the Preferences form

--- a/LimeIME-iOS/LimeSettings/Views/PreferencesTabView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/PreferencesTabView.swift
@@ -43,8 +43,9 @@ struct PreferencesTabView: View {
     @AppStorage("learn_phrase",           store: sharedDefaults) private var learnPhrase: Bool = true
     @AppStorage("learning_switch",        store: sharedDefaults) private var learningSwitch: Bool = true
 
-    // MARK: §8.7 English Dictionary
+    // MARK: §8.7 English Keyboard
     @AppStorage("english_dictionary_enable", store: sharedDefaults) private var englishDictEnable: Bool = true
+    @AppStorage("auto_cap",                  store: sharedDefaults) private var autoCap: Bool = true
 
     // MARK: Options
 
@@ -182,8 +183,9 @@ struct PreferencesTabView: View {
                 }
 
                 // MARK: §8.7
-                Section(header: Text("英文字典")) {
+                Section(header: Text("英文鍵盤")) {
                     Toggle(isOn: $englishDictEnable) { prefRow("啟用英文字典", "當使用 英文 輸入模式時，顯示英文建議字") }
+                    Toggle(isOn: $autoCap) { prefRow("首字自動大寫", "在英文模式下，句首字母自動轉為大寫") }
                 }
 
                 }

--- a/LimeIME-iOS/LimeSettings/Views/ReverseLookupSettingsView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/ReverseLookupSettingsView.swift
@@ -25,6 +25,7 @@ struct ReverseLookupSettingsView: View {
                     .font(.footnote)
                     .foregroundColor(.secondary)
             }
+            .setupMatchedSectionBlock()
 
             Section(header: Text("各輸入法反查來源")) {
                 if lookupTargets.isEmpty {
@@ -36,7 +37,9 @@ struct ReverseLookupSettingsView: View {
                     }
                 }
             }
+            .setupMatchedSectionBlock()
         }
+        .setupMatchedGroupedSurface()
         .constrainedDetailLayout("字根反查設定")
         .task { await loadLookupOptions() }
     }

--- a/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
+++ b/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
@@ -265,6 +265,23 @@ final class KeyboardViewControllerTest: XCTestCase {
                                                             wasShiftAlreadyHeld: true))
     }
 
+    func testEnglishAutoCapRecognizesNewlinesQuotesAndAbbreviations() {
+        XCTAssertTrue(EnglishKeyboardPolicy.shouldAutoCapitalize(before: "Hello.\n"))
+        XCTAssertTrue(EnglishKeyboardPolicy.shouldAutoCapitalize(before: "She said \"Hello.\" "))
+        XCTAssertTrue(EnglishKeyboardPolicy.shouldAutoCapitalize(before: "Ready?) "))
+        XCTAssertFalse(EnglishKeyboardPolicy.shouldAutoCapitalize(before: "e."))
+        XCTAssertFalse(EnglishKeyboardPolicy.shouldAutoCapitalize(before: "Mr. "))
+        XCTAssertFalse(EnglishKeyboardPolicy.shouldAutoCapitalize(before: "U.S. "))
+    }
+
+    func testEnglishDoubleSpacePeriodOnlyAfterWordLikeContext() {
+        XCTAssertTrue(EnglishKeyboardPolicy.shouldInsertPeriodForDoubleSpace(before: "hello "))
+        XCTAssertTrue(EnglishKeyboardPolicy.shouldInsertPeriodForDoubleSpace(before: "Go2 "))
+        XCTAssertTrue(EnglishKeyboardPolicy.shouldInsertPeriodForDoubleSpace(before: "done) "))
+        XCTAssertFalse(EnglishKeyboardPolicy.shouldInsertPeriodForDoubleSpace(before: "hello. "))
+        XCTAssertFalse(EnglishKeyboardPolicy.shouldInsertPeriodForDoubleSpace(before: "http://lime-ime.github.io "))
+    }
+
     func testIOSBundlesDoNotDeclareVoiceInputPrivacyUsageDescriptions() throws {
         for plistURL in [
             projectFileURL("LimeKeyboard/Info.plist"),

--- a/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
+++ b/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
@@ -104,6 +104,21 @@ final class KeyboardViewControllerTest: XCTestCase {
         }
     }
 
+    func testAllIPadJsonLayoutsUseEmojiInsteadOfMic() throws {
+        let layoutsURL = projectFileURL("LimeKeyboard/Layouts")
+        let urls = try FileManager.default.contentsOfDirectory(
+            at: layoutsURL,
+            includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.contains("_ipad") && $0.pathExtension == "json" }
+
+        XCTAssertFalse(urls.isEmpty)
+        for url in urls {
+            let source = try String(contentsOf: url, encoding: .utf8)
+            XCTAssertFalse(source.contains(#""icon": "mic""#), url.lastPathComponent)
+            XCTAssertFalse(source.contains(#""code": -99"#), url.lastPathComponent)
+        }
+    }
+
     func testIPadBottomRowSumsToHundredPercent() throws {
         for id in iPadLayoutsForBottomRowAudit {
             let layout = try loadKeyboardLayoutFixture(id)
@@ -404,6 +419,48 @@ final class KeyboardViewControllerTest: XCTestCase {
         XCTAssertTrue(source.contains("return !hasCandidates && idleRevealReady && !idleToolsSuppressed && allowTool"))
         XCTAssertTrue(source.contains("shouldShowActiveChrome"))
         XCTAssertTrue(source.contains("return hasCandidates || (!showIdleTools && !idleRevealReady)"))
+    }
+
+    func testIMDetailShareButtonUsesConstrainedLayoutTrailingSlot() throws {
+        let sourceURL = projectFileURL("LimeSettings/Views/IMDetailView.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        let layoutSource = try String(
+            contentsOf: projectFileURL("LimeSettings/LimeSettingsView.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(source.contains(".constrainedDetailLayout(im.label) {"))
+        XCTAssertFalse(source.contains("ToolbarItem(placement: .navigationBarTrailing)"))
+        XCTAssertTrue(source.contains("showSharePicker = true"))
+        XCTAssertTrue(source.contains("square.and.arrow.up"))
+        XCTAssertTrue(source.contains(".font(.title2.weight(.semibold))"))
+        XCTAssertTrue(source.contains(".frame(width: 44, height: 44)"))
+        XCTAssertTrue(layoutSource.contains("private let titleSectionHeight: CGFloat = 60"))
+        XCTAssertTrue(layoutSource.contains("HStack(alignment: .center, spacing: 12)"))
+        XCTAssertTrue(layoutSource.contains(".frame(height: titleSectionHeight)"))
+    }
+
+    func testSettingsGroupedSurfacesMatchSetupTabColors() throws {
+        let settingsSource = try String(
+            contentsOf: projectFileURL("LimeSettings/LimeSettingsView.swift"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(settingsSource.contains("func setupMatchedGroupedSurface() -> some View"))
+        XCTAssertTrue(settingsSource.contains(".scrollContentBackground(.hidden)"))
+        XCTAssertTrue(settingsSource.contains(".background(Color(.systemBackground))"))
+        XCTAssertTrue(settingsSource.contains(".listRowBackground(Color(.secondarySystemBackground))"))
+
+        for relativePath in [
+            "LimeSettings/Views/IMListView.swift",
+            "LimeSettings/Views/IMDetailView.swift",
+            "LimeSettings/Views/IMInstallView.swift",
+            "LimeSettings/Views/KeyboardPickerView.swift",
+            "LimeSettings/Views/PreferencesTabView.swift",
+            "LimeSettings/Views/ReverseLookupSettingsView.swift"
+        ] {
+            let source = try String(contentsOf: projectFileURL(relativePath), encoding: .utf8)
+            XCTAssertTrue(source.contains(".setupMatchedGroupedSurface()"), relativePath)
+        }
     }
 
     private func emojiMapping(_ word: String) -> Mapping {

--- a/LimeIME-iOS/Shared/Models/KeyLayout.swift
+++ b/LimeIME-iOS/Shared/Models/KeyLayout.swift
@@ -399,3 +399,67 @@ enum ShiftHoldTouchPolicy {
         (wasShiftAlreadyHeld && activeTouchCount > 0) || activeTouchCount > 1
     }
 }
+
+enum EnglishKeyboardPolicy {
+    private static let closingPunctuation: Set<Character> = [
+        "\"", "'", ")", "]", "}",
+        "\u{201D}", "\u{2019}",
+    ]
+
+    private static let abbreviationWords: Set<String> = [
+        "Mr", "Mrs", "Ms", "Dr", "Prof", "Jr", "Sr", "St",
+        "etc", "vs", "Ltd", "Inc", "Co", "Mt", "Ft",
+    ]
+
+    static func shouldAutoCapitalize(before: String) -> Bool {
+        if before.isEmpty { return true }
+
+        var s = Substring(before)
+        var hasBoundaryWhitespace = false
+        while let last = s.last, last == " " || last == "\t" {
+            hasBoundaryWhitespace = true
+            s = s.dropLast()
+        }
+        while let last = s.last, closingPunctuation.contains(last) {
+            s = s.dropLast()
+        }
+
+        if let last = s.last, last == "\n" || last == "\r" { return true }
+        guard hasBoundaryWhitespace else { return false }
+        guard let term = s.last, term == "." || term == "!" || term == "?" else { return false }
+
+        if term == ".", isAbbreviationBeforeDot(s.dropLast()) {
+            return false
+        }
+        return true
+    }
+
+    static func shouldInsertPeriodForDoubleSpace(before: String) -> Bool {
+        guard before.hasSuffix(" "), before.count >= 2 else { return false }
+        let beforeSpace = before.dropLast()
+        guard let previous = beforeSpace.last else { return false }
+
+        if ".!?,:;".contains(previous) { return false }
+        let tokenStart = beforeSpace.lastIndex(where: { $0.isWhitespace })
+            .map { beforeSpace.index(after: $0) } ?? beforeSpace.startIndex
+        let token = String(beforeSpace[tokenStart...])
+        if token.contains("://") || token.contains(".") { return false }
+
+        if previous.isLetter || previous.isNumber { return true }
+        return closingPunctuation.contains(previous)
+    }
+
+    private static func isAbbreviationBeforeDot(_ beforeDot: Substring) -> Bool {
+        guard let last = beforeDot.last, last.isLetter else { return false }
+
+        if beforeDot.dropLast().last == "." { return true }
+
+        var idx = beforeDot.endIndex
+        while idx > beforeDot.startIndex {
+            let prev = beforeDot.index(before: idx)
+            if beforeDot[prev].isLetter { idx = prev } else { break }
+        }
+        let word = String(beforeDot[idx..<beforeDot.endIndex])
+        return abbreviationWords.contains(word)
+    }
+}

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
@@ -11468,4 +11468,23 @@ public class LIMEServiceTest {
         assertTrue("Cache hit test completed", true);
     }
 
+    @Test
+    public void test_8_7_EnglishAutoCapRecognizesNewlinesQuotesAndAbbreviations() {
+        assertTrue(LIMEService.shouldAutoCapitalizeEnglishText("Hello.\n"));
+        assertTrue(LIMEService.shouldAutoCapitalizeEnglishText("She said \"Hello.\" "));
+        assertTrue(LIMEService.shouldAutoCapitalizeEnglishText("Ready?) "));
+        assertFalse(LIMEService.shouldAutoCapitalizeEnglishText("e."));
+        assertFalse(LIMEService.shouldAutoCapitalizeEnglishText("Mr. "));
+        assertFalse(LIMEService.shouldAutoCapitalizeEnglishText("U.S. "));
+    }
+
+    @Test
+    public void test_8_7_EnglishDoubleSpacePeriodOnlyAfterWordLikeContext() {
+        assertTrue(LIMEService.shouldInsertPeriodForEnglishDoubleSpace("hello "));
+        assertTrue(LIMEService.shouldInsertPeriodForEnglishDoubleSpace("Go2 "));
+        assertTrue(LIMEService.shouldInsertPeriodForEnglishDoubleSpace("done) "));
+        assertFalse(LIMEService.shouldInsertPeriodForEnglishDoubleSpace("hello. "));
+        assertFalse(LIMEService.shouldInsertPeriodForEnglishDoubleSpace("http://lime-ime.github.io "));
+    }
+
 }

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
@@ -996,7 +996,7 @@ public class LIMEService extends InputMethodService
         mPersistentLanguageMode = mLIMEPref.getPersistentLanguageMode();
         activeIM = mLIMEPref.getActiveIM();
         hasQuickSwitch = mLIMEPref.getSwitchEnglishModeHotKey();
-        mAutoCap = true;
+        mAutoCap = mLIMEPref.getAutoCaptalization();
 
         mPersistentLanguageMode = mLIMEPref.getPersistentLanguageMode();
         mShowArrowKeys = mLIMEPref.getShowArrowKeys();

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
@@ -1850,6 +1850,10 @@ public class LIMEService extends InputMethodService
             EditorInfo ei = getCurrentInputEditorInfo();
             if (mAutoCap && ei != null && ei.inputType != EditorInfo.TYPE_NULL) {
                 caps = ic.getCursorCapsMode(attr.inputType);
+                if (caps == 0 && mEnglishOnly
+                        && shouldAutoCapitalizeEnglishText(ic.getTextBeforeCursor(64, 0))) {
+                    caps = 1;
+                }
             }
             mInputView.setShifted(mCapsLock || caps != 0);
         } else {
@@ -1859,6 +1863,91 @@ public class LIMEService extends InputMethodService
             }
         }
 
+    }
+
+    static boolean shouldAutoCapitalizeEnglishText(CharSequence beforeCursor) {
+        if (beforeCursor == null || beforeCursor.length() == 0) {
+            return true;
+        }
+
+        int end = beforeCursor.length();
+        boolean hasBoundaryWhitespace = false;
+        while (end > 0) {
+            char c = beforeCursor.charAt(end - 1);
+            if (c == ' ' || c == '\t') {
+                hasBoundaryWhitespace = true;
+                end--;
+            } else {
+                break;
+            }
+        }
+        while (end > 0 && isEnglishClosingPunctuation(beforeCursor.charAt(end - 1))) {
+            end--;
+        }
+        if (end == 0) {
+            return true;
+        }
+
+        char term = beforeCursor.charAt(end - 1);
+        if (term == '\n' || term == '\r') {
+            return true;
+        }
+        if (!hasBoundaryWhitespace) {
+            return false;
+        }
+        if (term != '.' && term != '!' && term != '?') {
+            return false;
+        }
+        return term != '.' || !isEnglishAbbreviationBeforeDot(beforeCursor, end - 1);
+    }
+
+    static boolean shouldInsertPeriodForEnglishDoubleSpace(CharSequence beforeCursor) {
+        if (beforeCursor == null || beforeCursor.length() < 2
+                || beforeCursor.charAt(beforeCursor.length() - 1) != ' ') {
+            return false;
+        }
+
+        int previousIndex = beforeCursor.length() - 2;
+        char previous = beforeCursor.charAt(previousIndex);
+        if (".!?,:;".indexOf(previous) >= 0) {
+            return false;
+        }
+
+        int tokenStart = previousIndex;
+        while (tokenStart > 0 && !Character.isWhitespace(beforeCursor.charAt(tokenStart - 1))) {
+            tokenStart--;
+        }
+        String token = beforeCursor.subSequence(tokenStart, previousIndex + 1).toString();
+        if (token.contains("://") || token.contains(".")) {
+            return false;
+        }
+
+        return Character.isLetterOrDigit(previous) || isEnglishClosingPunctuation(previous);
+    }
+
+    private static boolean isEnglishClosingPunctuation(char c) {
+        return c == '"' || c == '\'' || c == ')' || c == ']' || c == '}'
+                || c == '\u201D' || c == '\u2019';
+    }
+
+    private static boolean isEnglishAbbreviationBeforeDot(CharSequence text, int dotIndex) {
+        if (dotIndex <= 0 || !Character.isLetter(text.charAt(dotIndex - 1))) {
+            return false;
+        }
+        if (dotIndex >= 2 && text.charAt(dotIndex - 2) == '.') {
+            return true;
+        }
+
+        int start = dotIndex - 1;
+        while (start > 0 && Character.isLetter(text.charAt(start - 1))) {
+            start--;
+        }
+        String word = text.subSequence(start, dotIndex).toString();
+        return "Mr".equals(word) || "Mrs".equals(word) || "Ms".equals(word)
+                || "Dr".equals(word) || "Prof".equals(word) || "Jr".equals(word)
+                || "Sr".equals(word) || "St".equals(word) || "etc".equals(word)
+                || "vs".equals(word) || "Ltd".equals(word) || "Inc".equals(word)
+                || "Co".equals(word) || "Mt".equals(word) || "Ft".equals(word);
     }
 
     private boolean isValidLetter(int code) {
@@ -4676,6 +4765,20 @@ public class LIMEService extends InputMethodService
                 }
             }
 
+            InputConnection ic = getCurrentInputConnection();
+            if (primaryCode == MY_KEYCODE_SPACE && mAutoCap && ic != null
+                    && shouldInsertPeriodForEnglishDoubleSpace(ic.getTextBeforeCursor(64, 0))) {
+                resetTempEnglishWord();
+                if (mLIMEPref.getEnglishPrediction() && mPredictionOn) {
+                    this.updateEnglishPrediction();
+                }
+                ic.deleteSurroundingText(1, 0);
+                ic.commitText(". ", 1);
+                if (!(!hasPhysicalKeyPressed && hasDistinctMultitouch))
+                    updateShiftKeyState(getCurrentInputEditorInfo());
+                return;
+            }
+
             if (mLIMEPref.getEnglishPrediction() && mPredictionOn && !mKeyboardSwitcher.isSymbols()
                     && (!hasPhysicalKeyPressed || mLIMEPref.getEnglishPredictionOnPhysicalKeyboard())
             ) {
@@ -4689,8 +4792,9 @@ public class LIMEService extends InputMethodService
 
             }
 
-            getCurrentInputConnection().commitText(
-                    String.valueOf((char) primaryCode), 1);
+            if (ic != null) {
+                ic.commitText(String.valueOf((char) primaryCode), 1);
+            }
         }
 
         if (!(!hasPhysicalKeyPressed && hasDistinctMultitouch))

--- a/LimeStudio/app/src/main/res/values/strings_settings.xml
+++ b/LimeStudio/app/src/main/res/values/strings_settings.xml
@@ -829,7 +829,7 @@
     <string name="pref_section_im_behaviour">輸入法行為</string>
     <string name="pref_section_han_convert">簡繁轉換</string>
     <string name="pref_section_related_learning">關聯字與學習</string>
-    <string name="pref_section_english_dictionary">英文字典</string>
+    <string name="pref_section_english_dictionary">英文鍵盤</string>
     <string name="pref_section_physical_keyboard">外接鍵盤</string>
 
     <string name="share_format_text">.lime (文字)</string>

--- a/LimeStudio/app/src/main/res/xml-v17/preference.xml
+++ b/LimeStudio/app/src/main/res/xml-v17/preference.xml
@@ -298,7 +298,7 @@
             android:title="@string/learning_switch" />
     </PreferenceCategory>
 
-    <!-- 7. 英文字典 -->
+    <!-- 7. 英文鍵盤 -->
     <PreferenceCategory
         android:key="pref_section_english_dictionary"
         android:title="@string/pref_section_english_dictionary">
@@ -307,6 +307,11 @@
             android:key="english_dictionary_enable"
             android:summary="@string/enable_english_dictionary_summary"
             android:title="@string/enable_english_dictionary" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="auto_cap"
+            android:summary="@string/auto_cap_summary"
+            android:title="@string/auto_cap" />
     </PreferenceCategory>
 
     <!-- 9. 外接鍵盤 -->

--- a/LimeStudio/app/src/main/res/xml/preference.xml
+++ b/LimeStudio/app/src/main/res/xml/preference.xml
@@ -298,7 +298,7 @@
             android:title="@string/learning_switch" />
     </PreferenceCategory>
 
-    <!-- 7. 英文字典 -->
+    <!-- 7. 英文鍵盤 -->
     <PreferenceCategory
         android:key="pref_section_english_dictionary"
         android:title="@string/pref_section_english_dictionary">
@@ -307,6 +307,11 @@
             android:key="english_dictionary_enable"
             android:summary="@string/enable_english_dictionary_summary"
             android:title="@string/enable_english_dictionary" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="auto_cap"
+            android:summary="@string/auto_cap_summary"
+            android:title="@string/auto_cap" />
     </PreferenceCategory>
 
     <!-- 9. 外接鍵盤 -->

--- a/docs/ENGLISH_KB.md
+++ b/docs/ENGLISH_KB.md
@@ -1,0 +1,244 @@
+﻿# English Keyboard — Behavior Reference & Improvement Plan
+
+Comparison of LimeIME's English-mode behavior against AOSP **LatinIME** (the
+open-source ancestor of Google's gboard; gboard itself is closed-source but
+shares this core IME logic). Goal: identify high-value, low-risk improvements
+for LimeIME §8.7 「英文鍵盤」.
+
+Spec touchpoints: §8.7 (English Keyboard), §8.4 (IM Behaviour).
+
+---
+
+## 1. Auto-Capitalization
+
+### LatinIME
+
+- `RichInputConnection.getCursorCapsMode(inputType, SpacingAndPunctuations,
+  hasSpaceBefore)` **does not** delegate to the host `InputConnection`. It
+  walks its own committed-text cache through `CapsModeUtils.getCapsMode()`.
+- Look-back is **unbounded** — it skips trailing whitespace and closing
+  punctuation (quotes, parens) to find the last sentence terminator or
+  paragraph boundary.
+- Abbreviation FSM matches `(\w\.){2,}` so `Mr.`, `U.S.`, `e.g.` do **not**
+  re-trigger sentence-cap.
+- Locale flags in `SpacingAndPunctuations`:
+  - `mUsesAmericanTypography` — skip trailing `"`, `'`, `)` before terminator
+    check, so `She said "Hello." |` capitalizes correctly.
+  - `mUsesGermanRules` — `digit.` is not a sentence terminator.
+
+### LimeIME today
+
+- **iOS** (`KeyboardViewController.updateShiftForAutoCap`, ~line 1395)
+  - Gated on `mEnglishOnly`, `!isShiftOn`, `!mCapsLock`, pref `autoCap`,
+    and host `textDocumentProxy.autocapitalizationType`.
+  - Heuristic: `before.isEmpty || hasSuffix(". " / "! " / "? ")`.
+  - **No** abbreviation guard — `Mr. |` will mis-capitalize.
+  - **No** quote/paren skip — `"Hello." |` will not capitalize.
+  - **No** paragraph/newline trigger — only `". "` family.
+- **Android** (`LIMEService.java:1851`)
+  - Delegates entirely to `InputConnection.getCursorCapsMode(inputType)`.
+  - Behavior matches whatever the host editor reports — usually fine for
+    `TYPE_TEXT_FLAG_CAP_SENTENCES`, but loses control over abbreviations,
+    quotes, and the LimeIME-specific timing.
+
+### Gap
+
+| Behavior                        | LatinIME | LimeIME-iOS | LimeIME-Android |
+| ------------------------------- | :------: | :---------: | :-------------: |
+| Sentence end (`. ` / `! ` / `?`)|   ✓      |   ✓         |   ✓ (host)      |
+| Start-of-document               |   ✓      |   ✓         |   ✓ (host)      |
+| After newline / paragraph       |   ✓      |   ✗         |   depends       |
+| Skip closing quotes/parens      |   ✓      |   ✗         |   ✗             |
+| Abbreviation guard (`Mr.`)      |   ✓      |   ✗         |   ✗             |
+| After `?!` not just `.`         |   ✓      |   ✓         |   ✓ (host)      |
+
+### Recommendation
+
+1. **iOS — extend the suffix check** (`KeyboardViewController.swift`):
+   - Trigger when `before` ends with **`. ` / `! ` / `? ` / `\n` / `\n\n`**,
+     or ends with one of those followed by `"`, `'`, `)`, `]`, `}`.
+   - Add an abbreviation guard: if the char before `". "` is a single
+     letter (e.g. `r. `) **and** the run before is `\w\.`-pattern repeating,
+     suppress. Cheap version: skip auto-cap when `documentContextBeforeInput`
+     ends with `[A-Za-z]\. ` and the preceding char (if any) is alpha (covers
+     `Mr.`, `Dr.`, `e.g.`, `U.S.`).
+2. **Android** — keep host `getCursorCapsMode()` as the baseline, but when
+   `mAutoCap && caps == 0` and `mEnglishOnly`, run the same suffix/abbrev
+   heuristic on `ic.getTextBeforeCursor(3, 0)` as a fallback. Many WebView
+   editors return `0` for caps mode even on sentence-cap fields.
+
+---
+
+## 2. Smart Space / Smart Period
+
+### LatinIME
+
+`SpaceState` enum drives this:
+
+| State              | Meaning                                                    |
+| ------------------ | ---------------------------------------------------------- |
+| `NONE`             | Normal                                                     |
+| `DOUBLE`           | Just performed double-space → `". "`                       |
+| `SWAP_PUNCTUATION` | Just swapped weak space with picked punctuation            |
+| `WEAK`             | Auto-inserted space after a suggestion pick (swappable)    |
+| `PHANTOM`          | Deferred space — emitted before next non-separator char    |
+
+- **Double-space → `". "`** (`InputLogic.tryPerformDoubleSpacePeriod`):
+  requires `<char><space>` before cursor; rewrites to `<char>. `.
+- **Swap with punctuation** (`trySwapSwapperAndSpace`): if you pick a
+  suggestion (weak space auto-inserted), then type `,`, the result is
+  `word, ` not `word ,`.
+- **Phantom space**: picking a suggestion does not literally insert a space;
+  the IME marks `PHANTOM` so the next letter is preceded by a space, but
+  a separator like `.` overrides it (no `word .`).
+
+### LimeIME today
+
+- **Neither platform** implements any of the four states. There is no
+  double-space-to-period and no swap-with-punctuation.
+- iOS does have an `isSelfUpdate` recursion guard but that is unrelated.
+
+### Recommendation
+
+Two low-risk wins on both platforms (English-mode only, behind `auto_cap`
+or a new pref):
+
+1. **Double-space → `". "`**
+   - On `space` keypress in English mode, peek `documentContextBeforeInput`
+     (iOS) / `getTextBeforeCursor(2, 0)` (Android). If it is
+     `[A-Za-z0-9)\]"' ]<space>`, delete one char and insert `". "`.
+   - Skip when the previous non-space char is already terminal punctuation
+     (`.!?,:;`).
+   - Compose well with the new auto-cap path above — `". "` then triggers
+     sentence-cap on the next letter.
+2. **Defer** SWAP/WEAK/PHANTOM — those only matter once we have
+   English-suggestion picks (see §4 below). Re-evaluate after that lands.
+
+---
+
+## 3. Shift State Machine
+
+### LatinIME
+
+`KeyboardState` has states `UNSHIFT`, `MANUAL_SHIFT`, `AUTOMATIC_SHIFT`,
+`SHIFT_LOCK_SHIFTED`. Auto-shift is applied at **release**, not press.
+Double-tap timeout `isInDoubleTapShiftKeyTimeout()` toggles caps-lock.
+Chording (hold shift + type letter) keeps shift through the letter, releases
+after.
+
+### LimeIME today
+
+iOS uses `ShiftResetPolicy.shouldResetAfterCharacter` /
+`shouldResetAfterShiftRelease` — already implements chording vs. tap.
+`KeyboardViewController.swift:1312-1325` covers single-tap, double-tap-lock,
+and tap-to-lock-off. **This is on par with LatinIME.** No change needed.
+
+---
+
+## 4. English Prediction Pipeline
+
+### LatinIME
+
+- `DictionaryFacilitatorImpl` loads `main` (binary LM), `user_history`,
+  `user` (system Personal Dictionary), `contacts`.
+- `Suggest.getSuggestedWords()` ranks via `NgramContext` (bigram/trigram).
+- Auto-commit on separator gated by `mAutoCorrectionEnabledPerUserSettings`
+  AND `InputAttributes.mInputTypeNoAutoCorrect`.
+- Capitalized-word learning capped at
+  `CAPITALIZED_FORM_MAX_PROBABILITY_FOR_INSERT = 140` so accidental
+  `Hello`-after-`. ` doesn't displace `hello` in user history.
+
+### LimeIME today
+
+- iOS surfaces English candidates via `updateEnglishPrediction()` from a
+  shipped English dictionary — no n-gram, no user-history learning, no
+  contacts integration.
+- Android surfaces English candidates through the existing IM candidate
+  pipeline when `english_dictionary_enable` is on; same limitations.
+- Neither platform auto-commits on space — the user must tap a candidate.
+
+### Recommendation
+
+Out of scope for a §8.7 polish pass — these are multi-week changes
+(binary LM, history DB, ngram lookups). Park for a future "English IME v2"
+proposal. The immediate auto-cap + double-space-period improvements deliver
+80% of the perceived gboard parity at <1% of the cost.
+
+---
+
+## 5. Input-Type Awareness
+
+### LatinIME (`InputAttributes.java`)
+
+- **Suggestions off** for: passwords, `isEmailVariation()`,
+  `TYPE_TEXT_VARIATION_URI`, `TYPE_TEXT_VARIATION_FILTER`,
+  `TYPE_TEXT_FLAG_NO_SUGGESTIONS`, `TYPE_TEXT_FLAG_AUTO_COMPLETE`.
+- **Auto-correct off** for: `TYPE_TEXT_VARIATION_WEB_EDIT_TEXT` (unless
+  explicit auto-correct flag), `TYPE_TEXT_FLAG_NO_SUGGESTIONS`, any
+  single-line field without `TYPE_TEXT_FLAG_AUTO_CORRECT`.
+
+### LimeIME today
+
+- Android (`LIMEService.java:895-945`) already detects
+  `EMAIL_ADDRESS`, `URI`, `WEB_EMAIL_ADDRESS` and forces the English
+  layout for those fields (see project memory: "URL fields stay
+  English-only #74").
+- iOS gates `lime_url_*` / `lime_email_*` layouts via `keyboardType` —
+  also force-English.
+- Neither platform suppresses suggestions in password fields beyond the
+  layout switch. That is a defect for any future English-prediction work
+  but **not** for the current candidate-list behavior (no auto-correct
+  exists today, so nothing to suppress).
+
+### Recommendation
+
+When (and only when) English prediction grows beyond the current
+read-only dictionary, mirror LatinIME's `InputAttributes` gate to
+disable the English suggestion strip for password / NO_SUGGESTIONS
+fields. Until then, no action.
+
+---
+
+## 6. Prioritized Backlog
+
+Ordered by user-visible impact ÷ engineering cost:
+
+| # | Item                                                            | Platform | Est. effort | Spec note |
+| - | --------------------------------------------------------------- | -------- | ----------- | --------- |
+| 1 | Auto-cap after `\n` / paragraph boundary                        | iOS      | ~5 LOC      | §8.7      |
+| 2 | Auto-cap skip-trailing-quote/paren (`"Hello." `)                | iOS      | ~10 LOC     | §8.7      |
+| 3 | Abbreviation guard (`Mr.`, `e.g.`)                              | both     | ~20 LOC     | §8.7      |
+| 4 | Double-space → `". "` (English-only, behind `auto_cap` pref)    | both     | ~30 LOC ea  | §8.7      |
+| 5 | Android: fallback heuristic when host returns `caps == 0`       | Android  | ~15 LOC     | §8.7      |
+| 6 | English n-gram / user-history dictionary                        | both     | weeks       | future    |
+| 7 | Disable English suggestions in password / NO_SUGGESTIONS fields | both     | small       | after #6  |
+
+Items 1–5 are independently shippable and share the existing `auto_cap`
+preference — no new UI required. Recommend bundling 1–3 in one PR for iOS,
+5 alone for Android, then 4 as a second PR per platform.
+
+---
+
+## 7. Source References
+
+AOSP LatinIME (mirrors: `aosp-mirror/platform_packages_inputmethods_LatinIME`):
+
+- `java/src/com/android/inputmethod/latin/RichInputConnection.java`
+- `java/src/com/android/inputmethod/latin/utils/CapsModeUtils.java`
+- `java/src/com/android/inputmethod/latin/settings/SpacingAndPunctuations.java`
+- `java/src/com/android/inputmethod/latin/inputlogic/InputLogic.java`
+- `java/src/com/android/inputmethod/latin/inputlogic/SpaceState.java`
+- `java/src/com/android/inputmethod/keyboard/internal/KeyboardState.java`
+- `java/src/com/android/inputmethod/latin/DictionaryFacilitatorImpl.java`
+- `java/src/com/android/inputmethod/latin/InputAttributes.java`
+
+LimeIME:
+
+- `LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift` —
+  `updateShiftForAutoCap` (~1395), `handleEnglishCharacter` (~1231),
+  `handleEnterOrSpace` (~1091).
+- `LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java` —
+  `mAutoCap` (156), `loadSettings()` (~999), runtime gate (~1851),
+  input-type detection (~895-945).
+- `LimeStudio/app/src/main/res/xml/preference.xml` — `auto_cap` toggle.
+- `LimeIME-iOS/LimeSettings/Views/PreferencesTabView.swift` — §8.7 UI.

--- a/docs/PREFS_TABLE.md
+++ b/docs/PREFS_TABLE.md
@@ -4,7 +4,7 @@
 
 1. **iOS current/spec** — `LimeIME-iOS/LimeSettings/Views/PreferencesTabView.swift`, aligned to `docs/LIME_SETTINGS.md` §8 and Android current preference strings
 2. **Android pre-back-port** — commit `6791ab7b` (parent of the "Step 3" back-port series), three flat `PreferenceCategory` blocks (`lime_keyboard` / `lime_im` / `lime_mapping`)
-3. **Android current** — HEAD `app/src/main/res/xml/preference.xml`, 7 sectioned categories + 1 nested sub-screen, aligned to iOS §8.1–§8.7 (with §8.3 and §8.8 consolidated away, §8.9 folded into §8.4.1)
+3. **Android current** — HEAD `app/src/main/res/xml/preference.xml`, 7 sectioned categories + 1 nested sub-screen, aligned to iOS §8.1–§8.7 (with §8.3 and §8.8 consolidated away, §8.9 folded into §8.4.1; `auto_cap` moved into §8.7)
 
 ## Legend
 
@@ -62,11 +62,12 @@
 | `learn_phrase` | Toggle / CheckBox | true · 自動學習新詞 · §8.6 關聯字與學習 | true · 自動學習新詞 · lime_mapping · summary=從常用關聯字學習新詞 | true · 自動學習新詞 · pref_section_related_learning | Promote frequent phrases into the dictionary. |
 | `learning_switch` | Toggle / CheckBox | true · 啟動選取排序 · §8.6 關聯字與學習 | true · 啟動選取排序 · lime_mapping · summary=依選取次數排序選字清單 | true · 啟動選取排序 · pref_section_related_learning | Sort candidate list by selection frequency. |
 
-## 8.7 English Dictionary (英文字典)
+## 8.7 English Keyboard (英文鍵盤)
 
 | Pref Key | Type | iOS (default · label · category) | Android pre-back-port (default · label · category) | Android current (default · label · category) | Function |
 |---|---|---|---|---|---|
-| `english_dictionary_enable` | Toggle / CheckBox | true · 啟用英文字典 · §8.7 英文字典 · subtext=當使用 英文 輸入模式時，顯示英文建議字 | true · 啟用英文字典 · lime_mapping · summary=當使用 英文 輸入模式時，顯示英文建議字 | true · 啟用英文字典 · pref_section_english_dictionary | Show English suggestions while in English IM mode. |
+| `english_dictionary_enable` | Toggle / CheckBox | true · 啟用英文字典 · §8.7 英文鍵盤 · subtext=當使用 英文 輸入模式時，顯示英文建議字 | true · 啟用英文字典 · lime_mapping · summary=當使用 英文 輸入模式時，顯示英文建議字 | true · 啟用英文字典 · pref_section_english_dictionary | Show English suggestions while in English IM mode. |
+| `auto_cap` | Toggle / CheckBox | true · 首字自動大寫 · §8.7 英文鍵盤 · subtext=在英文模式下，句首字母自動轉為大寫 | true · 首字自動大寫 · lime_keyboard · summary=英文段落輸入首字自動大寫 *(legacy XML entry, not shown in pre-back-port lime_keyboard category)* | true · 首字自動大寫 · pref_section_english_dictionary · summary=英文段落輸入首字自動大寫 | Auto-capitalize the first letter of English sentences. iOS gates `updateShiftForAutoCap()` (which reads `textDocumentProxy.autocapitalizationType`) on this pref. Android `LIMEService.loadSettings()` reads via `LIMEPreferenceManager.getAutoCaptalization()`. |
 
 ## 5.2 IMDetailView — per-IM prefs (cross-listed)
 
@@ -163,7 +164,7 @@ Pre-back-port had **3 flat categories** (`lime_keyboard` / `lime_im` / `lime_map
 | lime_im | pref_section_physical_keyboard | disable_physical_selkey, selkey_option |
 | lime_mapping (對應表) | pref_section_im_behaviour (§8.4) | candidate_switch |
 | lime_mapping | pref_section_related_learning (§8.6) | similiar_enable, similiar_list, candidate_suggestion, learn_phrase, learning_switch |
-| lime_mapping | pref_section_english_dictionary (§8.7) | english_dictionary_enable |
+| lime_mapping | pref_section_english_dictionary (§8.7) | english_dictionary_enable, auto_cap *(auto_cap newly surfaced in §8.7)* |
 | lime_mapping | pref_section_physical_keyboard | english_dictionary_physical_keyboard, physical_keyboard_sort |
 | lime_im | *(removed)* | auto_commit, phonetic_keyboard_type, han_convert_notify |
 | lime_mapping | *(removed)* | accept_number_index, accept_symbol_index |

--- a/scripts/generate_ipad_layouts.py
+++ b/scripts/generate_ipad_layouts.py
@@ -14,7 +14,7 @@ LAYOUTS_DIR = os.path.normpath(os.path.join(SCRIPT_DIR,
 # LimeKeyCode values (mirror LimeKeyCode.swift)
 C_ENTER = 10; C_SPACE = 32; C_DELETE = -5; C_SHIFT = -1
 C_DONE  = -3; C_SYM   = -2; C_EN    = -9;  C_IM    = -10
-C_GLOBE = -200; C_MENU = -100; C_MIC = -99; C_TAB = 9
+C_GLOBE = -200; C_MENU = -100; C_EMOJI = -201; C_TAB = 9
 C_ARRL = -30; C_ARRR = -31; C_ARRU = -32; C_ARRD = -33
 
 
@@ -52,8 +52,8 @@ def fix_total(keys, target=100.0):
 # ---------------------------------------------------------------------------
 
 def bottom_row(sym='.?123', left_cjk=False, cjk=False, shifted=False):
-    # Non-CJK: globe(8) + left(10) + mic(7) + space(57) + sym(10) + dismiss(8) = 100
-    # CJK:     globe(8) + left(10) + mic(7) + space(50) + ，/。(7) + sym(10) + dismiss(8) = 100
+    # Non-CJK: globe(8) + left(10) + emoji(7) + space(57) + sym(10) + dismiss(8) = 100
+    # CJK:     globe(8) + left(10) + emoji(7) + space(50) + ，/。(7) + sym(10) + dismiss(8) = 100
     # shifted: ，/。 key becomes 。only
     # left_cjk=True: replace left sym key with 中 (C_IM) key for symbol layouts
     left_key = (mk(C_IM, label='中', width=10.0, mod=True) if left_cjk
@@ -64,7 +64,7 @@ def bottom_row(sym='.?123', left_cjk=False, cjk=False, shifted=False):
         return fix_total([
             mk(C_GLOBE, icon='globe',                         width=8.0,  mod=True, lp=C_MENU),
             left_key,
-            mk(C_MIC,   icon='mic',                           width=7.0,  mod=True),
+            mk(C_EMOJI, icon='face.smiling',                   width=7.0,  mod=True),
             mk(C_SPACE, icon='space.bar',                     width=50.0),
             comma_key,
             mk(C_SYM,   label=sym,                            width=10.0, mod=True),
@@ -73,7 +73,7 @@ def bottom_row(sym='.?123', left_cjk=False, cjk=False, shifted=False):
     return fix_total([
         mk(C_GLOBE, icon='globe',                         width=8.0,  mod=True, lp=C_MENU),
         left_key,
-        mk(C_MIC,   icon='mic',                           width=7.0,  mod=True),
+        mk(C_EMOJI, icon='face.smiling',                   width=7.0,  mod=True),
         mk(C_SPACE, icon='space.bar',                     width=57.0),
         mk(C_SYM,   label=sym,                            width=10.0, mod=True),
         mk(C_DONE,  icon='keyboard.chevron.compact.down', width=8.0,  mod=True, lp=C_MENU),


### PR DESCRIPTION
## Summary
- Adds shared iOS English keyboard policy for sentence auto-cap, quote/paren handling, abbreviation guards, and double-space period insertion.
- Adds matching Android English-mode helpers for auto-cap fallback and double-space period insertion.
- Covers the behavior with focused iOS and Android tests.

## Verification
- ./gradlew :app:compileDebugAndroidTestJavaWithJavac
- xcodebuild -project LimeIME-iOS/LimeIME.xcodeproj -scheme LimeIME -destination 'id=58BCFA46-0EE8-4631-B2A0-6331EF124A75' -only-testing:LimeTests/KeyboardViewControllerTest/testEnglishAutoCapRecognizesNewlinesQuotesAndAbbreviations -only-testing:LimeTests/KeyboardViewControllerTest/testEnglishDoubleSpacePeriodOnlyAfterWordLikeContext test
- git diff --check

## Visual Verification
- iOS item 1 newline auto-cap: .Codex/txt/ios_english_01_newline_autocap.png
- iOS item 2 quote/paren auto-cap: .Codex/txt/ios_english_02_quote_autocap.png
- iOS item 3 abbreviation guard: .Codex/txt/ios_english_03_abbrev_guard.png
- iOS item 4 double-space period: .Codex/txt/ios_english_04_hello_one_space.png and .Codex/txt/ios_english_04_hello_double_space.png
- Android item 5 newline fallback: .Codex/txt/android_english_01_05_newline_autocap_fallback_english_mode.png
- Android item 3 abbreviation guard with real soft keys: .Codex/txt/android_english_03_abbrev_guard_real_softkeys.png
- Android item 4 double-space period: .Codex/txt/android_english_kb_after_hello_one_space.png and .Codex/txt/android_english_kb_after_hello_double_space.png