### PR TITLE
fix(android): surface database restore failures

### DIFF
--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/DBServerTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/DBServerTest.java
@@ -899,8 +899,13 @@ public class DBServerTest {
         
         // Test with non-existent file
         String nonExistentPath = appContext.getCacheDir().getAbsolutePath() + "/nonexistent_" + System.currentTimeMillis() + ".zip";
-        dbServer.restoreDatabase(nonExistentPath);
-        // Should show error notification, which is acceptable
+        try {
+            dbServer.restoreDatabase(nonExistentPath);
+            fail("restoreDatabase with non-existent path should throw");
+        } catch (Exception e) {
+            // Exception is expected for non-existent file.
+            assertTrue("restoreDatabase with non-existent path throws", true);
+        }
         
         // Test with null path
         try {
@@ -943,14 +948,13 @@ public class DBServerTest {
             // Create URI from file
             android.net.Uri testUri = android.net.Uri.fromFile(testFile);
             
-            // Test restoreDatabase with Uri
-            // This may fail if file format is invalid, which is acceptable
+            // Test restoreDatabase with a zero-byte Uri. This must fail visibly instead of
+            // returning and letting the UI report restore success.
             try {
                 dbServer.restoreDatabase(testUri);
-                assertTrue("restoreDatabase with Uri should complete", true);
+                fail("restoreDatabase with zero-byte Uri should throw");
             } catch (Exception e) {
-                // Exception is acceptable for invalid file format
-                assertTrue("restoreDatabase with Uri may throw exception", true);
+                assertTrue("restoreDatabase with zero-byte Uri throws", true);
             }
             
             // Clean up

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/DBServer.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/DBServer.java
@@ -481,7 +481,7 @@ public class  DBServer {
 
     }
 
-    public void restoreDatabase(Uri uri) {
+    public void restoreDatabase(Uri uri) throws IOException {
         if (DEBUG)
             Log.i(TAG, "restoreDatabase(Uri) Starting....");
 
@@ -502,12 +502,26 @@ public class  DBServer {
             while ((bytesRead = inputStream.read(buffer)) != -1) {
                 outputStream.write(buffer, 0, bytesRead);
             }
+            outputStream.flush();
+            outputStream.close();
+            outputStream = null;
+
+            // Reject zero-byte copies — Android Uri import can silently produce empty files
+            if (tempZip.length() == 0) {
+                throw new IOException("Restore failed: copied backup archive is empty (0 bytes)");
+            }
+
             Log.i(TAG, "restoreDatabase(Uri) temp file created: " + tempZip.getAbsolutePath());
             restoreDatabase(tempZip.getAbsolutePath());
 
+        } catch (IOException e) {
+            Log.e(TAG, "Error restoring database", e);
+            showNotificationMessage(appContext.getText(R.string.l3_initial_restore_error) + "");
+            throw e;
         } catch (Exception e) {
             Log.e(TAG, "Error restoring database", e);
             showNotificationMessage(appContext.getText(R.string.l3_initial_restore_error) + "");
+            throw new IOException("Restore failed: " + (e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName()), e);
         } finally {
             try {
                 if (inputStream != null) inputStream.close();
@@ -519,55 +533,74 @@ public class  DBServer {
         }
     }
 
-	public void restoreDatabase(String srcFilePath) {
+	public void restoreDatabase(String srcFilePath) throws IOException {
 		File check = new File(srcFilePath);
         String dataDir = getDataDirPath();
 
-		if(check.exists()){
-
-			datasource.holdDBConnection(); //Jeremy '15,5,23
-			closeDatabase();
-            //restore shared preference
-            File sharedPref = new File(dataDir, LIME.SHARED_PREFS_BACKUP_NAME);
-            File preferenceManifest = new File(dataDir, PreferenceBackupAdapter.MANIFEST_PATH);
-
-            boolean unzipSucceeded = false;
-            try {
-				LIMEUtilities.unzip(srcFilePath, dataDir, true);
-                unzipSucceeded = true;
-			} catch (Exception e) {
-				Log.e(TAG, "Error unzipping restore file", e);
-				showNotificationMessage(appContext.getText(R.string.l3_initial_restore_error) + "");
-			}
-
-				datasource.unHoldDBConnection(); //Jeremy '15,5,23
-				datasource.openDBConnection(true);
-				datasource.ensureCurrentDatabase();
-
-                if (!unzipSucceeded) {
-                    return;
-                }
-
-				showNotificationMessage(appContext.getText(R.string.l3_initial_restore_end) + "");
-
-                if (!restorePreferenceCompatibilityManifest(preferenceManifest)) {
-                    restoreDefaultSharedPreference(sharedPref);
-                }
-            //Delete the shared preference backup file after restored.
-            if(sharedPref.exists() && !sharedPref.delete()) Log.w(TAG, "Failed to delete shared preferences backup file after restore");
-            if(preferenceManifest.exists() && !preferenceManifest.delete()) Log.w(TAG, "Failed to delete preference manifest after restore");
-			//mLIMEPref.setResetCacheFlag(true);
-            net.toload.main.hd.SearchServer.resetCache(true);
-
-				// Check and upgrade the database table
-				datasource.checkAndUpdateRelatedTable();
-				datasource.ensureCurrentDatabase();
-
-			}else{
+		if (!check.exists()) {
 			showNotificationMessage(appContext.getText(R.string.error_restore_not_found) + "");
-
+			throw new FileNotFoundException("Restore source file not found: " + srcFilePath);
 		}
 
+		// Validate the archive contains a lime.db entry before touching the live database.
+		// Prevents wiping the running DB when the user picks an unrelated/corrupted zip.
+		if (!zipContainsLimeDbEntry(check)) {
+			showNotificationMessage(appContext.getText(R.string.l3_initial_restore_error) + "");
+			throw new IOException("Restore failed: backup archive does not contain a lime.db entry");
+		}
+
+		datasource.holdDBConnection(); //Jeremy '15,5,23
+		closeDatabase();
+		//restore shared preference
+		File sharedPref = new File(dataDir, LIME.SHARED_PREFS_BACKUP_NAME);
+		File preferenceManifest = new File(dataDir, PreferenceBackupAdapter.MANIFEST_PATH);
+
+		boolean unzipSucceeded = false;
+		IOException unzipError = null;
+		try {
+			LIMEUtilities.unzip(srcFilePath, dataDir, true);
+			unzipSucceeded = true;
+		} catch (Exception e) {
+			Log.e(TAG, "Error unzipping restore file", e);
+			showNotificationMessage(appContext.getText(R.string.l3_initial_restore_error) + "");
+			unzipError = new IOException("Restore failed: unable to unzip backup archive", e);
+		}
+
+		datasource.unHoldDBConnection(); //Jeremy '15,5,23
+		datasource.openDBConnection(true);
+		datasource.ensureCurrentDatabase();
+
+		if (!unzipSucceeded) {
+			throw unzipError;
+		}
+
+		showNotificationMessage(appContext.getText(R.string.l3_initial_restore_end) + "");
+
+		if (!restorePreferenceCompatibilityManifest(preferenceManifest)) {
+			restoreDefaultSharedPreference(sharedPref);
+		}
+		//Delete the shared preference backup file after restored.
+		if(sharedPref.exists() && !sharedPref.delete()) Log.w(TAG, "Failed to delete shared preferences backup file after restore");
+		if(preferenceManifest.exists() && !preferenceManifest.delete()) Log.w(TAG, "Failed to delete preference manifest after restore");
+		//mLIMEPref.setResetCacheFlag(true);
+		net.toload.main.hd.SearchServer.resetCache(true);
+
+		// Check and upgrade the database table
+		datasource.checkAndUpdateRelatedTable();
+		datasource.ensureCurrentDatabase();
+	}
+
+	private boolean zipContainsLimeDbEntry(File zipFile) throws IOException {
+		try (ZipInputStream zis = new ZipInputStream(new BufferedInputStream(new FileInputStream(zipFile)))) {
+			ZipEntry entry;
+			while ((entry = zis.getNextEntry()) != null) {
+				String name = entry.getName();
+				if (name != null && !entry.isDirectory() && name.endsWith("lime.db")) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
     private void backupPreferenceCompatibilityManifest(File manifestFile) {

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/ui/controller/SetupImController.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/ui/controller/SetupImController.java
@@ -195,17 +195,19 @@ public class SetupImController extends BaseController implements ImportDialog.On
      * 
      * @param uri The URI of the backup file to restore from
      */
-    public void performRestore(Uri uri) {
+    public void performRestore(Uri uri) throws Exception {
         try {
             showProgress(mainActivityView, "Restoring database...");
             dbServer.restoreDatabase(uri);
             hideProgress(mainActivityView);
-            
+
             // Refresh the menu and UI after restore
             refreshNavigationMenu();
             refreshSetupImButtonStates();
         } catch (Exception e) {
             handleError(mainActivityView, "Failed to restore database", e);
+            hideProgress(mainActivityView);
+            throw e;
         }
     }
 

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/ui/view/DbManagerFragment.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/ui/view/DbManagerFragment.java
@@ -263,8 +263,14 @@ public class DbManagerFragment extends Fragment {
     }
 
     private void performRestore(Uri uri) {
+        if (setupImController == null) {
+            showToastMessage(getString(R.string.l3_initial_restore_error), Toast.LENGTH_LONG);
+            runOnUi(() -> setStatus(getString(R.string.db_status_restore_fail, "controller unavailable")));
+            return;
+        }
         try {
-            if (setupImController != null) setupImController.performRestore(uri);
+            setupImController.performRestore(uri);
+            // Only reached when no exception propagated from the controller/DBServer chain.
             runOnUi(() -> setStatus(getString(R.string.db_status_restore_ok)));
         } catch (Exception e) {
             Log.e(TAG, "Failed to restore database", e);


### PR DESCRIPTION
## Summary
- Propagate Android database restore failures from `DBServer` through `SetupImController` to `DbManagerFragment`.
- Reject zero-byte restore copies and invalid/wrong ZIP backups before applying them to the live database.
- Keep the success status/toast path gated on a completed restore, and update Android instrumented tests for visible failure behavior.

## Scope
Android track only for #85. iOS restore/state-sync work remains separate.

Refs #85

## Verification
- `./gradlew :app:compileDebugJavaWithJavac`
- `./gradlew :app:compileDebugAndroidTestJavaWithJavac`
- `git diff --check`
- Claude Code narrow review: PASS
