### PR TITLE
Fix Android backup with missing journal

### DIFF
--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/DBServerTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/DBServerTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -1032,22 +1033,112 @@ public class DBServerTest {
     }
 
     @Test
+    public void testDBServerBackupDatabaseSkipsMissingOptionalJournal() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        DBServer dbServer = DBServer.getInstance(appContext);
+
+        if (!ensureDatabaseReady(dbServer)) {
+            fail("ERROR: Database is still on hold before missing-journal backup test.");
+        }
+
+        File journalFile = appContext.getDatabasePath(LIME.DATABASE_JOURNAL);
+        if (journalFile.exists() && !journalFile.delete()) {
+            fail("Could not remove optional journal before backup test: " + journalFile.getAbsolutePath());
+        }
+
+        File backupFile = new File(appContext.getCacheDir(), "test_backup_missing_journal_" + System.currentTimeMillis() + ".zip");
+        try {
+            dbServer.backupDatabase(android.net.Uri.fromFile(backupFile));
+
+            assertTrue("Backup should be created even when optional lime.db-journal is absent", backupFile.exists());
+            assertTrue("Backup should not be empty when optional lime.db-journal is absent", backupFile.length() > 0);
+
+            try (ZipFile zipFile = new ZipFile(backupFile)) {
+                assertNotNull("Backup should still include required lime.db", zipFile.getEntry("databases/" + LIME.DATABASE_NAME));
+                assertNull("Missing optional lime.db-journal should not be added to the zip", zipFile.getEntry("databases/" + LIME.DATABASE_JOURNAL));
+                assertNotNull("Backup should include shared preferences backup", zipFile.getEntry(LIME.SHARED_PREFS_BACKUP_NAME));
+            }
+        } finally {
+            if (backupFile.exists() && !backupFile.delete()) {
+                Log.w(TAG, "Failed to delete missing-journal backup test file: " + backupFile.getAbsolutePath());
+            }
+        }
+    }
+
+    @Test
+    public void testDBServerBackupDatabaseExcludesPresentOptionalJournal() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        DBServer dbServer = DBServer.getInstance(appContext);
+
+        if (!ensureDatabaseReady(dbServer)) {
+            fail("ERROR: Database is still on hold before present-journal backup test.");
+        }
+
+        File journalFile = appContext.getDatabasePath(LIME.DATABASE_JOURNAL);
+        File journalParent = journalFile.getParentFile();
+        assertTrue("Journal parent directory should exist", journalParent != null && (journalParent.exists() || journalParent.mkdirs()));
+        try (FileOutputStream out = new FileOutputStream(journalFile)) {
+            out.write("transient journal sidecar".getBytes());
+        }
+        assertTrue("Test should create an optional journal sidecar before backup", journalFile.exists());
+
+        File backupFile = new File(appContext.getCacheDir(), "test_backup_present_journal_" + System.currentTimeMillis() + ".zip");
+        try {
+            dbServer.backupDatabase(android.net.Uri.fromFile(backupFile));
+
+            assertTrue("Backup should be created when optional lime.db-journal is present", backupFile.exists());
+            assertTrue("Backup should not be empty when optional lime.db-journal is present", backupFile.length() > 0);
+
+            try (ZipFile zipFile = new ZipFile(backupFile)) {
+                assertNotNull("Backup should still include required lime.db", zipFile.getEntry("databases/" + LIME.DATABASE_NAME));
+                assertNull("Optional lime.db-journal should be excluded from the zip", zipFile.getEntry("databases/" + LIME.DATABASE_JOURNAL));
+                assertNotNull("Backup should include shared preferences backup", zipFile.getEntry(LIME.SHARED_PREFS_BACKUP_NAME));
+            }
+        } finally {
+            if (journalFile.exists() && !journalFile.delete()) {
+                Log.w(TAG, "Failed to delete present-journal test sidecar: " + journalFile.getAbsolutePath());
+            }
+            if (backupFile.exists() && !backupFile.delete()) {
+                Log.w(TAG, "Failed to delete present-journal backup test file: " + backupFile.getAbsolutePath());
+            }
+        }
+    }
+
+    @Test
+    public void testDBServerBackupDatabasePropagatesOutputFailures() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        DBServer dbServer = DBServer.getInstance(appContext);
+
+        if (!ensureDatabaseReady(dbServer)) {
+            fail("ERROR: Database is still on hold before output-failure backup test.");
+        }
+
+        File outputDirectory = new File(appContext.getCacheDir(), "backup_output_directory_" + System.currentTimeMillis());
+        assertTrue("Output directory should be created for failure propagation test", outputDirectory.mkdirs());
+
+        try {
+            dbServer.backupDatabase(android.net.Uri.fromFile(outputDirectory));
+            fail("backupDatabase should throw when the selected output URI cannot be written");
+        } catch (RemoteException e) {
+            assertTrue("Failure should describe backup failure", e.getMessage() != null && e.getMessage().contains("Failed to backup database"));
+        } finally {
+            if (outputDirectory.exists() && !outputDirectory.delete()) {
+                Log.w(TAG, "Failed to delete output failure test directory: " + outputDirectory.getAbsolutePath());
+            }
+        }
+    }
+
+    @Test
     public void testDBServerBackupDatabaseWithNullUri() {
         // Test backupDatabase with null Uri
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         DBServer dbServer = DBServer.getInstance(appContext);
         
-        // Test backupDatabase with null Uri
-        // This should handle null gracefully
         try {
             dbServer.backupDatabase(null);
-            assertTrue("backupDatabase with null Uri should handle gracefully", true);
+            fail("backupDatabase should propagate null output Uri failures");
         } catch (RemoteException e) {
-            // RemoteException is acceptable for null Uri
-            assertTrue("backupDatabase with null Uri may throw RemoteException", true);
-        } catch (Exception e) {
-            // Other exceptions are acceptable
-            assertTrue("backupDatabase with null Uri may throw exception", true);
+            assertTrue("Failure should describe backup failure", e.getMessage() != null && e.getMessage().contains("Failed to backup database"));
         }
     }
 

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/DBServer.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/DBServer.java
@@ -399,85 +399,110 @@ public class  DBServer {
             Log.i(TAG, "backupDatabase()");
 
         String dataDir = getDataDirPath();
-        //backup shared preferences
-
         File fileSharedPrefsBackup = new File(dataDir, LIME.SHARED_PREFS_BACKUP_NAME);
-        if(fileSharedPrefsBackup.exists() && !fileSharedPrefsBackup.delete()) Log.w(TAG, "Failed to delete existing shared preferences backup file");
-        backupDefaultSharedPreference(fileSharedPrefsBackup);
         File filePreferenceManifest = new File(dataDir, PreferenceBackupAdapter.MANIFEST_PATH);
-        backupPreferenceCompatibilityManifest(filePreferenceManifest);
-
-        // create backup file list.
-        String limeDBPath = ctx.getDatabasePath(LIME.DATABASE_NAME).getAbsolutePath();
-        String limeDBJournalPath = ctx.getDatabasePath(LIME.DATABASE_JOURNAL).getAbsolutePath();
-        if (limeDBPath.startsWith(dataDir)) {
-            limeDBPath = limeDBPath.substring(dataDir.length());
-        }
-        if (limeDBJournalPath.startsWith(dataDir)) {
-            limeDBJournalPath = limeDBJournalPath.substring(dataDir.length());
-        }
-        List<String> backupFileList = new ArrayList<>();
-        //backupFileList.add(LIME.DATABASE_RELATIVE_FOLDER + File.separator + LIME.DATABASE_NAME);
-        //backupFileList.add(LIME.DATABASE_RELATIVE_FOLDER + File.separator + LIME.DATABASE_JOURNAL);
-        backupFileList.add(limeDBPath);
-        backupFileList.add(limeDBJournalPath);
-        backupFileList.add(LIME.SHARED_PREFS_BACKUP_NAME);
-        backupFileList.add(PreferenceBackupAdapter.MANIFEST_PATH);
-
-        // hold database connection and close database.
-        datasource.holdDBConnection(); //Jeremy '15,5,23
-        closeDatabase();
-
-        //ready to zip backup file list
         File tempZip = new File(appContext.getCacheDir(), LIME.DATABASE_BACKUP_NAME);
-        if(tempZip.exists() && !tempZip.delete()) Log.w(TAG, "Failed to delete existing temp zip file");
         OutputStream outputStream = null;
         FileInputStream inputStream = null;
+        boolean backupSucceeded = false;
+        boolean databaseHeld = false;
 
         try {
+            //backup shared preferences
+            if(fileSharedPrefsBackup.exists() && !fileSharedPrefsBackup.delete()) Log.w(TAG, "Failed to delete existing shared preferences backup file");
+            backupDefaultSharedPreference(fileSharedPrefsBackup);
+            backupPreferenceCompatibilityManifest(filePreferenceManifest);
+
+            // hold database connection and close database before checking optional SQLite sidecar files.
+            datasource.holdDBConnection(); //Jeremy '15,5,23
+            databaseHeld = true;
+            closeDatabase();
+
+            // create backup file list after closeDatabase(), because SQLite can delete the rollback journal while closing.
+            File limeDBFile = ctx.getDatabasePath(LIME.DATABASE_NAME);
+            File limeDBJournalFile = ctx.getDatabasePath(LIME.DATABASE_JOURNAL);
+            String limeDBPath = limeDBFile.getAbsolutePath();
+            if (limeDBPath.startsWith(dataDir)) {
+                limeDBPath = limeDBPath.substring(dataDir.length());
+            }
+            List<String> backupFileList = new ArrayList<>();
+            //backupFileList.add(LIME.DATABASE_RELATIVE_FOLDER + File.separator + LIME.DATABASE_NAME);
+            // Do not add LIME.DATABASE_JOURNAL here. SQLite rollback journals are transient
+            // sidecar files; after closeDatabase() the main database is the required backup source.
+            backupFileList.add(limeDBPath);
+            Log.i(TAG, "Skipping optional SQLite journal during backup: " + limeDBJournalFile.getAbsolutePath());
+            backupFileList.add(LIME.SHARED_PREFS_BACKUP_NAME);
+            backupFileList.add(PreferenceBackupAdapter.MANIFEST_PATH);
+
+            //ready to zip backup file list
+            if(tempZip.exists() && !tempZip.delete()) Log.w(TAG, "Failed to delete existing temp zip file");
             LIMEUtilities.zip(tempZip.getAbsolutePath(), backupFileList, dataDir , true);
+            if (!tempZip.exists() || tempZip.length() == 0) {
+                throw new IOException("Backup zip was not created or is empty: " + tempZip.getAbsolutePath());
+            }
             //saveFileToDownloads(tempZip);
             // Copy temp zip to the User selected URI
             inputStream = new FileInputStream(tempZip);
             outputStream = appContext.getContentResolver().openOutputStream(uri);
+            if (outputStream == null) {
+                throw new FileNotFoundException("Could not open output stream for URI: " + uri);
+            }
 
             byte[] buffer = new byte[LIME.BUFFER_SIZE_4KB];
             int bytesRead;
+            long bytesCopied = 0;
             while ((bytesRead = inputStream.read(buffer)) != -1) {
                 outputStream.write(buffer, 0, bytesRead);
+                bytesCopied += bytesRead;
             }
+            outputStream.flush();
+            outputStream.close();
+            outputStream = null;
+            inputStream.close();
+            inputStream = null;
+            if (bytesCopied == 0) {
+                throw new IOException("Backup copy wrote 0 bytes to URI: " + uri);
+            }
+            Log.i(TAG, "Database backup wrote " + bytesCopied + " bytes to selected URI");
+            backupSucceeded = true;
 
         } catch (Exception e) {
             Log.e(TAG, "Error backing up database", e);
             showNotificationMessage(appContext.getText(R.string.l3_initial_backup_error) + "");
+            String detail = e.getMessage() != null ? e.getMessage() : e.toString();
+            RemoteException remoteException = new RemoteException("Failed to backup database: " + detail);
+            remoteException.initCause(e);
+            throw remoteException;
         } finally {
-            try {
-                if (outputStream != null) outputStream.close();
-                if (inputStream != null) inputStream.close();
-            } catch (IOException e) {
-                Log.e(TAG, "Error closing streams during backup", e);
+            if (outputStream != null) {
+                try {
+                    outputStream.close();
+                } catch (IOException e) {
+                    Log.e(TAG, "Error closing output stream during backup", e);
+                }
             }
-            // Reopen DB
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    Log.e(TAG, "Error closing input stream during backup", e);
+                }
+            }
+            // Reopen DB and release backup hold even when backup fails.
             if (datasource != null) {
+                if (databaseHeld) {
+                    datasource.unHoldDBConnection(); //Jeremy '15,5,23
+                }
                 datasource.openDBConnection(true);
             }
             if (fileSharedPrefsBackup.exists() && !fileSharedPrefsBackup.delete()) Log.w(TAG, "Failed to delete shared preferences backup file in finally");
             if (filePreferenceManifest.exists() && !filePreferenceManifest.delete()) Log.w(TAG, "Failed to delete preference manifest in finally");
             if (tempZip.exists() && !tempZip.delete()) Log.w(TAG, "Failed to delete temp zip file in finally");
 
-            showNotificationMessage(appContext.getText(R.string.l3_initial_backup_end) + "");
+            if (backupSucceeded) {
+                showNotificationMessage(appContext.getText(R.string.l3_initial_backup_end) + "");
+            }
         }
-
-
-
-        // backup finished.  unhold the database connection and false reopen the database.
-        datasource.unHoldDBConnection(); //Jeremy '15,5,23
-        //mLIMEPref.holdDatabaseConnection(false);
-        datasource.openDBConnection(true);
-
-        //cleanup the shared preference backup file.
-        if(fileSharedPrefsBackup.exists() && !fileSharedPrefsBackup.delete()) Log.w(TAG, "Failed to delete shared preferences backup file at end");
-        if(filePreferenceManifest.exists() && !filePreferenceManifest.delete()) Log.w(TAG, "Failed to delete preference manifest at end");
 
 
     }

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/ui/controller/SetupImController.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/ui/controller/SetupImController.java
@@ -182,10 +182,11 @@ public class SetupImController extends BaseController implements ImportDialog.On
         try {
             showProgress(settingsView, "Backing up database...");
             dbServer.backupDatabase(uri);
-            hideProgress(settingsView);
         } catch (Exception e) {
             handleError(settingsView, "Failed to backup database", e);
             throw e;
+        } finally {
+            hideProgress(settingsView);
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix Android backup creation when the optional SQLite rollback journal (`lime.db-journal`) is absent or transient.
- Propagate backup/write failures from `DBServer.backupDatabase()` so the UI shows failure instead of success/0 B output.
- Ensure backup progress is hidden on both success and failure.
- Add regression coverage for missing/present optional journal handling and output failure propagation.

## Verification
- `ANDROID_HOME=$HOME/Android/Sdk ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew :app:compileDebugJavaWithJavac :app:compileDebugAndroidTestJavaWithJavac`
- Attempted targeted connected androidTest for the new DBServer tests; blocked by no connected Android device (`DeviceException: No connected devices!`).
- Independent review performed; initial blockers fixed before PR.

Fixes #94
