### PR TITLE
android ios fix #90 #91 #93 #94 #96 #99 #100: next release updates

### DIFF
--- a/LimeIME-iOS/LimeKeyboard/KeyboardView.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardView.swift
@@ -839,16 +839,7 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
     /// Apply background color, corner radius and shadow to any key button.
     private func applyButtonStyle(_ btn: UIButton, keyDef: KeyDef,
                                   rowHeight: CGFloat, totalPercent: CGFloat) {
-        // Apple-style accent: when the Enter key represents a non-default
-        // primary action (.search / .go / .send / .next / .join / .done /
-        // .route / .continue), render the key with the system-blue tint to
-        // signal it submits the field. Default-return (.default) keeps the
-        // standard modifier-key background.
-        if enterKeyOverride(for: keyDef) != nil {
-            btn.backgroundColor = .systemBlue
-        } else {
-            btn.backgroundColor = keyDef.isModifier ? modifierKeyColor : normalKeyColor
-        }
+        btn.backgroundColor = restoredKeyBackgroundColor(for: keyDef)
         btn.layer.cornerRadius = keyCornerRadius
         btn.layer.masksToBounds = false
         btn.layer.shadowColor = LayoutMetrics.Shadow.color
@@ -856,6 +847,17 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
         btn.layer.shadowOpacity = keyShadowOpacity
         btn.layer.shadowRadius = 0
         styleKeyContent(btn: btn, keyDef: keyDef, rowHeight: rowHeight, totalPercent: totalPercent)
+    }
+
+    private func restoredKeyBackgroundColor(for keyDef: KeyDef) -> UIColor {
+        // Apple-style accent: when the Enter key represents a non-default
+        // primary action (.search / .go / .send / .next / .join / .done /
+        // .route / .continue), render and restore the key with the system-blue
+        // tint so its white icon/label remains readable after touch release.
+        if enterKeyOverride(for: keyDef) != nil {
+            return .systemBlue
+        }
+        return keyDef.isModifier ? modifierKeyColor : normalKeyColor
     }
 
     /// Apple-style Enter-key adaptation: if `keyDef` is the Enter key (code 10) and the host's
@@ -1176,18 +1178,17 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
         if keyBtn.keyDef.code == LimeKeyCode.shift.rawValue {
             shiftHoldTrackingActive = false
         }
-        let isModifier = keyBtn.keyDef.isModifier
-        btn.backgroundColor = isModifier ? modifierKeyColor : normalKeyColor
+        let keyDef = keyBtn.keyDef
+        btn.backgroundColor = restoredKeyBackgroundColor(for: keyDef)
         delegate?.keyboardViewDismissPreview(self)
-        delegate?.keyboardView(self, didRelease: keyBtn.keyDef)
+        delegate?.keyboardView(self, didRelease: keyDef)
         stopRepeating()
         keyBtn.wasSlideDown = false
     }
 
     @objc private func keyCancel(_ btn: UIButton) {
         guard let keyBtn = btn as? KeyButton else { return }
-        let isModifier = keyBtn.keyDef.isModifier
-        btn.backgroundColor = isModifier ? modifierKeyColor : normalKeyColor
+        btn.backgroundColor = restoredKeyBackgroundColor(for: keyBtn.keyDef)
         delegate?.keyboardViewDismissPreview(self)
         stopRepeating()
         keyBtn.wasSlideDown = false

--- a/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
@@ -39,6 +39,7 @@ final class KeyboardViewController: UIInputViewController {
     private var isShiftOn:    Bool = false
     private var isShiftKeyHeld: Bool = false
     private var shiftHoldModifiedCharacter: Bool = false
+    private var lastShiftTapTime: TimeInterval = 0
     private var activeIM:     String = "phonetic"
     /// Cached `imkeys` for the active IM (refreshed on every setTableName).
     /// On iPad layouts, characters whose code is NOT in this string are routed to
@@ -1479,25 +1480,22 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     // MARK: - Shift / CapsLock (spec §4 handleShift)
-    // Three states matching Android: off → one-shot (on) → caps lock → off
+    // Single tap toggles one-shot shift; double tap enters Shift Lock.
     // Layout switching: normal ↔ _shift variant (mirrors Android toggleShift())
 
     private func handleShift() {
-        if mCapsLock {
-            // Caps lock → off
-            mCapsLock = false
-            isShiftOn = false
-            applyShiftState()
-        } else if isShiftOn {
-            // One-shot → caps lock
-            mCapsLock = true
-            isShiftOn = true
-            applyShiftState()
-        } else {
-            // Off → one-shot
-            isShiftOn = true
-            applyShiftState()
-        }
+        let next = ShiftTapPolicy.nextState(shifted: isShiftOn,
+                                            capsLock: mCapsLock,
+                                            doubleTap: isShiftDoubleTap())
+        isShiftOn = next.shifted
+        mCapsLock = next.capsLock
+        applyShiftState()
+    }
+
+    private func isShiftDoubleTap(now: TimeInterval = Date().timeIntervalSinceReferenceDate) -> Bool {
+        defer { lastShiftTapTime = now }
+        guard lastShiftTapTime > 0 else { return false }
+        return now - lastShiftTapTime <= LayoutMetrics.Gesture.shiftDoubleTapTimeout
     }
 
     /// Apply the current shift/capsLock state to the keyboard view (icon) and layout.
@@ -1560,6 +1558,7 @@ final class KeyboardViewController: UIInputViewController {
         mCapsLock = false
         isShiftKeyHeld = false
         shiftHoldModifiedCharacter = false
+        lastShiftTapTime = 0
         applyShiftState()
     }
 

--- a/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
@@ -1087,6 +1087,10 @@ final class KeyboardViewController: UIInputViewController {
         case LimeKeyCode.arrowDown.rawValue:
             moveByLine(forward: true)
         default:
+            if handleLimeEndkeyCommit(code) {
+                consumeShiftAfterCharacter()
+                return
+            }
             handleCharacter(code)
             // Auto-commit check: array10 phone-numpad keyboard only.
             // Android uses currentSoftKeyboard.contains("phone") which accidentally also
@@ -1294,6 +1298,106 @@ final class KeyboardViewController: UIInputViewController {
         }
 
         consumeShiftAfterCharacter()
+    }
+
+    // MARK: - LIME Endkey Commit
+
+    private func activeImkeysForEndkey() -> String {
+        let configured = searchServer?.getImConfig(activeIM, "imkeys") ?? ""
+        return configured.isEmpty ? currentImKeys : configured
+    }
+
+    private func handleLimeEndkeyCommit(_ primaryCode: Int) -> Bool {
+        let limeendkey = searchServer?.getImConfig(activeIM, "limeendkey") ?? ""
+        guard LimeEndkeyPolicy.isCommitKey(primaryCode: primaryCode,
+                                           endkey: limeendkey,
+                                           englishOnly: mEnglishOnly) else {
+            return false
+        }
+
+        if LimeEndkeyPolicy.isKeyInImkeys(primaryCode: primaryCode, imkeys: activeImkeysForEndkey()) {
+            return commitComposingWithAppendedEndkey(primaryCode)
+        }
+
+        if !mComposing.isEmpty && !commitCurrentEndkeyComposing() {
+            return false
+        }
+        return commitFreshEndkeyOrRaw(primaryCode)
+    }
+
+    private func commitComposingWithAppendedEndkey(_ primaryCode: Int) -> Bool {
+        guard appendEndkeyToComposing(primaryCode) else { return false }
+        return commitResolvedEndkeyComposing()
+    }
+
+    private func commitCurrentEndkeyComposing() -> Bool {
+        if hasCurrentEndkeySelectedCandidate() {
+            commitSelectedEndkeyCandidate()
+            return true
+        }
+        return commitResolvedEndkeyComposing()
+    }
+
+    private func commitFreshEndkeyOrRaw(_ primaryCode: Int) -> Bool {
+        guard appendEndkeyToComposing(primaryCode) else { return false }
+        if commitResolvedEndkeyComposing() {
+            return true
+        }
+        clearComposing(force: false)
+        return true
+    }
+
+    private func appendEndkeyToComposing(_ primaryCode: Int) -> Bool {
+        guard primaryCode > 0, let scalar = UnicodeScalar(primaryCode) else { return false }
+        let char = String(Character(scalar))
+        let insertChar = (isShiftOn && primaryCode != LimeKeyCode.space.rawValue) ? char.uppercased() : char
+        mComposing += insertChar
+        isSelfUpdate = true
+        textDocumentProxy.insertText(insertChar)
+        isSelfUpdate = false
+        composingLength += 1
+        candidateBar.setIdleToolsSuppressed(true)
+        showComposingPopup()
+        return true
+    }
+
+    private func commitResolvedEndkeyComposing() -> Bool {
+        guard resolveEndkeySelectedCandidate() != nil else { return false }
+        commitSelectedEndkeyCandidate()
+        return true
+    }
+
+    private func commitSelectedEndkeyCandidate() {
+        commitTyped()
+        clearSuggestions()
+    }
+
+    private func resolveEndkeySelectedCandidate() -> Mapping? {
+        if hasCurrentEndkeySelectedCandidate() {
+            return selectedCandidate
+        }
+        guard !mComposing.isEmpty,
+              let ss = searchServer else { return nil }
+
+        currentSearchID &+= 1
+        let candidates = ss.getMappingByCode(mComposing, isSoftKeyboard: true)
+        guard !candidates.isEmpty else { return nil }
+
+        let idx = LimeEndkeyPolicy.defaultCommitCandidateIndex(candidates)
+        guard idx >= 0, idx < candidates.count else { return nil }
+        mCandidateList = candidates
+        selectedCandidate = candidates[idx]
+        hasCandidatesShown = true
+        isShowingRelatedPhrases = false
+        hasChineseSymbolCandidatesShown = false
+        return selectedCandidate
+    }
+
+    private func hasCurrentEndkeySelectedCandidate() -> Bool {
+        guard let candidate = selectedCandidate else { return false }
+        return !candidate.isComposingCodeRecord
+            && !candidate.code.isEmpty
+            && mComposing == candidate.code
     }
 
     // MARK: - English Character Handling (spec §5 English Mode)
@@ -1689,15 +1793,7 @@ final class KeyboardViewController: UIInputViewController {
               !full.isEmpty else { return }
         mCandidateList = full
         hasCandidatesShown = true
-        let idx: Int
-        if full.count > 1 && (full[1].isExactMatchToCodeRecord || full[1].isPartialMatchToCodeRecord) {
-            idx = 1
-        } else if let first = full.first,
-                  first.isComposingCodeRecord || first.isRuntimeBuiltPhraseRecord {
-            idx = 0
-        } else {
-            idx = -1
-        }
+        let idx = LimeEndkeyPolicy.defaultCommitCandidateIndex(full)
         selectedCandidate = (idx >= 0) ? full[idx] : nil
         candidateBar.appendCandidates(full, selectedIndex: idx)
         // If the expanded grid is currently visible for normal candidates,
@@ -1722,15 +1818,7 @@ final class KeyboardViewController: UIInputViewController {
         // Normal-candidate selection seed (mirrors Android CandidateView.setSuggestions,
         // CandidateView.java:1182–1196). Associated lists (related phrases, punctuation,
         // English) bypass this method entirely and stay at selectedIndex = -1.
-        let selectedIdx: Int
-        if list.count > 1 && (list[1].isExactMatchToCodeRecord || list[1].isPartialMatchToCodeRecord) {
-            selectedIdx = 1
-        } else if let first = list.first,
-                  first.isComposingCodeRecord || first.isRuntimeBuiltPhraseRecord {
-            selectedIdx = 0
-        } else {
-            selectedIdx = -1
-        }
+        let selectedIdx = LimeEndkeyPolicy.defaultCommitCandidateIndex(list)
         selectedCandidate = (selectedIdx >= 0) ? list[selectedIdx] : nil
         candidateBar.setIdleToolsSuppressed(false)
 
@@ -3293,7 +3381,7 @@ extension KeyboardViewController: KeyboardViewDelegate {
         guard !activatedIMs.isEmpty else { return }
         var items: [(title: String, action: () -> Void)] = []
         for (i, im) in activatedIMs.enumerated() {
-            let label = im.label.isEmpty ? im.tableNick : im.label
+            let label = im.label
             let display = (i == activeIMIndex) ? "✓ \(label)" : label
             items.append((display, { [weak self] in self?.switchIM(toIndex: i) }))
         }

--- a/LimeIME-iOS/LimeKeyboard/LayoutMetrics.swift
+++ b/LimeIME-iOS/LimeKeyboard/LayoutMetrics.swift
@@ -320,6 +320,10 @@ enum LayoutMetrics {
         // T9-style multi-tap window — same key within this window cycles
         // through `codes[]` instead of starting a new selection.
         static let multiTapTimeout: TimeInterval = 0.8
+
+        // Shift Lock gesture window. Single taps only toggle one-shot shift;
+        // a second tap inside this window enters Shift Lock.
+        static let shiftDoubleTapTimeout: TimeInterval = 0.3
     }
 
     // MARK: - Long-press popup keyboard (mini keyboard above a key)

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_dayi_sym_ipad_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_dayi_sym_ipad_shift.json
@@ -21,7 +21,7 @@
         {
           "code": 33,
           "label": "!",
-          "sublabel": "言",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -34,7 +34,7 @@
         {
           "code": 64,
           "label": "@",
-          "sublabel": "牛",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -47,7 +47,7 @@
         {
           "code": 35,
           "label": "#",
-          "sublabel": "目",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -60,7 +60,7 @@
         {
           "code": 36,
           "label": "$",
-          "sublabel": "四",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -73,7 +73,7 @@
         {
           "code": 37,
           "label": "%",
-          "sublabel": "王",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -86,7 +86,7 @@
         {
           "code": 94,
           "label": "^",
-          "sublabel": "門",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -99,7 +99,7 @@
         {
           "code": 38,
           "label": "&",
-          "sublabel": "田",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -112,7 +112,7 @@
         {
           "code": 42,
           "label": "*",
-          "sublabel": "米",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -125,7 +125,7 @@
         {
           "code": 40,
           "label": "(",
-          "sublabel": "足",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -138,7 +138,7 @@
         {
           "code": 41,
           "label": ")",
-          "sublabel": "金",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -512,7 +512,7 @@
         {
           "code": 58,
           "label": ":",
-          "sublabel": "虫",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -660,7 +660,7 @@
         {
           "code": 60,
           "label": "<",
-          "sublabel": "力",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -673,7 +673,7 @@
         {
           "code": 62,
           "label": ">",
-          "sublabel": "舟",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -686,7 +686,7 @@
         {
           "code": 63,
           "label": "?",
-          "sublabel": "竹",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_dayi_sym_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_dayi_sym_shift.json
@@ -8,7 +8,7 @@
         {
           "code": 33,
           "label": "!",
-          "sublabel": "言",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -20,7 +20,7 @@
         {
           "code": 64,
           "label": "@",
-          "sublabel": "牛",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -32,7 +32,7 @@
         {
           "code": 35,
           "label": "#",
-          "sublabel": "目",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -44,7 +44,7 @@
         {
           "code": 36,
           "label": "$",
-          "sublabel": "四",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -56,7 +56,7 @@
         {
           "code": 37,
           "label": "%",
-          "sublabel": "王",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -68,7 +68,7 @@
         {
           "code": 94,
           "label": "^",
-          "sublabel": "門",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -80,7 +80,7 @@
         {
           "code": 38,
           "label": "&",
-          "sublabel": "田",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -92,7 +92,7 @@
         {
           "code": 42,
           "label": "*",
-          "sublabel": "米",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -104,7 +104,7 @@
         {
           "code": 40,
           "label": "(",
-          "sublabel": "足",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -116,7 +116,7 @@
         {
           "code": 41,
           "label": ")",
-          "sublabel": "金",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -366,7 +366,7 @@
         {
           "code": 58,
           "label": ":",
-          "sublabel": "虫",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -467,7 +467,7 @@
         {
           "code": 60,
           "label": "<",
-          "sublabel": "力",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -479,7 +479,7 @@
         {
           "code": 62,
           "label": ">",
-          "sublabel": "舟",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -491,7 +491,7 @@
         {
           "code": 63,
           "label": "?",
-          "sublabel": "竹",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_et_41_ipad_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_et_41_ipad_shift.json
@@ -99,7 +99,7 @@
         {
           "code": 38,
           "label": "&",
-          "sublabel": "ㄑ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -112,7 +112,7 @@
         {
           "code": 42,
           "label": "*",
-          "sublabel": "ㄢ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -125,7 +125,7 @@
         {
           "code": 40,
           "label": "(",
-          "sublabel": "ㄣ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -138,7 +138,7 @@
         {
           "code": 41,
           "label": ")",
-          "sublabel": "ㄤ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -512,7 +512,7 @@
         {
           "code": 59,
           "label": ";",
-          "sublabel": "ㄗ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -660,7 +660,7 @@
         {
           "code": 44,
           "label": ",",
-          "sublabel": "ㄓ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -673,7 +673,7 @@
         {
           "code": 46,
           "label": ".",
-          "sublabel": "ㄔ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -686,7 +686,7 @@
         {
           "code": 47,
           "label": "/",
-          "sublabel": "ㄕ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_et_41_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_et_41_shift.json
@@ -80,7 +80,7 @@
         {
           "code": 38,
           "label": "&",
-          "sublabel": "ㄑ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -92,7 +92,7 @@
         {
           "code": 42,
           "label": "*",
-          "sublabel": "ㄢ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -104,7 +104,7 @@
         {
           "code": 40,
           "label": "(",
-          "sublabel": "ㄣ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -116,7 +116,7 @@
         {
           "code": 41,
           "label": ")",
-          "sublabel": "ㄤ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -366,7 +366,7 @@
         {
           "code": 58,
           "label": ":",
-          "sublabel": "ㄗ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -479,7 +479,7 @@
         {
           "code": 34,
           "label": "\"",
-          "sublabel": "ㄘ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -544,7 +544,7 @@
         {
           "code": 60,
           "label": "<",
-          "sublabel": "ㄓ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -556,7 +556,7 @@
         {
           "code": 62,
           "label": ">",
-          "sublabel": "ㄔ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -568,7 +568,7 @@
         {
           "code": 63,
           "label": "?",
-          "sublabel": "ㄕ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -580,7 +580,7 @@
         {
           "code": 95,
           "label": "_",
-          "sublabel": "ㄥ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -592,7 +592,7 @@
         {
           "code": 43,
           "label": "+",
-          "sublabel": "ㄦ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_ez_ipad_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_ez_ipad_shift.json
@@ -164,7 +164,7 @@
         {
           "code": 61,
           "label": "=",
-          "sublabel": "母",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -338,7 +338,7 @@
         {
           "code": 91,
           "label": "[",
-          "sublabel": "匚",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -364,7 +364,7 @@
         {
           "code": 92,
           "label": "\\",
-          "sublabel": "ㄏ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -512,7 +512,7 @@
         {
           "code": 59,
           "label": ";",
-          "sublabel": "寸",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -686,7 +686,7 @@
         {
           "code": 47,
           "label": "/",
-          "sublabel": "ㄥ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_ez_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_ez_shift.json
@@ -20,7 +20,7 @@
         {
           "code": 64,
           "label": "@",
-          "sublabel": "車",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -32,7 +32,7 @@
         {
           "code": 35,
           "label": "#",
-          "sublabel": "糸",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -44,7 +44,7 @@
         {
           "code": 36,
           "label": "$",
-          "sublabel": "言",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -56,7 +56,7 @@
         {
           "code": 37,
           "label": "%",
-          "sublabel": "貝",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -68,7 +68,7 @@
         {
           "code": 94,
           "label": "^",
-          "sublabel": "雨",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -80,7 +80,7 @@
         {
           "code": 38,
           "label": "&",
-          "sublabel": "ㄇ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -92,7 +92,7 @@
         {
           "code": 42,
           "label": "*",
-          "sublabel": "八",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -104,7 +104,7 @@
         {
           "code": 40,
           "label": "(",
-          "sublabel": "耳",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -116,7 +116,7 @@
         {
           "code": 41,
           "label": ")",
-          "sublabel": "鳥",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -366,7 +366,7 @@
         {
           "code": 58,
           "label": ":",
-          "sublabel": "寸",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -556,7 +556,7 @@
         {
           "code": 63,
           "label": "?",
-          "sublabel": "ㄥ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_phonetic_ipad_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_phonetic_ipad_shift.json
@@ -21,7 +21,7 @@
         {
           "code": 33,
           "label": "!",
-          "sublabel": "ㄅ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -34,7 +34,7 @@
         {
           "code": 64,
           "label": "@",
-          "sublabel": "ㄉ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -73,7 +73,7 @@
         {
           "code": 37,
           "label": "%",
-          "sublabel": "ㄓ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -112,7 +112,7 @@
         {
           "code": 42,
           "label": "*",
-          "sublabel": "ㄚ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -125,7 +125,7 @@
         {
           "code": 40,
           "label": "(",
-          "sublabel": "ㄞ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -138,7 +138,7 @@
         {
           "code": 41,
           "label": ")",
-          "sublabel": "ㄢ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -512,7 +512,7 @@
         {
           "code": 59,
           "label": ";",
-          "sublabel": "ㄤ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -660,7 +660,7 @@
         {
           "code": 44,
           "label": ",",
-          "sublabel": "ㄝ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -673,7 +673,7 @@
         {
           "code": 46,
           "label": ".",
-          "sublabel": "ㄡ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,
@@ -686,7 +686,7 @@
         {
           "code": 47,
           "label": "/",
-          "sublabel": "ㄥ",
+          "sublabel": "",
           "widthPercent": 7.0,
           "icon": "",
           "isModifier": false,

--- a/LimeIME-iOS/LimeKeyboard/Layouts/lime_phonetic_shift.json
+++ b/LimeIME-iOS/LimeKeyboard/Layouts/lime_phonetic_shift.json
@@ -8,7 +8,7 @@
         {
           "code": 33,
           "label": "!",
-          "sublabel": "ㄅ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -20,7 +20,7 @@
         {
           "code": 64,
           "label": "@",
-          "sublabel": "ㄉ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -56,7 +56,7 @@
         {
           "code": 37,
           "label": "%",
-          "sublabel": "ㄓ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -92,7 +92,7 @@
         {
           "code": 42,
           "label": "*",
-          "sublabel": "ㄚ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -104,7 +104,7 @@
         {
           "code": 40,
           "label": "(",
-          "sublabel": "ㄞ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -116,7 +116,7 @@
         {
           "code": 41,
           "label": ")",
-          "sublabel": "ㄢ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -366,7 +366,7 @@
         {
           "code": 58,
           "label": ":",
-          "sublabel": "ㄤ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -467,7 +467,7 @@
         {
           "code": 60,
           "label": "<",
-          "sublabel": "ㄝ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -479,7 +479,7 @@
         {
           "code": 62,
           "label": ">",
-          "sublabel": "ㄡ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -491,7 +491,7 @@
         {
           "code": 63,
           "label": "?",
-          "sublabel": "ㄥ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,
@@ -556,7 +556,7 @@
         {
           "code": 95,
           "label": "_",
-          "sublabel": "ㄦ",
+          "sublabel": "",
           "widthPercent": 10.0,
           "icon": "",
           "isModifier": false,

--- a/LimeIME-iOS/LimeSettings/Controllers/ManageImController.swift
+++ b/LimeIME-iOS/LimeSettings/Controllers/ManageImController.swift
@@ -225,7 +225,7 @@ final class ManageImController: BaseController {
         guard !tableNick.isEmpty else {
             return .failure(ControllerError.validation("輸入法代碼不能為空"))
         }
-        guard field == "name" || field == "version" else {
+        guard field == "name" || field == "version" || field == "limeendkey" else {
             return .failure(ControllerError.validation("欄位不正確"))
         }
         guard field != "name" || !trimmedValue.isEmpty else {

--- a/LimeIME-iOS/LimeSettings/Views/IMDetailView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/IMDetailView.swift
@@ -13,11 +13,29 @@ struct IMDetailView: View {
     private enum MetadataField: String, Identifiable {
         case name
         case version
+        case endkey
 
         var id: String { rawValue }
-        var label: String { self == .name ? "名稱" : "版本" }
-        var title: String { self == .name ? "編輯名稱" : "編輯版本" }
-        var dbField: String { rawValue }
+        var label: String {
+            switch self {
+            case .name: return "名稱"
+            case .version: return "版本"
+            case .endkey: return "結束鍵"
+            }
+        }
+        var title: String {
+            switch self {
+            case .name: return "編輯名稱"
+            case .version: return "編輯版本"
+            case .endkey: return "編輯結束鍵"
+            }
+        }
+        var dbField: String {
+            switch self {
+            case .name, .version: return rawValue
+            case .endkey: return "limeendkey"
+            }
+        }
     }
 
     let im: IMRow
@@ -61,6 +79,7 @@ struct IMDetailView: View {
     @State private var showShareSheet = false
     @State private var displayName: String
     @State private var displayVersion: String = "—"
+    @State private var displayEndkey: String = "-"
     @State private var editMetadataValue: String = ""
     @State private var editingMetadataField: MetadataField?
     @State private var metadataError: String?
@@ -117,6 +136,13 @@ struct IMDetailView: View {
                         beginMetadataEdit(.version)
                     } label: {
                         editableMetadataRow(label: "版本", value: displayVersion)
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        beginMetadataEdit(.endkey)
+                    } label: {
+                        editableMetadataRow(label: "結束鍵", value: displayEndkey)
                     }
                     .buttonStyle(.plain)
                 }
@@ -356,6 +382,8 @@ struct IMDetailView: View {
         let version = mappingVersion
         displayName = im.label
         displayVersion = version
+        let endkey = DBServer.shared.getImConfig(im.tableNick, "limeendkey")
+        displayEndkey = endkey.isEmpty ? "-" : endkey
         editMetadataValue = ""
     }
 
@@ -377,7 +405,14 @@ struct IMDetailView: View {
 
     private func beginMetadataEdit(_ field: MetadataField) {
         metadataError = nil
-        editMetadataValue = field == .name ? displayName : (displayVersion == "—" ? "" : displayVersion)
+        switch field {
+        case .name:
+            editMetadataValue = displayName
+        case .version:
+            editMetadataValue = displayVersion == "—" ? "" : displayVersion
+        case .endkey:
+            editMetadataValue = displayEndkey == "-" ? "" : displayEndkey
+        }
         editingMetadataField = field
     }
 
@@ -395,8 +430,10 @@ struct IMDetailView: View {
                     let trimmedValue = editMetadataValue.trimmingCharacters(in: .whitespacesAndNewlines)
                     if field == .name {
                         displayName = trimmedValue
-                    } else {
+                    } else if field == .version {
                         displayVersion = trimmedValue.isEmpty ? "—" : trimmedValue
+                    } else {
+                        displayEndkey = trimmedValue.isEmpty ? "-" : trimmedValue
                     }
                     editingMetadataField = nil
                     onRefresh?()

--- a/LimeIME-iOS/LimeTests/DBServerTest.swift
+++ b/LimeIME-iOS/LimeTests/DBServerTest.swift
@@ -424,6 +424,43 @@ final class DBServerTest: XCTestCase {
         }
     }
 
+    func testDBServerBackupDatabaseSkipsMissingRollbackJournal() throws {
+        let db = try makeLimeDB()
+        db.addOrUpdateMappingRecord(LIME.DB_TABLE_CUSTOM, "backup_no_journal", "無journal", 0)
+        let journalURL = tempURL.deletingLastPathComponent()
+            .appendingPathComponent(DBServer.databaseJournal)
+        try? FileManager.default.removeItem(at: journalURL)
+
+        let server = DBServer(_testDatasource: db)
+        let backupURL = tempFile(".zip")
+        defer { try? FileManager.default.removeItem(at: backupURL) }
+
+        try server.backupDatabase(uri: backupURL)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backupURL.path))
+        XCTAssertGreaterThan(backupURL.fileSizeBytes, 0)
+
+        let archive = try XCTUnwrap(Archive(url: backupURL, accessMode: .read))
+        let entryNames = Set(archive.map(\.path))
+        XCTAssertTrue(entryNames.contains(DBServer.databaseName),
+                      "Backup must include the live lime.db")
+        XCTAssertTrue(entryNames.contains(DBServer.preferenceManifestPath),
+                      "Backup must include the preference compatibility manifest")
+        XCTAssertFalse(entryNames.contains(DBServer.databaseJournal),
+                       "Missing rollback journal is optional and must not be required in the archive")
+    }
+
+    func testDBServerBackupDatabasePropagatesOutputWriteFailure() throws {
+        let db = try makeLimeDB()
+        db.addOrUpdateMappingRecord(LIME.DB_TABLE_CUSTOM, "backup_bad_uri", "壞路徑", 0)
+        let server = DBServer(_testDatasource: db)
+        let bogusURL = URL(fileURLWithPath: "/dev/null/\(UUID()).zip")
+
+        XCTAssertThrowsError(try server.backupDatabase(uri: bogusURL))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: bogusURL.path),
+                       "Failed backup destination must not be reported as a created backup")
+    }
+
     func testDBServerBackupDatabaseWithNullUri() {
         // Use a URL that cannot be written to.
         let bogusURL = URL(fileURLWithPath: "/dev/null/\(UUID()).zip")

--- a/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
+++ b/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
@@ -50,6 +50,15 @@ final class KeyboardViewControllerTest: XCTestCase {
         XCTAssertFalse(bottomCodes.contains(LimeKeyCode.emojiPanel.rawValue))
     }
 
+    func testContextualEnterKeyRestoreUsesSameBackgroundPolicyAsInitialRender() throws {
+        let source = try String(contentsOf: projectFileURL("LimeKeyboard/KeyboardView.swift"),
+                                encoding: .utf8)
+
+        XCTAssertTrue(source.contains("private func restoredKeyBackgroundColor(for keyDef: KeyDef) -> UIColor"))
+        XCTAssertTrue(source.contains("btn.backgroundColor = restoredKeyBackgroundColor(for: keyDef)"))
+        XCTAssertFalse(source.contains("btn.backgroundColor = isModifier ? modifierKeyColor : normalKeyColor"))
+    }
+
     func testIPhoneEnglishJsonLayoutsHaveChineseSwitchOnBottomRow() throws {
         for layoutID in ["lime_english", "lime_english_number"] {
             let layout = try loadKeyboardLayoutFixture(layoutID)
@@ -208,21 +217,24 @@ final class KeyboardViewControllerTest: XCTestCase {
                                                                     keyDef: dualGlyphKey))
     }
 
-    func testDayiSymbolIPadShiftKeepsShiftedRootPunctuation() throws {
-        let layout = try loadKeyboardLayoutFixture("lime_dayi_sym_ipad_shift")
-        let keys = layout.rows.flatMap(\.keys)
-        let expectedPunctuationByRoot: [String: (code: Int, label: String)] = [
-            "虫": (58, ":"),
-            "力": (60, "<"),
-            "舟": (62, ">"),
-            "竹": (63, "?")
+    func testShiftedSymbolKeysDoNotShowChineseRootSubLabels() throws {
+        let layoutIDs = [
+            "lime_phonetic_shift",
+            "lime_phonetic_ipad_shift",
+            "lime_ez_shift",
+            "lime_ez_ipad_shift",
+            "lime_et_41_shift",
+            "lime_et_41_ipad_shift",
+            "lime_dayi_sym_shift",
+            "lime_dayi_sym_ipad_shift",
         ]
 
-        for (root, expected) in expectedPunctuationByRoot {
-            let key = try XCTUnwrap(keys.first { $0.sublabel == root },
-                                    "Dayi symbol iPad shift layout should keep shifted punctuation for \(root)")
-            XCTAssertEqual(key.code, expected.code)
-            XCTAssertEqual(key.label, expected.label)
+        for layoutID in layoutIDs {
+            let layout = try loadKeyboardLayoutFixture(layoutID)
+            for key in layout.rows.flatMap(\.keys)
+                where isPunctuationOrSymbolCode(key.code) && containsChineseRootSublabel(key.sublabel) {
+                XCTFail("\(layoutID): shifted symbol key \(key.label) should not show root sublabel \(key.sublabel)")
+            }
         }
     }
 
@@ -358,6 +370,34 @@ final class KeyboardViewControllerTest: XCTestCase {
     func testShiftPressPolicyIgnoresRepeatedPressDuringSamePhysicalHold() {
         XCTAssertTrue(ShiftPressPolicy.shouldHandleShiftPress(wasShiftKeyHeld: false))
         XCTAssertFalse(ShiftPressPolicy.shouldHandleShiftPress(wasShiftKeyHeld: true))
+    }
+
+    func testSingleShiftTapTogglesBetweenShiftedAndUnshiftedOnly() {
+        var state = ShiftTapPolicy.nextState(shifted: false, capsLock: false, doubleTap: false)
+        XCTAssertTrue(state.shifted)
+        XCTAssertFalse(state.capsLock)
+
+        state = ShiftTapPolicy.nextState(shifted: state.shifted, capsLock: state.capsLock, doubleTap: false)
+        XCTAssertFalse(state.shifted)
+        XCTAssertFalse(state.capsLock)
+
+        state = ShiftTapPolicy.nextState(shifted: state.shifted, capsLock: state.capsLock, doubleTap: false)
+        XCTAssertTrue(state.shifted)
+        XCTAssertFalse(state.capsLock)
+    }
+
+    func testDoubleShiftTapEntersShiftLockAndSingleTapUnlocks() {
+        var state = ShiftTapPolicy.nextState(shifted: false, capsLock: false, doubleTap: true)
+        XCTAssertTrue(state.shifted)
+        XCTAssertTrue(state.capsLock)
+
+        state = ShiftTapPolicy.nextState(shifted: state.shifted, capsLock: state.capsLock, doubleTap: false)
+        XCTAssertFalse(state.shifted)
+        XCTAssertFalse(state.capsLock)
+
+        state = ShiftTapPolicy.nextState(shifted: true, capsLock: false, doubleTap: true)
+        XCTAssertTrue(state.shifted)
+        XCTAssertTrue(state.capsLock)
     }
 
     func testShiftHoldTouchPolicyRequiresAnotherActiveTouch() {
@@ -880,6 +920,21 @@ final class KeyboardViewControllerTest: XCTestCase {
                 XCTAssertEqual(key.label.lowercased(), key.label,
                                "\(layoutID): \(key.label) should show lowercase label")
             }
+        }
+    }
+
+    private func isPunctuationOrSymbolCode(_ code: Int) -> Bool {
+        (33...47).contains(code)
+            || (58...64).contains(code)
+            || (91...96).contains(code)
+            || (123...126).contains(code)
+    }
+
+    private func containsChineseRootSublabel(_ sublabel: String) -> Bool {
+        sublabel.unicodeScalars.contains { scalar in
+            (0x3100...0x312F).contains(Int(scalar.value))
+                || (0x31A0...0x31BF).contains(Int(scalar.value))
+                || (0x4E00...0x9FFF).contains(Int(scalar.value))
         }
     }
 

--- a/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
+++ b/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
@@ -671,6 +671,86 @@ final class KeyboardViewControllerTest: XCTestCase {
         XCTAssertTrue(layoutSource.contains(".frame(height: titleSectionHeight)"))
     }
 
+    func testIMDetailViewShowsEditableLimeEndkeyField() throws {
+        let sourceURL = projectFileURL("LimeSettings/Views/IMDetailView.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        XCTAssertTrue(source.contains("case endkey"))
+        XCTAssertTrue(source.contains("case .endkey: return \"結束鍵\""))
+        XCTAssertTrue(source.contains("case .endkey: return \"編輯結束鍵\""))
+        XCTAssertTrue(source.contains("case .endkey: return \"limeendkey\""))
+        XCTAssertTrue(source.contains("DBServer.shared.getImConfig(im.tableNick, \"limeendkey\")"))
+        XCTAssertTrue(source.contains("beginMetadataEdit(.endkey)"))
+        XCTAssertTrue(source.contains("editableMetadataRow(label: \"結束鍵\", value: displayEndkey)"))
+    }
+
+    func testLimeEndkeyPolicyMatchesAndroidTriggerRules() {
+        XCTAssertTrue(LimeEndkeyPolicy.isCommitKey(
+            primaryCode: Int(UnicodeScalar(",").value),
+            endkey: ".,",
+            englishOnly: false
+        ))
+        XCTAssertFalse(LimeEndkeyPolicy.isCommitKey(
+            primaryCode: Int(UnicodeScalar(",").value),
+            endkey: ".,",
+            englishOnly: true
+        ))
+        XCTAssertFalse(LimeEndkeyPolicy.isCommitKey(
+            primaryCode: Int(UnicodeScalar(",").value),
+            endkey: "",
+            englishOnly: false
+        ))
+
+        XCTAssertTrue(LimeEndkeyPolicy.isKeyInImkeys(
+            primaryCode: Int(UnicodeScalar("A").value),
+            imkeys: "abc"
+        ))
+        XCTAssertFalse(LimeEndkeyPolicy.isKeyInImkeys(
+            primaryCode: Int(UnicodeScalar(",").value),
+            imkeys: "abc"
+        ))
+    }
+
+    func testLimeEndkeyDefaultCandidatePrefersRealCommitCandidate() {
+        let composing = Mapping(id: 0, code: ",", word: ",", score: 0, baseScore: 0,
+                                recordType: Mapping.RecordType.composingCode)
+        let exact = Mapping(id: 1, code: ",", word: "，", score: 0, baseScore: 0,
+                            recordType: Mapping.RecordType.exactMatchToCode)
+        let punctuation = Mapping(id: 2, code: ".", word: "。", score: 0, baseScore: 0,
+                                  recordType: Mapping.RecordType.chinesePunctuation)
+
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([composing, exact]), 1)
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([composing, punctuation]), 1)
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([composing]), 0)
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([]), -1)
+    }
+
+    func testKeyboardControllerRoutesLimeEndkeyBeforeNormalCharacterHandling() throws {
+        let source = try String(
+            contentsOf: projectFileURL("LimeKeyboard/KeyboardViewController.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(source.contains("if handleLimeEndkeyCommit(code)"))
+        XCTAssertTrue(source.contains("searchServer?.getImConfig(activeIM, \"limeendkey\")"))
+        XCTAssertTrue(source.contains("commitComposingWithAppendedEndkey(primaryCode)"))
+        XCTAssertTrue(source.contains("commitFreshEndkeyOrRaw(primaryCode)"))
+        XCTAssertTrue(source.contains("LimeEndkeyPolicy.defaultCommitCandidateIndex(candidates)"))
+        XCTAssertTrue(source.contains("currentSearchID &+= 1"))
+    }
+
+    func testNormalCandidateSelectionUsesSameDefaultPolicyAsLimeEndkey() throws {
+        let source = try String(
+            contentsOf: projectFileURL("LimeKeyboard/KeyboardViewController.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(source.contains("let idx = LimeEndkeyPolicy.defaultCommitCandidateIndex(full)"))
+        XCTAssertTrue(source.contains("let selectedIdx = LimeEndkeyPolicy.defaultCommitCandidateIndex(list)"))
+        XCTAssertFalse(source.contains("full.count > 1 && (full[1].isExactMatchToCodeRecord || full[1].isPartialMatchToCodeRecord)"))
+        XCTAssertFalse(source.contains("list.count > 1 && (list[1].isExactMatchToCodeRecord || list[1].isPartialMatchToCodeRecord)"))
+    }
+
     func testSettingsGroupedSurfacesMatchSetupTabColors() throws {
         let settingsSource = try String(
             contentsOf: projectFileURL("LimeSettings/LimeSettingsView.swift"),

--- a/LimeIME-iOS/LimeTests/LimeDBTest.swift
+++ b/LimeIME-iOS/LimeTests/LimeDBTest.swift
@@ -624,8 +624,11 @@ final class LimeDBTest: XCTestCase {
         try db.importTxtFile(at: importURL.path, tableName: LIME.DB_TABLE_CUSTOM)
 
         XCTAssertEqual(db.getImConfig(LIME.DB_TABLE_CUSTOM, "version"), "My Custom Table 2026.05")
+        XCTAssertEqual(db.getImConfig(LIME.DB_TABLE_CUSTOM, "name"), "自建輸入法")
         XCTAssertEqual(db.getImConfig(LIME.DB_TABLE_CUSTOM, "selkey"), "123456789")
         XCTAssertEqual(db.getImConfig(LIME.DB_TABLE_CUSTOM, "amount"), "2")
+        let custom = try db.getAllImConfigs().first { $0.tableNick == LIME.DB_TABLE_CUSTOM }
+        XCTAssertEqual(custom?.label, "自建輸入法")
     }
 
     func testImportTxtFileStoresCnameMetadataFromLimeHeader() throws {
@@ -695,6 +698,9 @@ final class LimeDBTest: XCTestCase {
         try db.importTxtFile(at: importURL.path, tableName: LIME.DB_TABLE_CUSTOM)
 
         XCTAssertEqual(db.getImConfig(LIME.DB_TABLE_CUSTOM, "amount"), "2")
+        XCTAssertEqual(db.getImConfig(LIME.DB_TABLE_CUSTOM, "name"), "自建輸入法")
+        let custom = try db.getAllImConfigs().first { $0.tableNick == LIME.DB_TABLE_CUSTOM }
+        XCTAssertEqual(custom?.label, "自建輸入法")
         XCTAssertEqual(db.countRecords(LIME.DB_TABLE_CUSTOM, "code = ?", ["#"]), 0)
         XCTAssertEqual(db.countRecords(LIME.DB_TABLE_CUSTOM, "word IN (?, ?)", ["Begin", "End"]), 0)
     }
@@ -809,6 +815,7 @@ final class LimeDBTest: XCTestCase {
 
         let content = """
         @format@|lime-text-v2
+        @limeendkey@|.,
         @imkeys@|ab
         @imkeynames@|ㄅ\\|ㄆ
         %chardef begin
@@ -819,6 +826,7 @@ final class LimeDBTest: XCTestCase {
 
         try db.importTxtFile(at: importURL.path, tableName: LIME.DB_TABLE_CUSTOM)
 
+        XCTAssertEqual(db.getImConfig(LIME.DB_TABLE_CUSTOM, "limeendkey"), ".,")
         XCTAssertEqual(db.getImConfig(LIME.DB_TABLE_CUSTOM, "imkeys"), "ab")
         XCTAssertEqual(db.getImConfig(LIME.DB_TABLE_CUSTOM, "imkeynames"), "ㄅ|ㄆ")
     }
@@ -878,6 +886,37 @@ final class LimeDBTest: XCTestCase {
         let output = try String(contentsOf: exportURL, encoding: .utf8)
 
         XCTAssertTrue(output.contains("@format@|lime-text-v2"))
+        XCTAssertTrue(output.contains("@imkeys@|ab"))
+        XCTAssertTrue(output.contains("@imkeynames@|ㄅ\\|ㄆ"))
+    }
+
+    func testExportTxtTableLoadsImMetadataWhenConfigListIsNil() throws {
+        let db = try makeLimeDB()
+        db.setTableName(LIME.DB_TABLE_CUSTOM)
+        db.addOrUpdateMappingRecord("aa", "測")
+        db.setImConfig(LIME.DB_TABLE_CUSTOM, "name", "Friendly Name")
+        db.setImConfig(LIME.DB_TABLE_CUSTOM, "version", "Version 2.0")
+        db.setImConfig(LIME.DB_TABLE_CUSTOM, "selkey", "123456789")
+        db.setImConfig(LIME.DB_TABLE_CUSTOM, "endkey", " ")
+        db.setImConfig(LIME.DB_TABLE_CUSTOM, "limeendkey", ".,")
+        db.setImConfig(LIME.DB_TABLE_CUSTOM, "spacestyle", "auto")
+        db.setImConfig(LIME.DB_TABLE_CUSTOM, "imkeys", "ab")
+        db.setImConfig(LIME.DB_TABLE_CUSTOM, "imkeynames", "ㄅ|ㄆ")
+
+        let exportURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".lime")
+        defer { try? FileManager.default.removeItem(at: exportURL) }
+
+        XCTAssertTrue(db.exportTxtTable(LIME.DB_TABLE_CUSTOM, targetFile: exportURL, imConfig: nil))
+        let output = try String(contentsOf: exportURL, encoding: .utf8)
+
+        XCTAssertTrue(output.contains("@format@|lime-text-v2"))
+        XCTAssertTrue(output.contains("@version@|Version 2.0"))
+        XCTAssertTrue(output.contains("@cname@|Friendly Name"))
+        XCTAssertTrue(output.contains("@selkey@|123456789"))
+        XCTAssertTrue(output.contains("@endkey@| "))
+        XCTAssertTrue(output.contains("@limeendkey@|.,"))
+        XCTAssertTrue(output.contains("@spacestyle@|auto"))
         XCTAssertTrue(output.contains("@imkeys@|ab"))
         XCTAssertTrue(output.contains("@imkeynames@|ㄅ\\|ㄆ"))
     }
@@ -2468,6 +2507,27 @@ final class LimeDBTest: XCTestCase {
         XCTAssertEqual(custom?.label, "Friendly Custom")
         XCTAssertEqual(custom?.id, Int64(sourceRow?.id ?? -1))
         XCTAssertNotEqual(custom?.id, Int64(versionRow?.id ?? -1))
+    }
+
+    func testGetAllImConfigsFallsBackToBuiltInFullNameWhenNameDescIsEmpty() throws {
+        let db = try makeLimeDB()
+        db.setImConfig("array10", "source", "array10a-v2023-1.0-20260517.lime")
+        db.setImConfig("array10", "name", "")
+
+        let array10 = try db.getAllImConfigs().first { $0.tableNick == "array10" }
+
+        XCTAssertEqual(array10?.label, "行列10輸入法")
+        XCTAssertEqual(array10?.fullName, "行列10輸入法")
+    }
+
+    func testGetAllImConfigsExcludesEmojiMetadataRows() throws {
+        let db = try makeLimeDB()
+        db.setImConfig("emoji", "version", "17.0")
+        db.setImConfig("emoji", "name", "Emoji 17.0 Dataset")
+
+        let configs = try db.getAllImConfigs()
+
+        XCTAssertFalse(configs.contains { $0.tableNick == "emoji" })
     }
 
     // MARK: - 36. DB 104 integrated seed / upgrade / restore paths

--- a/LimeIME-iOS/LimeTests/LimeDBTest.swift
+++ b/LimeIME-iOS/LimeTests/LimeDBTest.swift
@@ -318,6 +318,57 @@ final class LimeDBTest: XCTestCase {
                                  "Partial matches should not exceed similarCodeCandidatesCap")
     }
 
+    func testLimeDBGetMappingByCodePreservesDuplicateCodeInsertionOrderWhenSortingDisabled() throws {
+        let db = try makeLimeDB()
+        db.setTableName(LIME.DB_TABLE_CUSTOM)
+        db.sortSuggestions = false
+        db.similarCodeCandidatesCap = 0
+
+        let code = "vmi"
+        db.addOrUpdateMappingRecord(LIME.DB_TABLE_CUSTOM, code, "狀", 0)
+        db.addOrUpdateMappingRecord(LIME.DB_TABLE_CUSTOM, code, "绒", 20)
+        db.addOrUpdateMappingRecord(LIME.DB_TABLE_CUSTOM, code, "戕", 0)
+
+        let results = try XCTUnwrap(db.getMappingByCode(code, softKeyboard: true, getAllRecords: true))
+        let exactWords = results
+            .filter { $0.code == code && $0.isExactMatchToCodeRecord }
+            .map(\.word)
+
+        XCTAssertGreaterThanOrEqual(exactWords.count, 3)
+        XCTAssertEqual(Array(exactWords.prefix(3)), ["狀", "绒", "戕"],
+                       "When suggestion sorting is disabled, exact duplicate-code records must follow source/_id order even if one row has a learned score")
+    }
+
+    func testCinImportPreservesDuplicateCodeOrderWhenSelectionSortDisabled() throws {
+        let db = try makeLimeDB()
+        db.setTableName(LIME.DB_TABLE_CUSTOM)
+        db.sortSuggestions = false
+        db.similarCodeCandidatesCap = 0
+        let importURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".cin")
+        defer { try? FileManager.default.removeItem(at: importURL) }
+
+        let content = """
+        %ename issue91
+        %cname Issue91
+        %chardef begin
+        vmi 狀
+        vmi 绒
+        vmi 戕
+        %chardef end
+        """
+        try content.write(to: importURL, atomically: true, encoding: .utf8)
+
+        try db.importTxtFile(at: importURL.path, tableName: LIME.DB_TABLE_CUSTOM)
+
+        let results = try XCTUnwrap(db.getMappingByCode("vmi", softKeyboard: true, getAllRecords: true))
+        let exactWords = results
+            .filter { $0.code == "vmi" && $0.isExactMatchToCodeRecord }
+            .map(\.word)
+
+        XCTAssertEqual(Array(exactWords.prefix(3)), ["狀", "绒", "戕"])
+    }
+
     func testLimeDBGetMappingByCodeWithAllRecords() throws {
         let db = try makeLimeDB()
         db.setTableName(LIME.DB_TABLE_CUSTOM)

--- a/LimeIME-iOS/LimeTests/ManageImControllerTest.swift
+++ b/LimeIME-iOS/LimeTests/ManageImControllerTest.swift
@@ -158,6 +158,30 @@ final class ManageImControllerTest: XCTestCase {
         XCTAssertEqual(db.getImConfig(testTable, "version"), "Independent Version")
     }
 
+    func testUpdateIMMetadataFieldAllowsBlankLimeEndkey() async throws {
+        let (url, db) = try makeDB()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let controller = await LimeIME.ManageImController(dbServer: LimeIME.DBServer(_testDatasource: db))
+
+        let setResult = await controller.updateIMMetadataField(tableNick: testTable,
+                                                               field: "limeendkey",
+                                                               value: " ., ")
+        guard case .success = setResult else {
+            XCTFail("Expected limeendkey update to succeed, got \(setResult)")
+            return
+        }
+        XCTAssertEqual(db.getImConfig(testTable, "limeendkey"), ".,")
+
+        let clearResult = await controller.updateIMMetadataField(tableNick: testTable,
+                                                                 field: "limeendkey",
+                                                                 value: " ")
+        guard case .success = clearResult else {
+            XCTFail("Expected blank limeendkey update to succeed, got \(clearResult)")
+            return
+        }
+        XCTAssertEqual(db.getImConfig(testTable, "limeendkey"), "")
+    }
+
     // MARK: - updateRecord
 
     func testUpdateRecordAfterAdd() async throws {

--- a/LimeIME-iOS/LimeTests/SearchServerTest.swift
+++ b/LimeIME-iOS/LimeTests/SearchServerTest.swift
@@ -898,6 +898,13 @@ final class SearchServerTest: XCTestCase {
         XCTAssertTrue(result.count >= list.count)
     }
 
+    func test_3_6_4_5_emojiInsertionPositionZeroDisablesCandidateInjection() throws {
+        XCTAssertFalse(SearchServer.shouldInjectEmojiCandidates(insertAt: 0))
+        XCTAssertFalse(SearchServer.shouldInjectEmojiCandidates(insertAt: -1))
+        XCTAssertTrue(SearchServer.shouldInjectEmojiCandidates(insertAt: 1))
+        XCTAssertTrue(SearchServer.shouldInjectEmojiCandidates(insertAt: 5))
+    }
+
     func test_3_6_4_5_emojiInsertionSkipsChinesePunctuationAtRequestedSlot() throws {
         let ss = try makeSearchServer()
         let list = [

--- a/LimeIME-iOS/Shared/Database/DBServer.swift
+++ b/LimeIME-iOS/Shared/Database/DBServer.swift
@@ -268,8 +268,9 @@ final class DBServer {
         }
 
         do {
-            let dbURL     = URL(fileURLWithPath: livePath)
-            let journalURL = dataDir.appendingPathComponent(DBServer.databaseJournal)
+            let dbURL = URL(fileURLWithPath: livePath)
+            let journalURL = dbURL.deletingLastPathComponent()
+                .appendingPathComponent(DBServer.databaseJournal)
 
             // Build file list
             var filesToZip: [(URL, String)] = []
@@ -284,6 +285,9 @@ final class DBServer {
             }
             if FileManager.default.fileExists(atPath: filePreferenceManifest.path) {
                 filesToZip.append((filePreferenceManifest, DBServer.preferenceManifestPath))
+            }
+            guard filesToZip.contains(where: { $0.1 == DBServer.databaseName }) else {
+                throw DBServerError.fileNotFound(DBServer.databaseName)
             }
 
             // Create zip archive
@@ -303,6 +307,9 @@ final class DBServer {
                     try archive.addEntry(with: entryName, fileURL: fileURL)
                 }
             }
+            guard DBServer.fileSizeBytes(at: tempZip) > 0 else {
+                throw DBServerError.archiveCreationFailed
+            }
 
             // Mark the temp zip with complete file protection (contains user dictionary data).
             try? FileManager.default.setAttributes(
@@ -312,6 +319,10 @@ final class DBServer {
             // (copyItem throws on collision — that would silently drop the backup).
             try? FileManager.default.removeItem(at: uri)
             try FileManager.default.copyItem(at: tempZip, to: uri)
+            guard FileManager.default.fileExists(atPath: uri.path),
+                  DBServer.fileSizeBytes(at: uri) > 0 else {
+                throw DBServerError.archiveCreationFailed
+            }
             // Apply protection on the destination too.
             try? FileManager.default.setAttributes(
                 [.protectionKey: FileProtectionType.complete], ofItemAtPath: uri.path)
@@ -1055,6 +1066,14 @@ final class DBServer {
     func seedCustomIM() throws {
         guard let ds = datasource else { throw DBServerError.datasourceUnavailable }
         try ds.seedCustomIM()
+    }
+
+    private static func fileSizeBytes(at url: URL) -> Int64 {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? NSNumber else {
+            return 0
+        }
+        return size.int64Value
     }
 }
 

--- a/LimeIME-iOS/Shared/Database/LimeDB.swift
+++ b/LimeIME-iOS/Shared/Database/LimeDB.swift
@@ -118,7 +118,15 @@ final class LimeDB {
     private static let DAYI_CHAR = "言|牛|目|四|王|門|田|米|足|金|石|山|一|工|糸|火|艸|木|口|耳|人|革|日|土|手|鳥|月|立|女|虫|心|水|鹿|禾|馬|魚|雨|力|舟|竹"
     private static let ARRAY_KEY  = "qazwsxedcrfvtgbyhnujmik,ol.p;/"
     private static let ARRAY_CHAR = "1^|1-|1v|2^|2-|2v|3^|3-|3v|4^|4-|4v|5^|5-|5v|6^|6-|6v|7^|7-|7v|8^|8-|8v|9^|9-|9v|0^|0-|0v|"
-
+    private static let IM_CODES = [
+        "custom", "cj", "scj", "cj5", "ecj", "dayi", "phonetic", "ez",
+        "array", "array10", "wb", "hs", "pinyin", "cj4"
+    ]
+    private static let IM_FULL_NAMES = [
+        "自建輸入法", "倉頡輸入法", "快倉輸入法", "倉頡五代輸入法", "速成輸入法",
+        "大易輸入法", "注音輸入法", "輕鬆輸入法", "行列輸入法", "行列10輸入法",
+        "筆順五碼輸入法", "華象直覺輸入法", "拼音輸入法", "四碼倉頡輸入法"
+    ]
     // MARK: - Initializer
 
     /// Opens (or creates) lime.db at the given path.
@@ -1126,35 +1134,42 @@ final class LimeDB {
     /// Enabled state is stored in the key-value row where title="disable", desc="true"/"false".
     func getAllImConfigs() throws -> [ImConfig] {
         // Known key-value field names — rows with these titles are config entries, not IM seed rows.
-        let kvFields: Set<String> = ["keyboard","disable","selkey","endkey","spacestyle",
+        let kvFields: Set<String> = ["keyboard","disable","selkey","endkey","limeendkey","spacestyle",
                                      "imkeys","imkeynames","name","label","version"]
         let allRows = getImConfigList(nil, nil)
 
         // Group all rows by IM code.
         var grouped: [String: [LimeImConfigRow]] = [:]
         for row in allRows where !row.code.isEmpty {
+            if row.code == "emoji" { continue }
             grouped[row.code, default: []].append(row)
         }
 
         return grouped.compactMap { (code, rows) -> ImConfig? in
             // Seed/registration row: title is the display label, not a config field name.
+            // Legacy DBs may only contain kv rows; still surface them through the DB model
+            // and resolve their display names below.
             guard let seedRow = rows.first(where: { !kvFields.contains($0.title) && !$0.title.isEmpty })
+                    ?? rows.first(where: { $0.title == "name" })
+                    ?? rows.first(where: { !$0.title.isEmpty })
             else { return nil }
             // Keyboard code: from key-value row (title="keyboard"), fall back to seed row column.
             let kbRow = rows.first(where: { $0.title == "keyboard" })
             let keyboardId = kbRow?.keyboard.isEmpty == false ? kbRow!.keyboard : seedRow.keyboard
-            guard !keyboardId.isEmpty else { return nil }
             // Enabled state: from key-value row (title="disable", desc="true"/"false").
             let disableStr = rows.first(where: { $0.title == "disable" })?.desc ?? "false"
             let enabled = disableStr != "true"
             // Full name from title="name" config entry (mirrors Android LIME.IM_FULL_NAME / sidebar).
-            let fullName = rows.first(where: { $0.title == "name" })?.desc ?? ""
+            // Legacy DBs may only have seed rows; keep the fallback here so UI lists and pickers
+            // can consume the resolved label directly.
+            let storedFullName = rows.first(where: { $0.title == "name" })?.desc ?? ""
+            let fullName = storedFullName.isEmpty ? defaultImFullName(code, fallback: seedRow.title) : storedFullName
             // Display label: prefer the cloud DB's `name` kv row (e.g. "拼音輸入法"),
             // because for cloud-installed IMs the seedRow.title is an arbitrary
             // non-kv field (`source` / `amount` / `original` / `import`) — whichever
             // row happens to be first. The synthetic legacy registerIM flow stores
             // the friendly label in `seedRow.title`, so fall back to that.
-            let label = !fullName.isEmpty ? fullName : seedRow.title
+            let label = fullName
             return ImConfig(
                 id:                  Int64(seedRow.id),
                 imName:              code,
@@ -2959,6 +2974,17 @@ final class LimeDB {
                     ])
                 }
             }
+            try db.execute(sql: """
+                INSERT INTO im (code, title, desc)
+                SELECT ?, 'name', ?
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM im WHERE code = ? AND title = 'name'
+                )
+            """, arguments: [
+                tableName,
+                defaultImFullName(tableName, fallback: tableName),
+                tableName,
+            ])
         }
     }
 
@@ -3004,11 +3030,13 @@ final class LimeDB {
             var useEscapedFormat = records.contains {
                 needsEscaping($0.code, delimiter: "|", codeField: true) || needsEscaping($0.word, delimiter: "|")
             }
-            if let configs = imConfig {
+            let configs = imConfig ?? getImConfigList(table, nil)
+            if !configs.isEmpty {
                 var version = ""
                 var name = ""
                 var selkey = ""
                 var endkey = ""
+                var limeendkey = ""
                 var spacestyle = ""
                 var imkeys = ""
                 var imkeynames = ""
@@ -3017,6 +3045,7 @@ final class LimeDB {
                     if c.title == "name" { name = c.desc }
                     if c.title == "selkey" { selkey = c.desc }
                     if c.title == "endkey" { endkey = c.desc }
+                    if c.title == "limeendkey" { limeendkey = c.desc }
                     if c.title == "spacestyle" { spacestyle = c.desc }
                     if c.title == "imkeys" { imkeys = c.desc }
                     if c.title == "imkeynames" { imkeynames = c.desc }
@@ -3025,6 +3054,7 @@ final class LimeDB {
                     || needsEscaping(name, delimiter: "|")
                     || needsEscaping(selkey, delimiter: "|")
                     || needsEscaping(endkey, delimiter: "|")
+                    || needsEscaping(limeendkey, delimiter: "|")
                     || needsEscaping(spacestyle, delimiter: "|")
                     || needsEscaping(imkeys, delimiter: "|")
                     || needsEscaping(imkeynames, delimiter: "|") {
@@ -3036,6 +3066,7 @@ final class LimeDB {
                 if !name.isEmpty { lines.append("@cname@|\(useEscapedFormat ? escapeField(name, delimiter: "|") : name)") }
                 if !selkey.isEmpty { lines.append("@selkey@|\(useEscapedFormat ? escapeField(selkey, delimiter: "|") : selkey)") }
                 if !endkey.isEmpty { lines.append("@endkey@|\(useEscapedFormat ? escapeField(endkey, delimiter: "|") : endkey)") }
+                if !limeendkey.isEmpty { lines.append("@limeendkey@|\(useEscapedFormat ? escapeField(limeendkey, delimiter: "|") : limeendkey)") }
                 if !spacestyle.isEmpty { lines.append("@spacestyle@|\(useEscapedFormat ? escapeField(spacestyle, delimiter: "|") : spacestyle)") }
                 if !imkeys.isEmpty { lines.append("@imkeys@|\(useEscapedFormat ? escapeField(imkeys, delimiter: "|") : imkeys)") }
                 if !imkeynames.isEmpty { lines.append("@imkeynames@|\(useEscapedFormat ? escapeField(imkeynames, delimiter: "|") : imkeynames)") }
@@ -3075,6 +3106,7 @@ final class LimeDB {
         var name = ""
         var selkey = ""
         var endkey = ""
+        var limeendkey = ""
         var spacestyle = ""
         var imkeys = ""
         var imkeynamesHeader = ""
@@ -3109,7 +3141,6 @@ final class LimeDB {
                         escapedFormat = value.lowercased() == "lime-text-v2"
                     case "@version@":
                         version = value
-                        if name.isEmpty { name = value }
                     case "@cname@":
                         name = value
                         if version.isEmpty { version = value }
@@ -3117,6 +3148,8 @@ final class LimeDB {
                         selkey = value
                     case "@endkey@":
                         endkey = value
+                    case "@limeendkey@":
+                        limeendkey = value
                     case "@spacestyle@":
                         spacestyle = value
                     case "@imkeys@":
@@ -3134,7 +3167,6 @@ final class LimeDB {
                 switch meta.key {
                 case "version":
                     version = meta.value
-                    if name.isEmpty { name = meta.value }
                 case "cname":
                     name = meta.value
                     if version.isEmpty { version = meta.value }
@@ -3144,6 +3176,8 @@ final class LimeDB {
                     selkey = meta.value
                 case "endkey":
                     endkey = meta.value
+                case "limeendkey":
+                    limeendkey = meta.value
                 case "spacestyle":
                     spacestyle = meta.value
                 default:
@@ -3222,16 +3256,24 @@ final class LimeDB {
         if !importCancelled {
             setImConfig(tableName, "source", sourceName)
             setImConfig(tableName, "version", version.isEmpty ? sourceName : version)
-            setImConfig(tableName, "name", name.isEmpty ? sourceName : name)
+            setImConfig(tableName, "name", name.isEmpty ? defaultImFullName(tableName, fallback: sourceName) : name)
             setImConfig(tableName, "amount", String(totalInserted))
             setImConfig(tableName, "import", Date().description)
             if !selkey.isEmpty { setImConfig(tableName, "selkey", selkey) }
             if !endkey.isEmpty { setImConfig(tableName, "endkey", endkey) }
+            if !limeendkey.isEmpty { setImConfig(tableName, "limeendkey", limeendkey) }
             if !spacestyle.isEmpty { setImConfig(tableName, "spacestyle", spacestyle) }
             if !imkeys.isEmpty { setImConfig(tableName, "imkeys", imkeys) }
             if !imkeynamesHeader.isEmpty { setImConfig(tableName, "imkeynames", imkeynamesHeader) }
             else if !imkeynames.isEmpty { setImConfig(tableName, "imkeynames", imkeynames.joined(separator: "|")) }
         }
+    }
+
+    private func defaultImFullName(_ tableName: String, fallback: String) -> String {
+        if let index = Self.IM_CODES.firstIndex(of: tableName), index < Self.IM_FULL_NAMES.count {
+            return Self.IM_FULL_NAMES[index]
+        }
+        return fallback
     }
 
     /// Auto-detect field delimiter from a data line (mirrors Java identifyDelimiter()).
@@ -3257,7 +3299,7 @@ final class LimeDB {
         }
 
         let lower = trimmed.lowercased()
-        for prefix in ["%version", "%cname", "%selkey", "%endkey", "%spacestyle"] where lower.hasPrefix(prefix) {
+        for prefix in ["%version", "%cname", "%selkey", "%endkey", "%limeendkey", "%spacestyle"] where lower.hasPrefix(prefix) {
             let rawValue = String(trimmed.dropFirst(prefix.count))
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let key = String(prefix.dropFirst())
@@ -3332,6 +3374,7 @@ final class LimeDB {
                 || lower.hasPrefix("%cname")
                 || lower.hasPrefix("%selkey")
                 || lower.hasPrefix("%endkey")
+                || lower.hasPrefix("%limeendkey")
                 || lower.hasPrefix("%spacestyle")))
     }
 

--- a/LimeIME-iOS/Shared/Database/LimeDB.swift
+++ b/LimeIME-iOS/Shared/Database/LimeDB.swift
@@ -608,12 +608,14 @@ final class LimeDB {
         }
 
         // Jeremy '15, 6, 1 between search clause without using related column for better sorting order.
-        var sortClause = "( exactmatch = 1 and ( score > 0 or  basescore >0) and length(word)=1) desc, exactmatch desc,"
-                       + " (length(\(codeCol)) >= \(codeLen) ) desc, "
+        var sortClause = "exactmatch desc, (length(\(codeCol)) >= \(codeLen) ) desc, "
         // Jeremy '11,6,11 separated suggestions sorting option for physical keyboard
         // iOS is always soft keyboard — mirrors Android softKeyboard=true path
         // NOTE: score sort must come BEFORE the length tiebreaker (mirrors Android LimeDB.java order)
-        if sortSuggestions { sortClause += " score desc, basescore desc, " }
+        if sortSuggestions {
+            sortClause += "( exactmatch = 1 and ( score > 0 or  basescore >0) and length(word)=1) desc, "
+            sortClause += "score desc, basescore desc, "
+        }
         sortClause += "(length(\(codeCol)) <= \(min(codeLen, 5)) )*length(\(codeCol)) desc, "
         sortClause += "_id asc"
 

--- a/LimeIME-iOS/Shared/Models/KeyLayout.swift
+++ b/LimeIME-iOS/Shared/Models/KeyLayout.swift
@@ -476,6 +476,25 @@ enum ShiftPressPolicy {
     }
 }
 
+struct ShiftTapState {
+    let shifted: Bool
+    let capsLock: Bool
+}
+
+enum ShiftTapPolicy {
+    static func nextState(shifted: Bool,
+                          capsLock: Bool,
+                          doubleTap: Bool) -> ShiftTapState {
+        if capsLock {
+            return ShiftTapState(shifted: false, capsLock: false)
+        }
+        if doubleTap {
+            return ShiftTapState(shifted: true, capsLock: true)
+        }
+        return ShiftTapState(shifted: !shifted, capsLock: false)
+    }
+}
+
 enum ShiftHoldTouchPolicy {
     static func isShiftStillHeld(activeTouchCount: Int) -> Bool {
         activeTouchCount > 1

--- a/LimeIME-iOS/Shared/Models/Mapping.swift
+++ b/LimeIME-iOS/Shared/Models/Mapping.swift
@@ -78,3 +78,36 @@ struct Mapping {
     mutating func setHasMoreRecordsMarkRecord() { recordType = RecordType.hasMoreMark }
     mutating func setPartialMatchToCodeRecord() { recordType = RecordType.partialMatchToCode }
 }
+
+enum LimeEndkeyPolicy {
+    static func isCommitKey(primaryCode: Int, endkey: String?, englishOnly: Bool) -> Bool {
+        guard !englishOnly,
+              let endkey,
+              !endkey.isEmpty,
+              let scalar = UnicodeScalar(primaryCode) else { return false }
+        return endkey.contains(String(Character(scalar)))
+    }
+
+    static func isKeyInImkeys(primaryCode: Int, imkeys: String?) -> Bool {
+        guard let imkeys,
+              !imkeys.isEmpty,
+              let scalar = UnicodeScalar(primaryCode) else { return false }
+        let key = String(Character(scalar))
+        return imkeys.contains(key) || imkeys.contains(key.lowercased())
+    }
+
+    static func defaultCommitCandidateIndex(_ suggestions: [Mapping]) -> Int {
+        guard !suggestions.isEmpty else { return -1 }
+        if let index = suggestions.firstIndex(where: isDefaultCommitCandidate) {
+            return index
+        }
+        return 0
+    }
+
+    private static func isDefaultCommitCandidate(_ candidate: Mapping) -> Bool {
+        !candidate.isComposingCodeRecord
+            && (candidate.isExactMatchToCodeRecord
+                || candidate.isPartialMatchToCodeRecord
+                || candidate.isChinesePunctuationRecord)
+    }
+}

--- a/LimeIME-iOS/Shared/Search/SearchServer.swift
+++ b/LimeIME-iOS/Shared/Search/SearchServer.swift
@@ -725,6 +725,7 @@ final class SearchServer {
     /// - Deduplicates within the emoji results using a Set<String> (mirrors Android emojiCheck HashMap).
     /// - Inserts at `insertAt` (0-based index into `list`). Clamped to list.count.
     func injectEmoji(into list: [Mapping], insertAt: Int = 3) -> [Mapping] {
+        guard SearchServer.shouldInjectEmojiCandidates(insertAt: insertAt) else { return list }
         guard !list.isEmpty else { return list }
 
         var emojiList: [Mapping] = []
@@ -771,6 +772,7 @@ final class SearchServer {
     /// Direct emoji injection by explicit word and type.
     /// Used for the English prediction path where the lookup word is known directly.
     func injectEmoji(into list: [Mapping], word: String, type: Int, insertAt: Int = 3) -> [Mapping] {
+        guard SearchServer.shouldInjectEmojiCandidates(insertAt: insertAt) else { return list }
         let candidates = emojiConvert(word, type)
         guard !candidates.isEmpty else { return list }
         let existingWords = Set(list.map { $0.word })
@@ -793,6 +795,10 @@ final class SearchServer {
             }
         }
         return index
+    }
+
+    static func shouldInjectEmojiCandidates(insertAt: Int) -> Bool {
+        insertAt > 0
     }
 
     private func isChinesePeriodOrComma(_ candidate: Mapping) -> Bool {

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/DBServerTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/DBServerTest.java
@@ -1051,6 +1051,68 @@ public class DBServerTest {
         }
     }
 
+    @Test(timeout = 30000)
+    public void backupDatabaseSkipsMissingRollbackJournal() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        DBServer dbServer = DBServer.getInstance(appContext);
+
+        if (!ensureDatabaseReady(dbServer)) {
+            fail("ERROR: Database is still on hold after waiting 10 seconds.");
+        }
+
+        File journalFile = appContext.getDatabasePath(LIME.DATABASE_JOURNAL);
+        if (journalFile.exists() && !journalFile.delete()) {
+            fail("Could not delete transient rollback journal before backup test");
+        }
+
+        File backupFile = new File(appContext.getCacheDir(),
+                "test_backup_without_journal_" + System.currentTimeMillis() + ".zip");
+        try {
+            dbServer.backupDatabase(android.net.Uri.fromFile(backupFile));
+
+            assertTrue("Backup file should be created", backupFile.exists());
+            assertTrue("Backup file should not be empty", backupFile.length() > 0);
+
+            List<String> entries = new ArrayList<>();
+            try (ZipFile zipFile = new ZipFile(backupFile)) {
+                Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
+                while (zipEntries.hasMoreElements()) {
+                    entries.add(zipEntries.nextElement().getName());
+                }
+            }
+
+            assertTrue("Backup zip should contain lime.db",
+                    entries.contains("databases/" + LIME.DATABASE_NAME));
+            assertTrue("Backup zip should contain shared preferences backup",
+                    entries.contains(LIME.SHARED_PREFS_BACKUP_NAME));
+            assertTrue("Backup zip should contain preference manifest",
+                    entries.contains(net.toload.main.hd.global.PreferenceBackupAdapter.MANIFEST_PATH));
+            assertFalse("Backup zip should not require missing rollback journal",
+                    entries.contains("databases/" + LIME.DATABASE_JOURNAL));
+        } finally {
+            if (backupFile.exists() && !backupFile.delete()) {
+                Log.w(TAG, "Failed to delete backup test file");
+            }
+        }
+    }
+
+    @Test(timeout = 30000)
+    public void backupDatabasePropagatesOutputWriteFailure() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        DBServer dbServer = DBServer.getInstance(appContext);
+
+        if (!ensureDatabaseReady(dbServer)) {
+            fail("ERROR: Database is still on hold after waiting 10 seconds.");
+        }
+
+        try {
+            dbServer.backupDatabase(null);
+            fail("backupDatabase should throw RemoteException when output Uri cannot be opened");
+        } catch (RemoteException expected) {
+            assertNotNull("backupDatabase should propagate a RemoteException", expected);
+        }
+    }
+
 
     @Test
     public void testDBServerResetMappingEdgeCases() {

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/KeyboardLayoutResourceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/KeyboardLayoutResourceTest.java
@@ -59,6 +59,16 @@ public class KeyboardLayoutResourceTest {
         assertSelectorDoesNotContainFocusedState(context, R.drawable.btn_emoji_relax_green);
     }
 
+    @Test
+    public void shiftedSymbolKeysDoNotShowChineseRootSubLabels() {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+        assertNoSubLabelsOnShiftedSymbolKeys(context, R.xml.lime_phonetic_shift);
+        assertNoSubLabelsOnShiftedSymbolKeys(context, R.xml.lime_ez_shift);
+        assertNoSubLabelsOnShiftedSymbolKeys(context, R.xml.lime_et_41_shift);
+        assertNoSubLabelsOnShiftedSymbolKeys(context, R.xml.lime_dayi_sym_shift);
+    }
+
     private void assertLetterKeyCodes(Context context, int layoutId, boolean shouldBeUppercase) {
         List<KeyDefinition> letterKeys = readLetterKeys(context, layoutId);
         assertFalse("HS layout should contain Latin letter keys", letterKeys.isEmpty());
@@ -104,6 +114,63 @@ public class KeyboardLayoutResourceTest {
             fail("Unable to read keyboard XML resource " + layoutId + ": " + e.getMessage());
         }
         return keys;
+    }
+
+    private void assertNoSubLabelsOnShiftedSymbolKeys(Context context, int layoutId) {
+        boolean sawSymbolKey = false;
+        boolean sawAlphabetSubLabel = false;
+        try {
+            XmlPullParser parser = context.getResources().getXml(layoutId);
+            int eventType;
+            while ((eventType = parser.next()) != XmlPullParser.END_DOCUMENT) {
+                if (eventType != XmlPullParser.START_TAG || !"Key".equals(parser.getName())) {
+                    continue;
+                }
+
+                String value = parser.getAttributeValue(LIME_ATTR_NS, "codes");
+                if (value == null || value.isEmpty() || value.contains(",")) {
+                    continue;
+                }
+
+                int code = Integer.parseInt(value);
+                String label = parser.getAttributeValue(LIME_ATTR_NS, "keyLabel");
+                if (label == null) {
+                    continue;
+                }
+
+                String normalizedLabel = label.replace("\\n", "\n");
+                if (isUppercaseAsciiLetter(code)) {
+                    if (normalizedLabel.contains("\n")) {
+                        sawAlphabetSubLabel = true;
+                    }
+                    continue;
+                }
+
+                if (isPrintableNonAlphabetSymbol(code)) {
+                    sawSymbolKey = true;
+                    assertFalse("Shifted symbol key should not show root sub-label in layout "
+                                    + layoutId + ": code=" + code + " label=" + label,
+                            normalizedLabel.contains("\n"));
+                }
+            }
+        } catch (Exception e) {
+            fail("Unable to read keyboard XML resource " + layoutId + ": " + e.getMessage());
+        }
+
+        assertTrue("Shifted layout should contain printable symbol keys: " + layoutId, sawSymbolKey);
+        assertTrue("Shifted alphabet roots should remain in layout: " + layoutId, sawAlphabetSubLabel);
+    }
+
+    private boolean isPrintableNonAlphabetSymbol(int code) {
+        return code >= 33 && code <= 126 && !isUppercaseAsciiLetter(code) && !isLowercaseAsciiLetter(code);
+    }
+
+    private boolean isUppercaseAsciiLetter(int code) {
+        return code >= 'A' && code <= 'Z';
+    }
+
+    private boolean isLowercaseAsciiLetter(int code) {
+        return code >= 'a' && code <= 'z';
     }
 
     private void assertVectorPaintUsesOnlyColor(Context context, int drawableId, int expectedColorId) {

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/KeyboardLayoutResourceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/KeyboardLayoutResourceTest.java
@@ -77,6 +77,22 @@ public class KeyboardLayoutResourceTest {
         assertLayoutContainsTextResource(context, R.layout.fragment_im_detail, R.string.auto_commit_summary);
     }
 
+    @Test
+    public void settingsActionLayoutsUseThemeAccentInsteadOfFixedBlue() throws Exception {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+        assertLayoutDoesNotReferenceColor(context, R.layout.fragment_db_manager, R.color.material_blue);
+        assertLayoutDoesNotReferenceColor(context, R.layout.fragment_im_list, R.color.material_blue);
+        assertLayoutDoesNotReferenceColor(context, R.layout.fragment_manage_im, R.color.material_blue);
+        assertLayoutDoesNotReferenceColor(context, R.layout.fragment_manage_related, R.color.material_blue);
+        assertLayoutDoesNotReferenceColor(context, R.layout.fragment_im_detail, R.color.material_blue);
+        assertLayoutDoesNotReferenceColor(context, R.layout.fragment_setup, R.color.material_blue);
+        assertLayoutDoesNotReferenceColor(context, R.layout.sheet_manage_im_add, R.color.material_blue);
+        assertLayoutDoesNotReferenceColor(context, R.layout.sheet_manage_im_edit, R.color.material_blue);
+        assertLayoutDoesNotReferenceColor(context, R.layout.sheet_manage_related_add, R.color.material_blue);
+        assertLayoutDoesNotReferenceColor(context, R.layout.sheet_manage_related_edit, R.color.material_blue);
+    }
+
     private void assertLayoutContainsTextResource(Context context, int layoutId, int textResId) throws Exception {
         XmlPullParser parser = context.getResources().getLayout(layoutId);
         while (parser.next() != XmlPullParser.END_DOCUMENT) {
@@ -92,6 +108,27 @@ public class KeyboardLayoutResourceTest {
         fail("Layout " + context.getResources().getResourceEntryName(layoutId)
                 + " should contain text resource "
                 + context.getResources().getResourceEntryName(textResId));
+    }
+
+    private void assertLayoutDoesNotReferenceColor(Context context, int layoutId, int colorId) throws Exception {
+        XmlPullParser parser = context.getResources().getLayout(layoutId);
+        while (parser.next() != XmlPullParser.END_DOCUMENT) {
+            if (parser.getEventType() != XmlPullParser.START_TAG) {
+                continue;
+            }
+
+            AttributeSet attrs = Xml.asAttributeSet(parser);
+            for (int i = 0; i < attrs.getAttributeCount(); i++) {
+                int value = attrs.getAttributeResourceValue(i, 0);
+                assertNotEquals("Settings layout "
+                                + context.getResources().getResourceEntryName(layoutId)
+                                + " should use theme accent instead of fixed "
+                                + context.getResources().getResourceEntryName(colorId)
+                                + " on <" + parser.getName() + "> attribute "
+                                + attrs.getAttributeName(i),
+                        colorId, value);
+            }
+        }
     }
 
     private void assertLetterKeyCodes(Context context, int layoutId, boolean shouldBeUppercase) {

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/KeyboardLayoutResourceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/KeyboardLayoutResourceTest.java
@@ -69,6 +69,31 @@ public class KeyboardLayoutResourceTest {
         assertNoSubLabelsOnShiftedSymbolKeys(context, R.xml.lime_dayi_sym_shift);
     }
 
+    @Test
+    public void array10AutoCommitRowHasTitleAndSummary() throws Exception {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+        assertLayoutContainsTextResource(context, R.layout.fragment_im_detail, R.string.auto_commit);
+        assertLayoutContainsTextResource(context, R.layout.fragment_im_detail, R.string.auto_commit_summary);
+    }
+
+    private void assertLayoutContainsTextResource(Context context, int layoutId, int textResId) throws Exception {
+        XmlPullParser parser = context.getResources().getLayout(layoutId);
+        while (parser.next() != XmlPullParser.END_DOCUMENT) {
+            if (parser.getEventType() != XmlPullParser.START_TAG) {
+                continue;
+            }
+            AttributeSet attrs = Xml.asAttributeSet(parser);
+            int value = attrs.getAttributeResourceValue(ANDROID_ATTR_NS, "text", 0);
+            if (value == textResId) {
+                return;
+            }
+        }
+        fail("Layout " + context.getResources().getResourceEntryName(layoutId)
+                + " should contain text resource "
+                + context.getResources().getResourceEntryName(textResId));
+    }
+
     private void assertLetterKeyCodes(Context context, int layoutId, boolean shouldBeUppercase) {
         List<KeyDefinition> letterKeys = readLetterKeys(context, layoutId);
         assertFalse("HS layout should contain Latin letter keys", letterKeys.isEmpty());

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
@@ -65,6 +65,23 @@ import static org.mockito.Mockito.*;
 @RunWith(AndroidJUnit4.class)
 public class LIMEServiceTest {
 
+    private void setPrivateField(Object target, String fieldName, Object value) throws Exception {
+        Class<?> currentClass = target.getClass();
+        Field field = null;
+        while (currentClass != null && field == null) {
+            try {
+                field = currentClass.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                currentClass = currentClass.getSuperclass();
+            }
+        }
+        if (field == null) {
+            throw new NoSuchFieldException(fieldName);
+        }
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
     @Before
     public void clearEmojiDisplayPositionPrefs() {
         // Tests in this class write to enable_emoji / enable_emoji_position to
@@ -122,6 +139,110 @@ public class LIMEServiceTest {
 
         assertEquals(4, LIMEService.adjustedEmojiInsertionPosition(commaCandidates, 3));
         assertEquals(4, LIMEService.adjustedEmojiInsertionPosition(periodCandidates, 3));
+    }
+
+    @Test
+    public void endkeyCommitKeyRequiresOptInComposingCandidates() {
+        assertTrue(LIMEService.isEndkeyCommitKey(';', ";/", false, 2, true));
+        assertTrue(LIMEService.isEndkeyCommitKey('/', ";/", false, 2, true));
+
+        assertFalse(LIMEService.isEndkeyCommitKey(';', "", false, 2, true));
+        assertFalse(LIMEService.isEndkeyCommitKey(';', null, false, 2, true));
+        assertFalse(LIMEService.isEndkeyCommitKey(';', ";/", true, 2, true));
+        assertFalse(LIMEService.isEndkeyCommitKey(';', ";/", false, 0, true));
+        assertFalse(LIMEService.isEndkeyCommitKey(';', ";/", false, 2, false));
+        assertFalse(LIMEService.isEndkeyCommitKey(',', ";/", false, 2, true));
+    }
+
+    @Test
+    public void endkeyCommitConsumesOptedInKeyThroughHighlightedCandidate() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        DBServer.getInstance(appContext).setImConfig("custom", "limeendkey", ";/");
+
+        LIMEService service = new LIMEService();
+        setPrivateField(service, "SearchSrv", new SearchServer(appContext));
+        setPrivateField(service, "activeIM", "custom");
+        setPrivateField(service, "mEnglishOnly", false);
+        setPrivateField(service, "mComposing", new StringBuilder("aa"));
+        setPrivateField(service, "hasCandidatesShown", true);
+
+        CandidateView candidateView = mock(CandidateView.class);
+        when(candidateView.takeSelectedSuggestion()).thenReturn(true);
+        setPrivateField(service, "mCandidateView", candidateView);
+
+        Method handleEndkeyCommit = LIMEService.class.getDeclaredMethod("handleEndkeyCommit", int.class);
+        handleEndkeyCommit.setAccessible(true);
+
+        assertTrue((Boolean) handleEndkeyCommit.invoke(service, (int) ';'));
+        verify(candidateView).takeSelectedSuggestion();
+
+        assertFalse((Boolean) handleEndkeyCommit.invoke(service, (int) ','));
+    }
+
+    @Test
+    public void endkeyCommitFallsBackToSelectedCandidateWhenHighlightedViewSelectionFails() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        InputConnection inputConnection = mock(InputConnection.class);
+        when(inputConnection.commitText(any(), anyInt())).thenReturn(true);
+
+        class TestableLIMEService extends LIMEService {
+            @Override
+            public InputConnection getCurrentInputConnection() {
+                return inputConnection;
+            }
+        }
+
+        Mapping candidate = createCandidate("aa", "日");
+        SearchServer searchServer = mock(SearchServer.class);
+        when(searchServer.getImConfig("cj4", LIME.IM_LIME_ENDKEY)).thenReturn(",.");
+        when(searchServer.getRealCodeLength(candidate, "aa")).thenReturn(2);
+        when(searchServer.getRelatedByWord("日", false)).thenReturn(new LinkedList<>());
+
+        TestableLIMEService service = new TestableLIMEService();
+        setPrivateField(service, "SearchSrv", searchServer);
+        setPrivateField(service, "activeIM", "cj4");
+        setPrivateField(service, "mEnglishOnly", false);
+        setPrivateField(service, "mComposing", new StringBuilder("aa"));
+        setPrivateField(service, "hasCandidatesShown", true);
+        setPrivateField(service, "hasMappingList", true);
+        setPrivateField(service, "selectedCandidate", candidate);
+        setPrivateField(service, "currentSoftKeyboard", "cj");
+        setPrivateField(service, "mLIMEPref", new LIMEPreferenceManager(appContext));
+
+        CandidateView candidateView = mock(CandidateView.class);
+        when(candidateView.takeSelectedSuggestion()).thenReturn(false);
+        setPrivateField(service, "mCandidateView", candidateView);
+
+        Method handleEndkeyCommit = LIMEService.class.getDeclaredMethod("handleEndkeyCommit", int.class);
+        handleEndkeyCommit.setAccessible(true);
+
+        assertTrue((Boolean) handleEndkeyCommit.invoke(service, (int) ','));
+        verify(candidateView).takeSelectedSuggestion();
+        verify(inputConnection).commitText("日", 1);
+    }
+
+    @Test
+    public void conventionalEndkeyMetadataDoesNotTriggerLimeEndkeyCommit() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        DBServer.getInstance(appContext).setImConfig("custom", "endkey", ";/");
+        DBServer.getInstance(appContext).setImConfig("custom", "limeendkey", "");
+
+        LIMEService service = new LIMEService();
+        setPrivateField(service, "SearchSrv", new SearchServer(appContext));
+        setPrivateField(service, "activeIM", "custom");
+        setPrivateField(service, "mEnglishOnly", false);
+        setPrivateField(service, "mComposing", new StringBuilder("aa"));
+        setPrivateField(service, "hasCandidatesShown", true);
+
+        CandidateView candidateView = mock(CandidateView.class);
+        when(candidateView.takeSelectedSuggestion()).thenReturn(true);
+        setPrivateField(service, "mCandidateView", candidateView);
+
+        Method handleEndkeyCommit = LIMEService.class.getDeclaredMethod("handleEndkeyCommit", int.class);
+        handleEndkeyCommit.setAccessible(true);
+
+        assertFalse((Boolean) handleEndkeyCommit.invoke(service, (int) ';'));
+        verify(candidateView, never()).takeSelectedSuggestion();
     }
 
     @Test

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
@@ -329,6 +329,28 @@ public class LIMEServiceTest {
     }
 
     @Test
+    public void emojiPanelFollowSystemUsesSystemAccentHighlight() {
+        int dynamicPurple = 0xFF6750A4;
+
+        LIMEService.EmojiPanelColors systemLight = LIMEService.emojiPanelColorsForTheme(6, false, dynamicPurple);
+        LIMEService.EmojiPanelColors systemDark = LIMEService.emojiPanelColorsForTheme(6, true, dynamicPurple);
+
+        assertEquals(0x336750A4, systemLight.categoryHighlight);
+        assertEquals(0x336750A4, systemDark.categoryHighlight);
+        assertEquals(0x22000000, LIMEService.emojiPanelColorsForTheme(0, false, dynamicPurple).categoryHighlight);
+        assertEquals(0x33FFFFFF, LIMEService.emojiPanelColorsForTheme(1, true, dynamicPurple).categoryHighlight);
+    }
+
+    @Test
+    public void keyboardThemeValuesKeepExistingFollowSystemOption() {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+        assertArrayEquals(
+                new String[]{"0", "1", "2", "3", "4", "5", "6"},
+                appContext.getResources().getStringArray(R.array.keyboard_themes_values));
+    }
+
+    @Test
     public void emojiCategoryPaginationKeepsCategoryCompact() {
         MockInputMethodServiceHelper helper = new MockInputMethodServiceHelper();
         List<List<String>> categories = new ArrayList<>();

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
@@ -414,6 +414,36 @@ public class LIMEServiceTest {
     }
 
     @Test
+    public void singleShiftTapTogglesBetweenShiftedAndUnshiftedOnly() {
+        LIMEService.ShiftTapState state = LIMEService.nextShiftTapState(false, false, false);
+        assertTrue(state.shifted);
+        assertFalse(state.capsLock);
+
+        state = LIMEService.nextShiftTapState(state.shifted, state.capsLock, false);
+        assertFalse(state.shifted);
+        assertFalse(state.capsLock);
+
+        state = LIMEService.nextShiftTapState(state.shifted, state.capsLock, false);
+        assertTrue(state.shifted);
+        assertFalse(state.capsLock);
+    }
+
+    @Test
+    public void doubleShiftTapEntersShiftLockAndSingleTapUnlocks() {
+        LIMEService.ShiftTapState state = LIMEService.nextShiftTapState(false, false, true);
+        assertTrue(state.shifted);
+        assertTrue(state.capsLock);
+
+        state = LIMEService.nextShiftTapState(state.shifted, state.capsLock, false);
+        assertFalse(state.shifted);
+        assertFalse(state.capsLock);
+
+        state = LIMEService.nextShiftTapState(true, false, true);
+        assertTrue(state.shifted);
+        assertTrue(state.capsLock);
+    }
+
+    @Test
     public void imPickerSelectionShowsSelectedImNameToast() {
         MockInputMethodServiceHelper helper = new MockInputMethodServiceHelper();
         CandidateView candidateView = helper.injectMockCandidateView();

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
@@ -142,29 +142,80 @@ public class LIMEServiceTest {
     }
 
     @Test
-    public void endkeyCommitKeyRequiresOptInComposingCandidates() {
+    public void endkeyCommitKeyRequiresOptInAndComposing() {
         assertTrue(LIMEService.isEndkeyCommitKey(';', ";/", false, 2, true));
         assertTrue(LIMEService.isEndkeyCommitKey('/', ";/", false, 2, true));
+        assertTrue(LIMEService.isEndkeyCommitKey(';', ";/", false, 2, false));
 
         assertFalse(LIMEService.isEndkeyCommitKey(';', "", false, 2, true));
         assertFalse(LIMEService.isEndkeyCommitKey(';', null, false, 2, true));
         assertFalse(LIMEService.isEndkeyCommitKey(';', ";/", true, 2, true));
-        assertFalse(LIMEService.isEndkeyCommitKey(';', ";/", false, 0, true));
-        assertFalse(LIMEService.isEndkeyCommitKey(';', ";/", false, 2, false));
+        assertTrue(LIMEService.isEndkeyCommitKey(';', ";/", false, 0, true));
         assertFalse(LIMEService.isEndkeyCommitKey(',', ";/", false, 2, true));
     }
 
     @Test
-    public void endkeyCommitConsumesOptedInKeyThroughHighlightedCandidate() throws Exception {
-        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        DBServer.getInstance(appContext).setImConfig("custom", "limeendkey", ";/");
+    public void defaultSelectedCandidatePrefersChinesePunctuationOverRawComposingCode() {
+        Mapping composing = createPlainCandidate(".", ".");
+        composing.setComposingCodeRecord();
+        Mapping punctuation = createPlainCandidate(".", "。");
+        punctuation.setChinesePunctuationSymbolRecord();
+        List<Mapping> candidates = new ArrayList<>();
+        candidates.add(composing);
+        candidates.add(punctuation);
 
-        LIMEService service = new LIMEService();
-        setPrivateField(service, "SearchSrv", new SearchServer(appContext));
+        assertEquals(1, LIMEService.defaultSelectedCandidateIndex(candidates, false));
+        assertSame(punctuation, LIMEService.defaultSelectedCandidateForSuggestions(candidates, false));
+    }
+
+    @Test
+    public void defaultSelectedCandidateDoesNotPromoteArbitrarySecondCandidate() {
+        Mapping composing = createPlainCandidate(".", ".");
+        composing.setComposingCodeRecord();
+        Mapping arbitrary = createPlainCandidate(".", "not-default");
+        List<Mapping> candidates = new ArrayList<>();
+        candidates.add(composing);
+        candidates.add(arbitrary);
+
+        assertEquals(0, LIMEService.defaultSelectedCandidateIndex(candidates, false));
+        assertSame(composing, LIMEService.defaultSelectedCandidateForSuggestions(candidates, false));
+    }
+
+    @Test
+    public void endkeyCommitAppendsOptedInImkeyBeforeCommitting() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        InputConnection inputConnection = mock(InputConnection.class);
+        when(inputConnection.commitText(any(), anyInt())).thenReturn(true);
+
+        class TestableLIMEService extends LIMEService {
+            @Override
+            public InputConnection getCurrentInputConnection() {
+                return inputConnection;
+            }
+        }
+
+        Mapping composing = createCandidate("aa;", "aa;");
+        composing.setComposingCodeRecord();
+        Mapping candidate = createCandidate("aa;", "日");
+        LinkedList<Mapping> candidates = new LinkedList<>();
+        candidates.add(composing);
+        candidates.add(candidate);
+
+        SearchServer searchServer = mock(SearchServer.class);
+        when(searchServer.getImConfig("custom", LIME.IM_LIME_ENDKEY)).thenReturn(";/");
+        when(searchServer.getImConfig("custom", "imkeys")).thenReturn("abcdefghijklmnopqrstuvwxyz;");
+        when(searchServer.getMappingByCode("aa;", true, false)).thenReturn(candidates);
+        when(searchServer.getRealCodeLength(candidate, "aa;")).thenReturn(3);
+        when(searchServer.getRelatedByWord("日", false)).thenReturn(new LinkedList<>());
+
+        TestableLIMEService service = new TestableLIMEService();
+        setPrivateField(service, "SearchSrv", searchServer);
         setPrivateField(service, "activeIM", "custom");
         setPrivateField(service, "mEnglishOnly", false);
         setPrivateField(service, "mComposing", new StringBuilder("aa"));
         setPrivateField(service, "hasCandidatesShown", true);
+        setPrivateField(service, "currentSoftKeyboard", "custom");
+        setPrivateField(service, "mLIMEPref", new LIMEPreferenceManager(appContext));
 
         CandidateView candidateView = mock(CandidateView.class);
         when(candidateView.takeSelectedSuggestion()).thenReturn(true);
@@ -174,13 +225,15 @@ public class LIMEServiceTest {
         handleEndkeyCommit.setAccessible(true);
 
         assertTrue((Boolean) handleEndkeyCommit.invoke(service, (int) ';'));
-        verify(candidateView).takeSelectedSuggestion();
+        verify(searchServer).getMappingByCode("aa;", true, false);
+        verify(candidateView, never()).takeSelectedSuggestion();
+        verify(inputConnection).commitText("日", 1);
 
         assertFalse((Boolean) handleEndkeyCommit.invoke(service, (int) ','));
     }
 
     @Test
-    public void endkeyCommitFallsBackToSelectedCandidateWhenHighlightedViewSelectionFails() throws Exception {
+    public void endkeyOutsideImkeysCommitsCurrentThenRawTriggerWhenNoTriggerMapping() throws Exception {
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         InputConnection inputConnection = mock(InputConnection.class);
         when(inputConnection.commitText(any(), anyInt())).thenReturn(true);
@@ -195,6 +248,7 @@ public class LIMEServiceTest {
         Mapping candidate = createCandidate("aa", "日");
         SearchServer searchServer = mock(SearchServer.class);
         when(searchServer.getImConfig("cj4", LIME.IM_LIME_ENDKEY)).thenReturn(",.");
+        when(searchServer.getImConfig("cj4", "imkeys")).thenReturn("abcdefghijklmnopqrstuvwxyz");
         when(searchServer.getRealCodeLength(candidate, "aa")).thenReturn(2);
         when(searchServer.getRelatedByWord("日", false)).thenReturn(new LinkedList<>());
 
@@ -219,6 +273,168 @@ public class LIMEServiceTest {
         assertTrue((Boolean) handleEndkeyCommit.invoke(service, (int) ','));
         verify(candidateView).takeSelectedSuggestion();
         verify(inputConnection).commitText("日", 1);
+        verify(inputConnection).commitText(",", 1);
+    }
+
+    @Test
+    public void endkeyOutsideImkeysCommitsCurrentThenFreshTriggerCandidate() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        InputConnection inputConnection = mock(InputConnection.class);
+        when(inputConnection.commitText(any(), anyInt())).thenReturn(true);
+
+        class TestableLIMEService extends LIMEService {
+            @Override
+            public InputConnection getCurrentInputConnection() {
+                return inputConnection;
+            }
+        }
+
+        Mapping composing = createCandidate("aa", "aa");
+        composing.setComposingCodeRecord();
+        Mapping candidate = createCandidate("aa", "昌");
+        LinkedList<Mapping> candidates = new LinkedList<>();
+        candidates.add(composing);
+        candidates.add(candidate);
+        Mapping commaComposing = createCandidate(",", ",");
+        commaComposing.setComposingCodeRecord();
+        Mapping commaCandidate = createCandidate(",", "，");
+        LinkedList<Mapping> commaCandidates = new LinkedList<>();
+        commaCandidates.add(commaComposing);
+        commaCandidates.add(commaCandidate);
+
+        SearchServer searchServer = mock(SearchServer.class);
+        when(searchServer.getImConfig("cj", LIME.IM_LIME_ENDKEY)).thenReturn(",.");
+        when(searchServer.getImConfig("cj", "imkeys")).thenReturn("abcdefghijklmnopqrstuvwxyz");
+        when(searchServer.getMappingByCode("aa", true, false)).thenReturn(candidates);
+        when(searchServer.getMappingByCode(",", true, false)).thenReturn(commaCandidates);
+        when(searchServer.getRealCodeLength(candidate, "aa")).thenReturn(2);
+        when(searchServer.getRealCodeLength(commaCandidate, ",")).thenReturn(1);
+        when(searchServer.getRelatedByWord("昌", false)).thenReturn(new LinkedList<>());
+        when(searchServer.getRelatedByWord("，", false)).thenReturn(new LinkedList<>());
+
+        TestableLIMEService service = new TestableLIMEService();
+        setPrivateField(service, "SearchSrv", searchServer);
+        setPrivateField(service, "activeIM", "cj");
+        setPrivateField(service, "mEnglishOnly", false);
+        setPrivateField(service, "mComposing", new StringBuilder("aa"));
+        setPrivateField(service, "hasCandidatesShown", false);
+        setPrivateField(service, "currentSoftKeyboard", "cj");
+        setPrivateField(service, "mLIMEPref", new LIMEPreferenceManager(appContext));
+
+        CandidateView candidateView = mock(CandidateView.class);
+        when(candidateView.takeSelectedSuggestion()).thenReturn(false);
+        setPrivateField(service, "mCandidateView", candidateView);
+
+        Method handleEndkeyCommit = LIMEService.class.getDeclaredMethod("handleEndkeyCommit", int.class);
+        handleEndkeyCommit.setAccessible(true);
+
+        assertTrue((Boolean) handleEndkeyCommit.invoke(service, (int) ','));
+        verify(searchServer).getMappingByCode("aa", true, false);
+        verify(searchServer).getMappingByCode(",", true, false);
+        org.mockito.InOrder inOrder = inOrder(inputConnection);
+        inOrder.verify(inputConnection).commitText("昌", 1);
+        inOrder.verify(inputConnection).commitText("，", 1);
+    }
+
+    @Test
+    public void endkeyCommitIgnoresStalePrefixCandidateAndResolvesCurrentComposing() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        InputConnection inputConnection = mock(InputConnection.class);
+        when(inputConnection.commitText(any(), anyInt())).thenReturn(true);
+
+        class TestableLIMEService extends LIMEService {
+            @Override
+            public InputConnection getCurrentInputConnection() {
+                return inputConnection;
+            }
+        }
+
+        Mapping staleCandidate = createCandidate("a", "日");
+        Mapping composing = createCandidate("aa", "aa");
+        composing.setComposingCodeRecord();
+        Mapping currentCandidate = createCandidate("aa", "昌");
+        LinkedList<Mapping> candidates = new LinkedList<>();
+        candidates.add(composing);
+        candidates.add(currentCandidate);
+
+        SearchServer searchServer = mock(SearchServer.class);
+        when(searchServer.getImConfig("cj", LIME.IM_LIME_ENDKEY)).thenReturn(",.");
+        when(searchServer.getMappingByCode("aa", true, false)).thenReturn(candidates);
+        when(searchServer.getRealCodeLength(currentCandidate, "aa")).thenReturn(2);
+        when(searchServer.getRelatedByWord("昌", false)).thenReturn(new LinkedList<>());
+
+        TestableLIMEService service = new TestableLIMEService();
+        setPrivateField(service, "SearchSrv", searchServer);
+        setPrivateField(service, "activeIM", "cj");
+        setPrivateField(service, "mEnglishOnly", false);
+        setPrivateField(service, "mComposing", new StringBuilder("aa"));
+        setPrivateField(service, "hasCandidatesShown", true);
+        setPrivateField(service, "hasMappingList", true);
+        setPrivateField(service, "selectedCandidate", staleCandidate);
+        setPrivateField(service, "currentSoftKeyboard", "cj");
+        setPrivateField(service, "mLIMEPref", new LIMEPreferenceManager(appContext));
+
+        CandidateView candidateView = mock(CandidateView.class);
+        when(candidateView.takeSelectedSuggestion()).thenReturn(false);
+        setPrivateField(service, "mCandidateView", candidateView);
+
+        Method handleEndkeyCommit = LIMEService.class.getDeclaredMethod("handleEndkeyCommit", int.class);
+        handleEndkeyCommit.setAccessible(true);
+
+        assertTrue((Boolean) handleEndkeyCommit.invoke(service, (int) ','));
+        verify(searchServer).getMappingByCode("aa", true, false);
+        verify(inputConnection).commitText("昌", 1);
+    }
+
+    @Test
+    public void endkeyCommitDoesNotPickHighlightedStalePrefixCandidate() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        InputConnection inputConnection = mock(InputConnection.class);
+        when(inputConnection.commitText(any(), anyInt())).thenReturn(true);
+
+        class TestableLIMEService extends LIMEService {
+            @Override
+            public InputConnection getCurrentInputConnection() {
+                return inputConnection;
+            }
+        }
+
+        Mapping staleCandidate = createCandidate("a", "日");
+        Mapping composing = createCandidate("aa", "aa");
+        composing.setComposingCodeRecord();
+        Mapping currentCandidate = createCandidate("aa", "昌");
+        LinkedList<Mapping> candidates = new LinkedList<>();
+        candidates.add(composing);
+        candidates.add(currentCandidate);
+
+        SearchServer searchServer = mock(SearchServer.class);
+        when(searchServer.getImConfig("cj", LIME.IM_LIME_ENDKEY)).thenReturn(",.");
+        when(searchServer.getMappingByCode("aa", true, false)).thenReturn(candidates);
+        when(searchServer.getRealCodeLength(currentCandidate, "aa")).thenReturn(2);
+        when(searchServer.getRelatedByWord("昌", false)).thenReturn(new LinkedList<>());
+
+        TestableLIMEService service = new TestableLIMEService();
+        setPrivateField(service, "SearchSrv", searchServer);
+        setPrivateField(service, "activeIM", "cj");
+        setPrivateField(service, "mEnglishOnly", false);
+        setPrivateField(service, "mComposing", new StringBuilder("aa"));
+        setPrivateField(service, "hasCandidatesShown", true);
+        setPrivateField(service, "hasMappingList", true);
+        setPrivateField(service, "selectedCandidate", staleCandidate);
+        setPrivateField(service, "currentSoftKeyboard", "cj");
+        setPrivateField(service, "mLIMEPref", new LIMEPreferenceManager(appContext));
+
+        CandidateView candidateView = mock(CandidateView.class);
+        when(candidateView.takeSelectedSuggestion()).thenReturn(true);
+        setPrivateField(service, "mCandidateView", candidateView);
+
+        Method handleEndkeyCommit = LIMEService.class.getDeclaredMethod("handleEndkeyCommit", int.class);
+        handleEndkeyCommit.setAccessible(true);
+
+        assertTrue((Boolean) handleEndkeyCommit.invoke(service, (int) ','));
+        verify(candidateView, never()).takeSelectedSuggestion();
+        verify(searchServer).getMappingByCode("aa", true, false);
+        verify(inputConnection).commitText("昌", 1);
     }
 
     @Test
@@ -511,6 +727,13 @@ public class LIMEServiceTest {
         mapping.setCode(code);
         mapping.setWord(word);
         mapping.setExactMatchToCodeRecord();
+        return mapping;
+    }
+
+    private static Mapping createPlainCandidate(String code, String word) {
+        Mapping mapping = new Mapping();
+        mapping.setCode(code);
+        mapping.setWord(word);
         return mapping;
     }
 

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LimeDBTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LimeDBTest.java
@@ -146,6 +146,47 @@ public class LimeDBTest {
     }
 
     @Test
+    public void cinImportPreservesDuplicateCodeOrderWhenSelectionSortDisabled() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LimeDB limeDB = new LimeDB(appContext);
+        assertTrue(initializeDatabase(limeDB));
+
+        boolean oldPhysicalSort = PreferenceManager.getDefaultSharedPreferences(appContext)
+                .getBoolean("physical_keyboard_sort", true);
+        File fixture = new File(appContext.getCacheDir(), "issue91_order.cin");
+        try {
+            PreferenceManager.getDefaultSharedPreferences(appContext)
+                    .edit().putBoolean("physical_keyboard_sort", false).commit();
+            writeUtf8(fixture,
+                    "%ename issue91\n" +
+                    "%cname Issue91\n" +
+                    "%chardef begin\n" +
+                    "vmi \u72C0\n" +
+                    "vmi \u7ED2\n" +
+                    "vmi \u6215\n" +
+                    "%chardef end\n");
+
+            limeDB.setTableName(LIME.DB_TABLE_CUSTOM);
+            limeDB.clearTable(LIME.DB_TABLE_CUSTOM);
+            limeDB.setFilename(fixture);
+            limeDB.importTxtTable(LIME.DB_TABLE_CUSTOM, null);
+            waitForImportThread(limeDB);
+
+            List<Mapping> mappings = limeDB.getMappingByCode("vmi", false, true);
+            assertTrue("Expected at least three duplicate-code mappings", mappings.size() >= 3);
+            assertEquals("\u72C0", mappings.get(0).getWord());
+            assertEquals("\u7ED2", mappings.get(1).getWord());
+            assertEquals("\u6215", mappings.get(2).getWord());
+        } finally {
+            PreferenceManager.getDefaultSharedPreferences(appContext)
+                    .edit().putBoolean("physical_keyboard_sort", oldPhysicalSort).commit();
+            if (fixture.exists() && !fixture.delete()) {
+                Log.w(TAG, "Failed to delete issue91 fixture");
+            }
+        }
+    }
+
+    @Test
     public void testLimeDBInitialization() {
         // Test LimeDB initialization
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LimeDBTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LimeDBTest.java
@@ -222,6 +222,118 @@ public class LimeDBTest {
         }
     }
 
+    @Test(timeout = 15000)
+    public void cinImportPersistsEndkeyMetadata() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LimeDB limeDB = new LimeDB(appContext);
+        assertTrue(initializeDatabase(limeDB));
+
+        File fixture = new File(appContext.getCacheDir(), "issue96_endkey.cin");
+        try {
+            writeUtf8(fixture,
+                    "%version Endkey Test\n" +
+                    "%cname Endkey Table\n" +
+                    "%endkey ;/\n" +
+                    "%chardef begin\n" +
+                    "aa \u6E2C\n" +
+                    "%chardef end\n");
+
+            limeDB.setFilename(fixture);
+            limeDB.importTxtTable(LIME.DB_TABLE_CUSTOM, null);
+            waitForImportThread(limeDB);
+
+            assertEquals(";/", limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "endkey"));
+        } finally {
+            if (fixture.exists() && !fixture.delete()) {
+                Log.w(TAG, "Failed to delete issue96 cin fixture");
+            }
+        }
+    }
+
+    @Test(timeout = 15000)
+    public void limeImportPersistsEndkeyMetadata() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LimeDB limeDB = new LimeDB(appContext);
+        assertTrue(initializeDatabase(limeDB));
+
+        File fixture = new File(appContext.getCacheDir(), "issue96_endkey.lime");
+        try {
+            writeUtf8(fixture,
+                    "@version@|Endkey Test\n" +
+                    "@cname@|Endkey Table\n" +
+                    "@endkey@ |;/\n" +
+                    "aa|\u6E2C\n");
+
+            limeDB.setFilename(fixture);
+            limeDB.importTxtTable(LIME.DB_TABLE_CUSTOM, null);
+            waitForImportThread(limeDB);
+
+            assertEquals(";/", limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "endkey"));
+        } finally {
+            if (fixture.exists() && !fixture.delete()) {
+                Log.w(TAG, "Failed to delete issue96 lime fixture");
+            }
+        }
+    }
+
+    @Test(timeout = 15000)
+    public void cinImportPersistsLimeEndkeyMetadata() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LimeDB limeDB = new LimeDB(appContext);
+        assertTrue(initializeDatabase(limeDB));
+
+        File fixture = new File(appContext.getCacheDir(), "issue96_limeendkey.cin");
+        try {
+            writeUtf8(fixture,
+                    "%version Lime Endkey Test\n" +
+                    "%cname Lime Endkey Table\n" +
+                    "%endkey abcdefghijklmnopqrstuvwxyz\n" +
+                    "%limeendkey ;/\n" +
+                    "%chardef begin\n" +
+                    "aa \u6E2C\n" +
+                    "%chardef end\n");
+
+            limeDB.setFilename(fixture);
+            limeDB.importTxtTable(LIME.DB_TABLE_CUSTOM, null);
+            waitForImportThread(limeDB);
+
+            assertEquals("abcdefghijklmnopqrstuvwxyz", limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "endkey"));
+            assertEquals(";/", limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "limeendkey"));
+        } finally {
+            if (fixture.exists() && !fixture.delete()) {
+                Log.w(TAG, "Failed to delete issue96 limeendkey cin fixture");
+            }
+        }
+    }
+
+    @Test(timeout = 15000)
+    public void limeImportPersistsLimeEndkeyMetadata() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LimeDB limeDB = new LimeDB(appContext);
+        assertTrue(initializeDatabase(limeDB));
+
+        File fixture = new File(appContext.getCacheDir(), "issue96_limeendkey.lime");
+        try {
+            writeUtf8(fixture,
+                    "@version@|Lime Endkey Test\n" +
+                    "@cname@|Lime Endkey Table\n" +
+                    "@endkey@|abcdefghijklmnopqrstuvwxyz\n" +
+                    "@limeendkey@|;/\n" +
+                    "aa|\u6E2C\n");
+
+            limeDB.setFilename(fixture);
+            limeDB.importTxtTable(LIME.DB_TABLE_CUSTOM, null);
+            waitForImportThread(limeDB);
+
+            assertEquals("abcdefghijklmnopqrstuvwxyz", limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "endkey"));
+            assertEquals(";/", limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "limeendkey"));
+        } finally {
+            if (fixture.exists() && !fixture.delete()) {
+                Log.w(TAG, "Failed to delete issue96 limeendkey lime fixture");
+            }
+        }
+    }
+
     @Test
     public void testLimeDBInitialization() {
         // Test LimeDB initialization

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LimeDBTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LimeDBTest.java
@@ -200,8 +200,8 @@ public class LimeDBTest {
                     "# Comment between metadata\n" +
                     "@cname@ |\u884C\u521710\u6E2C\u8A66\n" +
                     "# Comment before mappings\n" +
-                    ",|\uFF0C\n" +
-                    ".|\u3002\n");
+                    ",\t\uFF0C\n" +
+                    ".\t\u3002\n");
 
             limeDB.setTableName(LIME.DB_TABLE_CUSTOM);
             limeDB.clearTable(LIME.DB_TABLE_CUSTOM);
@@ -805,6 +805,41 @@ public class LimeDBTest {
         if (imConfigByCode != null) {
             assertTrue("IM list by code should be accessible", true);
         }
+    }
+
+    @Test(timeout = 5000)
+    public void testGetImConfigListNameFallsBackToBuiltInFullNameForLegacyRows() {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LimeDB limeDB = new LimeDB(appContext);
+
+        if (!initializeDatabase(limeDB)) {
+            fail("ERROR: Cannot initialize database connection. Database may be on hold from a previous operation. Test cannot proceed.");
+        }
+
+        limeDB.resetImConfig(LIME.DB_TABLE_CUSTOM);
+        limeDB.setIMConfigKeyboard(LIME.DB_TABLE_CUSTOM, "Legacy Keyboard", "lime");
+
+        List<ImConfig> configs = limeDB.getImConfigList(LIME.DB_TABLE_CUSTOM, LIME.IM_FULL_NAME);
+        assertFalse("Legacy IM row should still be surfaced for the name list", configs.isEmpty());
+        assertEquals("自建輸入法", configs.get(0).getDesc());
+    }
+
+    @Test(timeout = 5000)
+    public void testGetImConfigListNameFallsBackToBuiltInFullNameWhenDescIsEmpty() {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LimeDB limeDB = new LimeDB(appContext);
+
+        if (!initializeDatabase(limeDB)) {
+            fail("ERROR: Cannot initialize database connection. Database may be on hold from a previous operation. Test cannot proceed.");
+        }
+
+        limeDB.resetImConfig(LIME.DB_TABLE_ARRAY10);
+        limeDB.setImConfig(LIME.DB_TABLE_ARRAY10, "source", "array10a-v2023-1.0-20260517.lime");
+        limeDB.setImConfig(LIME.DB_TABLE_ARRAY10, LIME.IM_FULL_NAME, "");
+
+        List<ImConfig> configs = limeDB.getImConfigList(LIME.DB_TABLE_ARRAY10, LIME.IM_FULL_NAME);
+        assertFalse("IM name row should be surfaced for the name list", configs.isEmpty());
+        assertEquals("行列10輸入法", configs.get(0).getDesc());
     }
 
     @Test(timeout = 5000) // 5 second timeout to prevent infinite hang
@@ -5415,6 +5450,8 @@ public class LimeDBTest {
 
             assertEquals("My Android Table 2026.05",
                     limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "version"));
+            assertEquals("自建輸入法",
+                    limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "name"));
             assertEquals("123456789",
                     limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "selkey"));
             assertEquals("2",
@@ -5521,6 +5558,8 @@ public class LimeDBTest {
 
             assertEquals("2",
                     limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "amount"));
+            assertEquals("自建輸入法",
+                    limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "name"));
             assertEquals(0,
                     limeDB.countRecords(LIME.DB_TABLE_CUSTOM, "code = ?", new String[]{"#"}));
             assertEquals(0,

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LimeDBTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LimeDBTest.java
@@ -186,6 +186,42 @@ public class LimeDBTest {
         }
     }
 
+    @Test(timeout = 15000)
+    public void limeImportSkipsHashCommentsAndPersistsCnameVersion() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LimeDB limeDB = new LimeDB(appContext);
+        assertTrue(initializeDatabase(limeDB));
+
+        File fixture = new File(appContext.getCacheDir(), "issue93_array10.lime");
+        try {
+            writeUtf8(fixture,
+                    "# Array10 comment before metadata\n" +
+                    "@version@ |\u884C\u521710\u6E2C\u8A66\u7248\n" +
+                    "# Comment between metadata\n" +
+                    "@cname@ |\u884C\u521710\u6E2C\u8A66\n" +
+                    "# Comment before mappings\n" +
+                    ",|\uFF0C\n" +
+                    ".|\u3002\n");
+
+            limeDB.setTableName(LIME.DB_TABLE_CUSTOM);
+            limeDB.clearTable(LIME.DB_TABLE_CUSTOM);
+            limeDB.setFilename(fixture);
+            limeDB.importTxtTable(LIME.DB_TABLE_CUSTOM, null);
+            waitForImportThread(limeDB);
+
+            assertEquals("\u884C\u521710\u6E2C\u8A66",
+                    limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "name"));
+            assertEquals("\u884C\u521710\u6E2C\u8A66\u7248",
+                    limeDB.getImConfig(LIME.DB_TABLE_CUSTOM, "version"));
+            assertEquals("\uFF0C", limeDB.getMappingByCode(",", false, true).get(0).getWord());
+            assertEquals("\u3002", limeDB.getMappingByCode(".", false, true).get(0).getWord());
+        } finally {
+            if (fixture.exists() && !fixture.delete()) {
+                Log.w(TAG, "Failed to delete issue93 fixture");
+            }
+        }
+    }
+
     @Test
     public void testLimeDBInitialization() {
         // Test LimeDB initialization

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/ManageImControllerTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/ManageImControllerTest.java
@@ -109,4 +109,18 @@ public class ManageImControllerTest {
         assertTrue(controller.updateIMMetadataField("custom", "version", editedVersion));
         assertEquals(editedVersion, dbServer.getImConfig("custom", "version"));
     }
+
+    @Test
+    public void updateIMMetadataField_allowsLimeEndkey() {
+        android.content.Context context = ApplicationProvider.getApplicationContext();
+        DBServer dbServer = DBServer.getInstance(context);
+        SearchServer searchServer = new SearchServer(context);
+        ManageImController controller = new ManageImController(searchServer);
+
+        assertTrue(controller.updateIMMetadataField("custom", "limeendkey", " ;/ "));
+        assertEquals(";/", dbServer.getImConfig("custom", "limeendkey"));
+
+        assertTrue(controller.updateIMMetadataField("custom", "limeendkey", " "));
+        assertEquals("", dbServer.getImConfig("custom", "limeendkey"));
+    }
 }

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/DBServer.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/DBServer.java
@@ -409,7 +409,8 @@ public class  DBServer {
 
         // create backup file list.
         String limeDBPath = ctx.getDatabasePath(LIME.DATABASE_NAME).getAbsolutePath();
-        String limeDBJournalPath = ctx.getDatabasePath(LIME.DATABASE_JOURNAL).getAbsolutePath();
+        File limeDBJournalFile = ctx.getDatabasePath(LIME.DATABASE_JOURNAL);
+        String limeDBJournalPath = limeDBJournalFile.getAbsolutePath();
         if (limeDBPath.startsWith(dataDir)) {
             limeDBPath = limeDBPath.substring(dataDir.length());
         }
@@ -420,7 +421,9 @@ public class  DBServer {
         //backupFileList.add(LIME.DATABASE_RELATIVE_FOLDER + File.separator + LIME.DATABASE_NAME);
         //backupFileList.add(LIME.DATABASE_RELATIVE_FOLDER + File.separator + LIME.DATABASE_JOURNAL);
         backupFileList.add(limeDBPath);
-        backupFileList.add(limeDBJournalPath);
+        if (limeDBJournalFile.exists()) {
+            backupFileList.add(limeDBJournalPath);
+        }
         backupFileList.add(LIME.SHARED_PREFS_BACKUP_NAME);
         backupFileList.add(PreferenceBackupAdapter.MANIFEST_PATH);
 
@@ -433,23 +436,33 @@ public class  DBServer {
         if(tempZip.exists() && !tempZip.delete()) Log.w(TAG, "Failed to delete existing temp zip file");
         OutputStream outputStream = null;
         FileInputStream inputStream = null;
+        boolean backupSucceeded = false;
 
         try {
             LIMEUtilities.zip(tempZip.getAbsolutePath(), backupFileList, dataDir , true);
+            if (!tempZip.exists() || tempZip.length() == 0) {
+                throw new IOException("Backup archive was not created or is empty");
+            }
             //saveFileToDownloads(tempZip);
             // Copy temp zip to the User selected URI
             inputStream = new FileInputStream(tempZip);
             outputStream = appContext.getContentResolver().openOutputStream(uri);
+            if (outputStream == null) {
+                throw new FileNotFoundException("Could not open backup output stream for URI: " + uri);
+            }
 
             byte[] buffer = new byte[LIME.BUFFER_SIZE_4KB];
             int bytesRead;
             while ((bytesRead = inputStream.read(buffer)) != -1) {
                 outputStream.write(buffer, 0, bytesRead);
             }
+            outputStream.flush();
+            backupSucceeded = true;
 
         } catch (Exception e) {
             Log.e(TAG, "Error backing up database", e);
             showNotificationMessage(appContext.getText(R.string.l3_initial_backup_error) + "");
+            throw new RemoteException("Error backing up database: " + e.getMessage());
         } finally {
             try {
                 if (outputStream != null) outputStream.close();
@@ -459,25 +472,18 @@ public class  DBServer {
             }
             // Reopen DB
             if (datasource != null) {
+                datasource.unHoldDBConnection(); //Jeremy '15,5,23
                 datasource.openDBConnection(true);
             }
             if (fileSharedPrefsBackup.exists() && !fileSharedPrefsBackup.delete()) Log.w(TAG, "Failed to delete shared preferences backup file in finally");
             if (filePreferenceManifest.exists() && !filePreferenceManifest.delete()) Log.w(TAG, "Failed to delete preference manifest in finally");
             if (tempZip.exists() && !tempZip.delete()) Log.w(TAG, "Failed to delete temp zip file in finally");
 
-            showNotificationMessage(appContext.getText(R.string.l3_initial_backup_end) + "");
+            if (backupSucceeded) {
+                showNotificationMessage(appContext.getText(R.string.l3_initial_backup_end) + "");
+            }
         }
 
-
-
-        // backup finished.  unhold the database connection and false reopen the database.
-        datasource.unHoldDBConnection(); //Jeremy '15,5,23
-        //mLIMEPref.holdDatabaseConnection(false);
-        datasource.openDBConnection(true);
-
-        //cleanup the shared preference backup file.
-        if(fileSharedPrefsBackup.exists() && !fileSharedPrefsBackup.delete()) Log.w(TAG, "Failed to delete shared preferences backup file at end");
-        if(filePreferenceManifest.exists() && !filePreferenceManifest.delete()) Log.w(TAG, "Failed to delete preference manifest at end");
 
 
     }

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
@@ -67,6 +67,7 @@ import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewConfiguration;
 import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.CompletionInfo;
@@ -164,6 +165,7 @@ public class LIMEService extends InputMethodService
     private boolean mPredictionOn;
     private boolean mCompletionOn;
     private boolean mCapsLock;
+    private long mLastShiftTime = -1;
     private boolean mAutoCap;
     private boolean mHasShift;
 
@@ -4564,29 +4566,77 @@ public class LIMEService extends InputMethodService
             return;
         }
 
+        boolean doubleTap = isShiftDoubleTap();
         if (mKeyboardSwitcher.isAlphabetMode()) {
-            // Alphabet keyboard
-            checkToggleCapsLock();
-            mInputView.setShifted(mCapsLock || !mInputView.isShifted());
-            mHasShift = mCapsLock || !mInputView.isShifted();
-            if (mHasShift) {
-                mKeyboardSwitcher.toggleShift();
-            }
+            ShiftTapState nextState = nextShiftTapState(mInputView.isShifted(), mCapsLock, doubleTap);
+            applyAlphabetShiftState(nextState);
         } else {
-            if (mCapsLock) {
-                toggleCapsLock();
-                mHasShift = false;
-            } else if (mHasShift) {
-                toggleCapsLock();
-                mHasShift = true;
-            } else {
-                mKeyboardSwitcher.toggleShift();
-                mHasShift = mKeyboardSwitcher.isShifted();
-
-            }
+            ShiftTapState nextState = nextShiftTapState(mHasShift, mCapsLock, doubleTap);
+            applyImShiftState(nextState);
         }
     }
 
+    private boolean isShiftDoubleTap() {
+        long now = SystemClock.uptimeMillis();
+        boolean doubleTap = mLastShiftTime > 0
+                && now - mLastShiftTime <= ViewConfiguration.getDoubleTapTimeout();
+        mLastShiftTime = now;
+        return doubleTap;
+    }
+
+    static ShiftTapState nextShiftTapState(boolean shifted, boolean capsLock, boolean doubleTap) {
+        if (capsLock) {
+            return new ShiftTapState(false, false);
+        }
+        if (doubleTap) {
+            return new ShiftTapState(true, true);
+        }
+        return new ShiftTapState(!shifted, false);
+    }
+
+    static final class ShiftTapState {
+        final boolean shifted;
+        final boolean capsLock;
+
+        ShiftTapState(boolean shifted, boolean capsLock) {
+            this.shifted = shifted;
+            this.capsLock = capsLock;
+        }
+    }
+
+    private void applyAlphabetShiftState(ShiftTapState state) {
+        setCapsLockState(state.capsLock);
+        mInputView.setShifted(state.shifted);
+        mHasShift = state.shifted;
+        if (state.shifted && !mKeyboardSwitcher.isShifted()) {
+            mKeyboardSwitcher.toggleShift();
+        } else if (!state.shifted && mKeyboardSwitcher.isShifted()) {
+            mKeyboardSwitcher.toggleShift();
+        }
+    }
+
+    private void applyImShiftState(ShiftTapState state) {
+        setCapsLockState(state.capsLock);
+        if (state.shifted && !mKeyboardSwitcher.isShifted()) {
+            mKeyboardSwitcher.toggleShift();
+        } else if (!state.shifted && mKeyboardSwitcher.isShifted()) {
+            mKeyboardSwitcher.toggleShift();
+        }
+        mHasShift = state.shifted;
+    }
+
+    private void setCapsLockState(boolean capsLock) {
+        if (mCapsLock == capsLock) {
+            if (mInputView != null && mInputView.getKeyboard() instanceof LIMEKeyboard) {
+                ((LIMEKeyboard) mInputView.getKeyboard()).setShiftLocked(capsLock);
+            }
+            return;
+        }
+        mCapsLock = capsLock;
+        if (mInputView != null && mInputView.getKeyboard() instanceof LIMEKeyboard) {
+            ((LIMEKeyboard) mInputView.getKeyboard()).setShiftLocked(mCapsLock);
+        }
+    }
 
     /**
      * Integrated all soft keyboards switching in this function.

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
@@ -88,6 +88,7 @@ import net.toload.main.hd.data.Mapping;
 import net.toload.main.hd.global.LIME;
 import net.toload.main.hd.global.LIMEPreferenceManager;
 import net.toload.main.hd.global.LIMEUtilities;
+import net.toload.main.hd.global.SystemAccentColor;
 import net.toload.main.hd.keyboard.LIMEBaseKeyboard;
 import net.toload.main.hd.keyboard.LIMEKeyboard;
 import net.toload.main.hd.keyboard.LIMEKeyboardBaseView;
@@ -104,6 +105,8 @@ import net.toload.main.hd.voice.VoiceInputMode;
 import net.toload.main.hd.voice.VoiceInputRoute;
 import net.toload.main.hd.voice.VoicePermissionHelper;
 import net.toload.main.hd.voice.VoicePermissionState;
+
+import com.google.android.material.color.DynamicColors;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -4897,6 +4900,7 @@ public class LIMEService extends InputMethodService
         }
         if (mCandidateView != mCandidateViewInInputView)
             mCandidateView = mCandidateViewInInputView;
+        applyFollowSystemAccentColors();
 
 
         // Check if mKeyboardSwitcher == null
@@ -6402,8 +6406,43 @@ public class LIMEService extends InputMethodService
         return mKeyboardThemeIndex == 6;
     }
 
+    private void applyFollowSystemAccentColors() {
+        if (!isFollowSystemTheme()) return;
+
+        int accent = resolveSystemAccentColor(0);
+        if (!isUsableAccentColor(accent)) return;
+
+        boolean darkTheme = isEffectiveDarkTheme();
+        if (mInputView != null) {
+            mInputView.applyFollowSystemAccentColor(accent, darkTheme);
+        }
+        if (mCandidateViewInInputView != null) {
+            mCandidateViewInInputView.applyFollowSystemAccentColor(accent, darkTheme);
+        }
+        if (mCandidateView != null && mCandidateView != mCandidateViewInInputView) {
+            mCandidateView.applyFollowSystemAccentColor(accent, darkTheme);
+        }
+    }
+
     private int resolveSystemAccentColor(int fallbackColor) {
-        int resolved = resolveThemeColor(com.google.android.material.R.attr.colorPrimary, 0);
+        int systemSeed = SystemAccentColor.resolveSeedColor(this, 0);
+        if (isUsableAccentColor(systemSeed)) {
+            return systemSeed;
+        }
+
+        Context dynamicColorContext = DynamicColors.wrapContextIfAvailable(
+                this,
+                SystemAccentColor.dynamicColorOptions(this));
+        int resolved = resolveThemeColor(dynamicColorContext, com.google.android.material.R.attr.colorPrimary, 0);
+        if (!isUsableAccentColor(resolved)) {
+            resolved = resolveThemeColor(dynamicColorContext, com.google.android.material.R.attr.colorSecondary, 0);
+        }
+        if (!isUsableAccentColor(resolved)) {
+            resolved = resolveThemeColor(dynamicColorContext, android.R.attr.colorAccent, 0);
+        }
+        if (!isUsableAccentColor(resolved)) {
+            resolved = resolveThemeColor(com.google.android.material.R.attr.colorPrimary, 0);
+        }
         if (!isUsableAccentColor(resolved)) {
             resolved = resolveThemeColor(com.google.android.material.R.attr.colorSecondary, 0);
         }
@@ -6414,10 +6453,14 @@ public class LIMEService extends InputMethodService
     }
 
     private int resolveThemeColor(int attr, int fallbackColor) {
+        return resolveThemeColor(this, attr, fallbackColor);
+    }
+
+    private int resolveThemeColor(Context context, int attr, int fallbackColor) {
         TypedValue value = new TypedValue();
-        if (getTheme().resolveAttribute(attr, value, true)) {
+        if (context.getTheme().resolveAttribute(attr, value, true)) {
             if (value.resourceId != 0) {
-                return ContextCompat.getColor(this, value.resourceId);
+                return ContextCompat.getColor(context, value.resourceId);
             }
             if (value.type >= TypedValue.TYPE_FIRST_COLOR_INT
                     && value.type <= TypedValue.TYPE_LAST_COLOR_INT) {

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
@@ -122,6 +122,7 @@ public class LIMEService extends InputMethodService
 
     private static final boolean DEBUG = false;
     private static final String TAG = "LIMEService";
+    private static final String IMKEYS_CONFIG = "imkeys";
 
     private static Thread queryThread; // queryThread for no-blocking I/O  Jeremy '15,6,1
 
@@ -2125,30 +2126,47 @@ public class LIMEService extends InputMethodService
     static boolean isEndkeyCommitKey(int primaryCode, String endkey, boolean englishOnly,
                                      int composingLength, boolean candidatesShown) {
         return !englishOnly
-                && composingLength > 0
-                && candidatesShown
                 && endkey != null
                 && endkey.indexOf((char) primaryCode) >= 0;
     }
 
     private boolean handleEndkeyCommit(int primaryCode) {
         String endkey = "";
+        String imkeys = "";
         if (SearchSrv != null && activeIM != null) {
             endkey = SearchSrv.getImConfig(activeIM, LIME.IM_LIME_ENDKEY);
+            imkeys = SearchSrv.getImConfig(activeIM, IMKEYS_CONFIG);
         }
         if (!isEndkeyCommitKey(primaryCode, endkey, mEnglishOnly, mComposing.length(), hasCandidatesShown)) {
             return false;
         }
 
-        if (pickHighlightedCandidate()) {
+        if (isKeyInImkeys(primaryCode, imkeys)) {
+            return commitComposingWithAppendedEndkey(primaryCode);
+        }
+
+        if (mComposing.length() > 0 && !commitCurrentEndkeyComposing()) {
+            return false;
+        }
+
+        return commitFreshEndkeyOrRaw(primaryCode);
+    }
+
+    private boolean commitCurrentEndkeyComposing() {
+        if (hasCurrentEndkeySelectedCandidate() && pickHighlightedCandidate()) {
+            if (mComposing.length() > 0) {
+                clearComposing(false);
+            }
+            hideCandidateView();
             return true;
         }
 
-        if (selectedCandidate != null) {
+        if (resolveEndkeySelectedCandidate() != null) {
             commitTyped(getCurrentInputConnection());
-            if (mComposing.length() == 0) {
-                hideCandidateView();
+            if (mComposing.length() > 0) {
+                clearComposing(false);
             }
+            hideCandidateView();
             return true;
         }
 
@@ -2156,6 +2174,118 @@ public class LIMEService extends InputMethodService
             hideCandidateView();
         }
         return false;
+    }
+
+    private boolean commitComposingWithAppendedEndkey(int primaryCode) {
+        String code = String.valueOf((char) primaryCode);
+        mComposing.append(code);
+        InputConnection ic = getCurrentInputConnection();
+        if (ic != null && mPredictionOn) {
+            ic.setComposingText(mComposing, 1);
+        }
+        return commitResolvedEndkeyComposing();
+    }
+
+    private boolean commitFreshEndkeyOrRaw(int primaryCode) {
+        String code = String.valueOf((char) primaryCode);
+        mComposing.append(code);
+        InputConnection ic = getCurrentInputConnection();
+        if (ic != null && mPredictionOn) {
+            ic.setComposingText(mComposing, 1);
+        }
+        if (commitResolvedEndkeyComposing()) {
+            return true;
+        }
+        clearComposing(false);
+        if (ic != null) {
+            ic.commitText(code, 1);
+        }
+        finishComposing();
+        return true;
+    }
+
+    private boolean commitResolvedEndkeyComposing() {
+        if (resolveEndkeySelectedCandidate() == null) {
+            return false;
+        }
+        commitTyped(getCurrentInputConnection());
+        if (mComposing.length() > 0) {
+            clearComposing(false);
+        }
+        hideCandidateView();
+        return true;
+    }
+
+    private Mapping resolveEndkeySelectedCandidate() {
+        if (hasCurrentEndkeySelectedCandidate()) {
+            return selectedCandidate;
+        }
+        if (SearchSrv == null || mComposing.length() == 0) {
+            return null;
+        }
+        if (queryThread != null && queryThread.isAlive()) {
+            queryThread.interrupt();
+        }
+        try {
+            List<Mapping> candidates = SearchSrv.getMappingByCode(mComposing.toString(),
+                    !hasPhysicalKeyPressed, false);
+            if (candidates == null || candidates.isEmpty()) {
+                return null;
+            }
+            mCandidateList = new LinkedList<>(candidates);
+            selectedCandidate = defaultSelectedCandidateForSuggestions(mCandidateList, hasPhysicalKeyPressed);
+            hasMappingList = selectedCandidate != null;
+            hasCandidatesShown = selectedCandidate != null;
+            return selectedCandidate;
+        } catch (RemoteException e) {
+            Log.e(TAG, "Error resolving end-key candidate", e);
+            return null;
+        }
+    }
+
+    private static boolean isKeyInImkeys(int primaryCode, String imkeys) {
+        if (imkeys == null || imkeys.isEmpty()) {
+            return false;
+        }
+        String key = String.valueOf((char) primaryCode);
+        return imkeys.contains(key) || imkeys.contains(key.toLowerCase(Locale.US));
+    }
+
+    private boolean hasCurrentEndkeySelectedCandidate() {
+        return selectedCandidate != null
+                && !selectedCandidate.isComposingCodeRecord()
+                && selectedCandidate.getCode() != null
+                && mComposing.toString().equals(selectedCandidate.getCode());
+    }
+
+    public static Mapping defaultSelectedCandidateForSuggestions(List<Mapping> suggestions,
+                                                                 boolean physicalKeyPressed) {
+        int selectedIndex = defaultSelectedCandidateIndex(suggestions, physicalKeyPressed);
+        if (selectedIndex < 0) {
+            return null;
+        }
+        return suggestions.get(selectedIndex);
+    }
+
+    public static int defaultSelectedCandidateIndex(List<Mapping> suggestions,
+                                                    boolean physicalKeyPressed) {
+        if (suggestions == null || suggestions.isEmpty()) {
+            return -1;
+        }
+        for (int i = 0; i < suggestions.size(); i++) {
+            if (isDefaultCommitCandidate(suggestions.get(i))) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    private static boolean isDefaultCommitCandidate(Mapping candidate) {
+        return candidate != null
+                && !candidate.isComposingCodeRecord()
+                && (candidate.isExactMatchToCodeRecord()
+                || candidate.isPartialMatchToCodeRecord()
+                || candidate.isChinesePunctuationSymbolRecord());
     }
 
     private void showEmojiKeyboard() {
@@ -3445,7 +3575,7 @@ public class LIMEService extends InputMethodService
                 if (index < 0) continue;
                 if (activeState.length() > 0) activeState.append(";");
                 activeState.append(index);
-                activatedIMFullNameList.add(fullNames[index]);
+                activatedIMFullNameList.add(im.getDesc());
                 activatedIMShortNameList.add(shortNames[index]);
                 activatedIMList.add(IMs[index]);
             }
@@ -4380,13 +4510,7 @@ public class LIMEService extends InputMethodService
                 mCandidateList = (LinkedList<Mapping>) suggestions;
                 try {
 
-                    if (suggestions.size() > 1 && ( !hasPhysicalKeyPressed || suggestions.get(1).isExactMatchToCodeRecord() || suggestions.get(1).isPartialMatchToCodeRecord())) {
-                        selectedCandidate = suggestions.get(1);
-                        // this is for no exact match condition with code.  //do not set default suggestion for other record type like chinese punctuation symbols1 or related phrases. Jeremy '15,6,4
-                    } else if (!suggestions.isEmpty()) {
-                        selectedCandidate = suggestions.get(0);
-
-                    }
+                    selectedCandidate = defaultSelectedCandidateForSuggestions(suggestions, hasPhysicalKeyPressed);
                 } catch (Exception e) {
                     Log.e(TAG, "Error in suggestion processing", e);
                 }

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
@@ -58,6 +58,7 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
 import android.view.Gravity;
 import android.view.KeyCharacterMap;
@@ -6158,7 +6159,12 @@ public class LIMEService extends InputMethodService
     }
 
     static EmojiPanelColors emojiPanelColorsForTheme(int themeIndex, boolean systemDark) {
+        return emojiPanelColorsForTheme(themeIndex, systemDark, 0);
+    }
+
+    static EmojiPanelColors emojiPanelColorsForTheme(int themeIndex, boolean systemDark, int systemAccent) {
         int resolvedTheme = themeIndex == 6 ? (systemDark ? 1 : 0) : themeIndex;
+        int accentOverlay = isUsableAccentColor(systemAccent) ? withAlpha(systemAccent, 0x33) : 0;
         switch (resolvedTheme) {
             case 1:
                 return new EmojiPanelColors(
@@ -6167,7 +6173,7 @@ public class LIMEService extends InputMethodService
                         0xFFCFD8DC,
                         0xFFCFD8DC,
                         0xFFCFD8DC,
-                        0x33FFFFFF);
+                        themeIndex == 6 && accentOverlay != 0 ? accentOverlay : 0x33FFFFFF);
             case 2:
                 return new EmojiPanelColors(
                         0xFFFEF3F7,
@@ -6208,12 +6214,51 @@ public class LIMEService extends InputMethodService
                         0xFF000000,
                         0xFF000000,
                         0xFF000000,
-                        0x22000000);
+                        themeIndex == 6 && accentOverlay != 0 ? accentOverlay : 0x22000000);
         }
     }
 
     private EmojiPanelColors currentEmojiPanelColors() {
-        return emojiPanelColorsForTheme(mKeyboardThemeIndex, isEffectiveDarkTheme());
+        int fallbackAccent = isEffectiveDarkTheme() ? 0x33FFFFFF : 0x22000000;
+        int accent = isFollowSystemTheme() ? resolveSystemAccentColor(fallbackAccent) : 0;
+        return emojiPanelColorsForTheme(mKeyboardThemeIndex, isEffectiveDarkTheme(), accent);
+    }
+
+    private boolean isFollowSystemTheme() {
+        return mKeyboardThemeIndex == 6;
+    }
+
+    private int resolveSystemAccentColor(int fallbackColor) {
+        int resolved = resolveThemeColor(com.google.android.material.R.attr.colorPrimary, 0);
+        if (!isUsableAccentColor(resolved)) {
+            resolved = resolveThemeColor(com.google.android.material.R.attr.colorSecondary, 0);
+        }
+        if (!isUsableAccentColor(resolved)) {
+            resolved = resolveThemeColor(android.R.attr.colorAccent, 0);
+        }
+        return isUsableAccentColor(resolved) ? resolved : fallbackColor;
+    }
+
+    private int resolveThemeColor(int attr, int fallbackColor) {
+        TypedValue value = new TypedValue();
+        if (getTheme().resolveAttribute(attr, value, true)) {
+            if (value.resourceId != 0) {
+                return ContextCompat.getColor(this, value.resourceId);
+            }
+            if (value.type >= TypedValue.TYPE_FIRST_COLOR_INT
+                    && value.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+                return value.data;
+            }
+        }
+        return fallbackColor;
+    }
+
+    private static boolean isUsableAccentColor(int color) {
+        return Color.alpha(color) != 0;
+    }
+
+    private static int withAlpha(int color, int alpha) {
+        return (color & 0x00FFFFFF) | ((alpha & 0xFF) << 24);
     }
 
     private int getKeyboardTheme() {

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
@@ -2082,6 +2082,8 @@ public class LIMEService extends InputMethodService
             // Jeremy '11,5,31 Rewrite softkeybaord enter/space and english separator processing.
         } else if (primaryCode == KEYCODE_SWITCH_TO_IM_MODE && mInputView != null) { //eng -> chi
             switchKeyboard(primaryCode);
+        } else if (handleEndkeyCommit(primaryCode)) {
+            // End-key commit is opt-in per IM table metadata and consumes the trigger key.
         } else if ( //Jeremy '12,7,1 bug fixed on enter not functioning in english mode
                 ((primaryCode == MY_KEYCODE_SPACE && !mEnglishOnly && !activeIM.equals(LIME.IM_PHONETIC))
                         || (primaryCode == MY_KEYCODE_SPACE && !mEnglishOnly &&
@@ -2115,6 +2117,42 @@ public class LIMEService extends InputMethodService
                 }
             }
         }
+    }
+
+    static boolean isEndkeyCommitKey(int primaryCode, String endkey, boolean englishOnly,
+                                     int composingLength, boolean candidatesShown) {
+        return !englishOnly
+                && composingLength > 0
+                && candidatesShown
+                && endkey != null
+                && endkey.indexOf((char) primaryCode) >= 0;
+    }
+
+    private boolean handleEndkeyCommit(int primaryCode) {
+        String endkey = "";
+        if (SearchSrv != null && activeIM != null) {
+            endkey = SearchSrv.getImConfig(activeIM, LIME.IM_LIME_ENDKEY);
+        }
+        if (!isEndkeyCommitKey(primaryCode, endkey, mEnglishOnly, mComposing.length(), hasCandidatesShown)) {
+            return false;
+        }
+
+        if (pickHighlightedCandidate()) {
+            return true;
+        }
+
+        if (selectedCandidate != null) {
+            commitTyped(getCurrentInputConnection());
+            if (mComposing.length() == 0) {
+                hideCandidateView();
+            }
+            return true;
+        }
+
+        if (mComposing.length() == 0) {
+            hideCandidateView();
+        }
+        return false;
     }
 
     private void showEmojiKeyboard() {

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/candidate/CandidateView.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/candidate/CandidateView.java
@@ -1541,21 +1541,7 @@ public class CandidateView extends View implements View.OnClickListener {
                     Log.i(TAG, "setSuggestions():mSuggestions.size():" + mSuggestions.size()
                             + " mCount=" + mCount);
 
-                if (mCount > 1 && (mSuggestions.get(1).isExactMatchToCodeRecord() || mSuggestions.get(1).isPartialMatchToCodeRecord())) {
-                    mSelectedIndex = 1;
-                } else if (mCount > 0 && (mSuggestions.get(0).isComposingCodeRecord() || mSuggestions.get(0).isRuntimeBuiltPhraseRecord())) {
-/*
-                    int seloption = mLIMEPref.getSelkeyOption();
-                    if(seloption > 0 && suggestions.size() > seloption){
-                        mSelectedIndex = seloption;
-                    }else{*/
-                    mSelectedIndex = 0;
-                    //}
-
-                } else {
-                    // no default selection for related phrase, chinese punctuation symbols1 and English suggestions  Jeremy '15,6,4
-                    mSelectedIndex = -1;
-                }
+                mSelectedIndex = LIMEService.defaultSelectedCandidateIndex(mSuggestions, false);
             } else {
                 if (DEBUG)
                     Log.i(TAG, "setSuggestions():mSuggestions=null");
@@ -1830,7 +1816,7 @@ public class CandidateView extends View implements View.OnClickListener {
         }
 
 
-        if (mSuggestions != null && index >= 0 && index <= mSuggestions.size()) {
+        if (mSuggestions != null && index >= 0 && index < mSuggestions.size()) {
             mService.pickCandidateManually(index);
             return true;  // Selection picked
         } else

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/candidate/CandidateView.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/candidate/CandidateView.java
@@ -348,6 +348,29 @@ public class CandidateView extends View implements View.OnClickListener {
 
     }
 
+    public void applyFollowSystemAccentColor(int accentColor, boolean darkTheme) {
+        if ((accentColor >>> 24) == 0) return;
+
+        mDrawableSuggestHighlight = createFollowSystemSuggestHighlight(accentColor, darkTheme);
+        mColorComposingCode = accentColor;
+        mColorSelKeyShifted = accentColor;
+        mColorNormalTextHighlight = darkTheme ? 0xFFFFFFFF : 0xFF000000;
+        invalidate();
+    }
+
+    private Drawable createFollowSystemSuggestHighlight(int accentColor, boolean darkTheme) {
+        final float density = getResources().getDisplayMetrics().density;
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setShape(GradientDrawable.RECTANGLE);
+        drawable.setCornerRadius(4f * density);
+        drawable.setColor(withAlpha(accentColor, darkTheme ? 0x66 : 0x44));
+        return drawable;
+    }
+
+    private static int withAlpha(int color, int alpha) {
+        return (color & 0x00FFFFFF) | ((alpha & 0xFF) << 24);
+    }
+
     /*
     * New embedded composing view inside candidate container for floating candidate mode. Jeremy '15,6,14
     * (android 5.1 does not allow popup composing go over candidate area).

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/global/LIME.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/global/LIME.java
@@ -248,6 +248,7 @@ public class LIME {
 	public static final String IM_KEYBOARD = "keyboard";
 	public static final String IM_SELKEY = "selkey";
 	public static final String IM_ENDKEY = "endkey";
+	public static final String IM_LIME_ENDKEY = "limeendkey";
 	public static final String IM_SPACESTYLE = "spacestyle";
 	
 	// Database and IM Status

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/global/SystemAccentColor.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/global/SystemAccentColor.java
@@ -1,0 +1,109 @@
+package net.toload.main.hd.global;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.provider.Settings;
+import android.text.TextUtils;
+
+import com.google.android.material.color.DynamicColorsOptions;
+
+/**
+ * Resolves Android's user-selected Material You palette for LIME's follow-system theme.
+ */
+public final class SystemAccentColor {
+    private static final String THEME_CUSTOMIZATION = "theme_customization_overlay_packages";
+    private static final String SYSTEM_PALETTE = "system_palette";
+    private static final String ACCENT_COLOR = "accent_color";
+
+    private SystemAccentColor() {
+    }
+
+    public static DynamicColorsOptions dynamicColorOptions(Context context) {
+        DynamicColorsOptions.Builder builder = new DynamicColorsOptions.Builder();
+        int seedColor = resolveSeedColor(context, 0);
+        if (isUsableColor(seedColor)) {
+            builder.setContentBasedSource(seedColor);
+        }
+        return builder.build();
+    }
+
+    public static int resolveSeedColor(Context context, int fallbackColor) {
+        if (context == null) return fallbackColor;
+        try {
+            String value = Settings.Secure.getString(
+                    context.getContentResolver(),
+                    THEME_CUSTOMIZATION);
+            int parsed = parseThemeCustomizationColor(value);
+            return isUsableColor(parsed) ? parsed : fallbackColor;
+        } catch (RuntimeException e) {
+            return fallbackColor;
+        }
+    }
+
+    static int parseThemeCustomizationColor(String value) {
+        if (TextUtils.isEmpty(value)) return 0;
+
+        int parsed = parseColorAfterKey(value, SYSTEM_PALETTE);
+        if (isUsableColor(parsed)) return parsed;
+
+        return parseColorAfterKey(value, ACCENT_COLOR);
+    }
+
+    private static int parseColorAfterKey(String value, String key) {
+        int keyIndex = value.indexOf(key);
+        if (keyIndex < 0) return 0;
+
+        int index = keyIndex + key.length();
+        int length = value.length();
+        while (index < length) {
+            char c = value.charAt(index);
+            if (c == ':' || c == '=' || c == '"' || c == '\'' || Character.isWhitespace(c)) {
+                index++;
+                continue;
+            }
+            break;
+        }
+
+        int start = index;
+        while (index < length) {
+            char c = value.charAt(index);
+            if (c == '#' || isHexDigit(c)) {
+                index++;
+                continue;
+            }
+            break;
+        }
+        if (index <= start) return 0;
+        return parseColorToken(value.substring(start, index));
+    }
+
+    private static int parseColorToken(String token) {
+        if (TextUtils.isEmpty(token)) return 0;
+
+        String normalized = token.trim();
+        if (normalized.startsWith("#")) {
+            normalized = normalized.substring(1);
+        }
+        if (normalized.length() == 6) {
+            normalized = "FF" + normalized;
+        }
+        if (normalized.length() != 8) return 0;
+
+        try {
+            long value = Long.parseLong(normalized, 16);
+            return (int) value;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private static boolean isHexDigit(char c) {
+        return (c >= '0' && c <= '9')
+                || (c >= 'a' && c <= 'f')
+                || (c >= 'A' && c <= 'F');
+    }
+
+    private static boolean isUsableColor(int color) {
+        return Color.alpha(color) != 0;
+    }
+}

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/keyboard/LIMEKeyboardBaseView.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/keyboard/LIMEKeyboardBaseView.java
@@ -45,6 +45,8 @@ import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.StateListDrawable;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
@@ -52,6 +54,7 @@ import android.os.SystemClock;
 import androidx.annotation.NonNull;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.util.StateSet;
 import android.util.TypedValue;
 import android.view.GestureDetector;
 import android.view.Gravity;
@@ -201,6 +204,7 @@ public class LIMEKeyboardBaseView extends View implements PointerTracker.UIProxy
     private int mShadowColor;
     private float mShadowRadius;
     private Drawable mKeyBackground;
+    private Drawable mBaseKeyBackground;
     private float mBackgroundDimAmount;
     private float mKeyHysteresisDistance;
     private float mVerticalCorrection;
@@ -687,6 +691,7 @@ public class LIMEKeyboardBaseView extends View implements PointerTracker.UIProxy
 
         mPadding = new Rect(0, 0, 0, 0);
         if(mKeyBackground != null) {
+            mBaseKeyBackground = mKeyBackground;
             mKeyBackground.getPadding(mPadding);
         }
 
@@ -741,6 +746,50 @@ public class LIMEKeyboardBaseView extends View implements PointerTracker.UIProxy
         mHasDistinctMultitouch = context.getPackageManager()
                 .hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN_MULTITOUCH_DISTINCT);
         mKeyRepeatInterval = res.getInteger(R.integer.config_key_repeat_interval);
+    }
+
+    public void applyFollowSystemAccentColor(int accentColor, boolean darkTheme) {
+        if ((accentColor >>> 24) == 0) return;
+
+        mKeyTextColorPressed = accentColor;
+        mFunctionKeyTextColorPressed = accentColor;
+        mKeySubLabelTextColorPressed = accentColor;
+        if (mPreviewText != null) {
+            mPreviewText.setTextColor(accentColor);
+        }
+
+        StateListDrawable keyBackground = new StateListDrawable();
+        keyBackground.addState(
+                new int[]{android.R.attr.state_single, android.R.attr.state_pressed},
+                createFollowSystemPressedKeyDrawable(accentColor, darkTheme));
+        keyBackground.addState(
+                new int[]{android.R.attr.state_pressed},
+                createFollowSystemPressedKeyDrawable(accentColor, darkTheme));
+        Drawable baseBackground = mBaseKeyBackground != null ? mBaseKeyBackground : mKeyBackground;
+        if (baseBackground != null) {
+            keyBackground.addState(StateSet.WILD_CARD, baseBackground);
+        }
+        mKeyBackground = keyBackground;
+        mKeyBackground.getPadding(mPadding);
+
+        mKeyboardChanged = true;
+        invalidateAllKeys();
+    }
+
+    private Drawable createFollowSystemPressedKeyDrawable(int accentColor, boolean darkTheme) {
+        final float density = getResources().getDisplayMetrics().density;
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setShape(GradientDrawable.RECTANGLE);
+        drawable.setCornerRadius(3f * density);
+        drawable.setColor(withAlpha(accentColor, darkTheme ? 0x66 : 0x44));
+        drawable.setStroke(Math.max(1, Math.round(2f * density)),
+                darkTheme ? 0xFF141414 : 0xFFE1E1E1);
+        drawable.setSize(Math.round(30f * density), Math.round(46f * density));
+        return drawable;
+    }
+
+    private static int withAlpha(int color, int alpha) {
+        return (color & 0x00FFFFFF) | ((alpha & 0xFF) << 24);
     }
 
     public void setOnKeyboardActionListener(OnKeyboardActionListener listener) {

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/limedb/LimeDB.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/limedb/LimeDB.java
@@ -3652,6 +3652,7 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                 String imname = "";
                 String line;
                 String endkey = "";
+                String limeendkey = "";
                 String selkey = "";
                 String spacestyle = "";
                 boolean escapedFormat = false;
@@ -3782,6 +3783,7 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                                         || line.trim().toLowerCase(Locale.US).startsWith("%cname")
                                         || line.trim().toLowerCase(Locale.US).startsWith("%selkey")
                                         || line.trim().toLowerCase(Locale.US).startsWith("%endkey")
+                                        || line.trim().toLowerCase(Locale.US).startsWith("%limeendkey")
                                         || line.trim().toLowerCase(Locale.US).startsWith("%spacestyle")
                                 )) {
                                     continue;
@@ -3849,6 +3851,9 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                                         continue;
                                     } else if ("@endkey@".equals(metaKey)) {
                                         endkey = metaValue;
+                                        continue;
+                                    } else if ("@limeendkey@".equals(metaKey)) {
+                                        limeendkey = metaValue;
                                         continue;
                                     } else if ("@spacestyle@".equals(metaKey)) {
                                         spacestyle = metaValue;
@@ -4043,6 +4048,10 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                                 endkey = metadataWord;
                                 if (DEBUG) Log.i(TAG, "loadfile(): endkey:" + endkey);
                                 continue;
+                            } else if (!escapedMetadataCode && codeLower.equals("%limeendkey")) {
+                                limeendkey = metadataWord;
+                                if (DEBUG) Log.i(TAG, "loadfile(): limeendkey:" + limeendkey);
+                                continue;
                             } else if (!escapedMetadataCode && codeLower.equals("%spacestyle")) {
                                 spacestyle = metadataWord;
                                 continue;
@@ -4139,6 +4148,7 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                     } else {
                         if (!selkey.isEmpty()) setImConfig(table, "selkey", selkey);
                         if (!endkey.isEmpty()) setImConfig(table, "endkey", endkey);
+                        if (!limeendkey.isEmpty()) setImConfig(table, LIME.IM_LIME_ENDKEY, limeendkey);
                         if (!spacestyle.isEmpty()) setImConfig(table, "spacestyle", spacestyle);
                         if (!imkeysHeader.isEmpty()) setImConfig(table, "imkeys", imkeysHeader);
                         else if (!imkeys.toString().isEmpty()) setImConfig(table, "imkeys", imkeys.toString());
@@ -4382,6 +4392,7 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                 || lower.startsWith("%cname")
                 || lower.startsWith("%selkey")
                 || lower.startsWith("%endkey")
+                || lower.startsWith("%limeendkey")
                 || lower.startsWith("%spacestyle")));
     }
 
@@ -5478,7 +5489,7 @@ public class LimeDB extends LimeSQLiteOpenHelper {
      * <ul>
      *   <li><b>Regular mapping tables:</b> .lime format
      *     <ul>
-     *       <li>Header lines with IM info (@format@, @version@, @cname@, @selkey@, @endkey@, @spacestyle@) if imConfig provided</li>
+     *       <li>Header lines with IM info (@format@, @version@, @cname@, @selkey@, @endkey@, @limeendkey@, @spacestyle@) if imConfig provided</li>
      *       <li>Data lines: code|word|score|basescore</li>
      *     </ul>
      *   </li>
@@ -5626,6 +5637,7 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                                 String name = "";
                                 String selkey = "";
                                 String endkey = "";
+                                String limeendkey = "";
                                 String spacestyle = "";
                                 String imkeys = "";
                                 String imkeynames = "";
@@ -5636,6 +5648,7 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                                     else if (LIME.IM_FULL_NAME.equals(i.getTitle()) || "name".equals(i.getTitle())) name = i.getDesc();
                                     else if (LIME.IM_SELKEY.equals(i.getTitle())) selkey = i.getDesc();
                                     else if (LIME.IM_ENDKEY.equals(i.getTitle())) endkey = i.getDesc();
+                                    else if (LIME.IM_LIME_ENDKEY.equals(i.getTitle())) limeendkey = i.getDesc();
                                     else if (LIME.IM_SPACESTYLE.equals(i.getTitle())) spacestyle = i.getDesc();
                                     else if ("imkeys".equals(i.getTitle())) imkeys = i.getDesc();
                                     else if ("imkeynames".equals(i.getTitle())) imkeynames = i.getDesc();
@@ -5644,6 +5657,7 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                                         || needsEscapedField(name, "|", false)
                                         || needsEscapedField(selkey, "|", false)
                                         || needsEscapedField(endkey, "|", false)
+                                        || needsEscapedField(limeendkey, "|", false)
                                         || needsEscapedField(spacestyle, "|", false)
                                         || needsEscapedField(imkeys, "|", false)
                                         || needsEscapedField(imkeynames, "|", false)) {
@@ -5668,6 +5682,10 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                                 }
                                 if (!endkey.isEmpty()) {
                                     fout.write("@endkey@|" + (useEscapedFormat ? escapeField(endkey, "|") : endkey));
+                                    fout.newLine();
+                                }
+                                if (!limeendkey.isEmpty()) {
+                                    fout.write("@limeendkey@|" + (useEscapedFormat ? escapeField(limeendkey, "|") : limeendkey));
                                     fout.newLine();
                                 }
                                 if (!spacestyle.isEmpty()) {

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/limedb/LimeDB.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/limedb/LimeDB.java
@@ -3676,6 +3676,9 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                     List<String> templist = new ArrayList<>();
                     while ((line = buf.readLine()) != null
                             && !isCinFormat) {
+                        if (line.trim().isEmpty() || line.trim().startsWith("#")) {
+                            continue;
+                        }
                         templist.add(line);
                         if (i >= maxLinesToProcess) {
                             break;
@@ -3817,6 +3820,9 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                             }
                             firstline = false;
                         } else if (line.trim().isEmpty()) {
+                            continue;
+                        }
+                        if (!isCinFormat && line.trim().startsWith("#")) {
                             continue;
                         }
                         //else { line.length() }

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/limedb/LimeDB.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/limedb/LimeDB.java
@@ -1939,21 +1939,23 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                         selectClause = expandBetweenSearchClause(codeCol, code) + extraSelectClause;
                     }
                     // Sort key order (issue #49 follow-up):
-                    //   1. exactmatch-with-score single-char priority
-                    //   2. exactmatch DESC                      -- exact hits always above partial hits
-                    //   3. length(code) >= codeLen              -- at-least-as-long-as-typed first
-                    //   4. score DESC / basescore DESC          -- when `sort` pref is on, score now
+                    //   1. exactmatch DESC                      -- exact hits always above partial hits
+                    //   2. length(code) >= codeLen              -- at-least-as-long-as-typed first
+                    //   3. exactmatch-with-score single-char priority / score DESC / basescore DESC
+                    //                                           -- when `sort` pref is on, score now
                     //                                              dominates over code-length so picks
                     //                                              from the partial-match list can
                     //                                              float to the top after score bumps
-                    //   5. (length(code) <= 5) * length(code)   -- tiebreaker among equal-score rows
-                    //   6. _id ASC
-                    sortClause = "( exactmatch = 1 and ( score > 0 or  basescore >0) and length(word)=1) desc, exactmatch desc,"
-                            + " (length(" + codeCol + ") >= " + codeLen + " ) desc, ";
+                    //   4. (length(code) <= 5) * length(code)   -- tiebreaker among equal-score rows
+                    //   5. _id ASC                              -- source insertion order for exact duplicate codes
+                    sortClause = "exactmatch desc, (length(" + codeCol + ") >= " + codeLen + " ) desc, ";
 
 
                     StringBuilder sortClauseBuilder = new StringBuilder(sortClause);
-                    if (sort) sortClauseBuilder.append(" score desc, basescore desc, ");
+                    if (sort) {
+                        sortClauseBuilder.append("( exactmatch = 1 and ( score > 0 or  basescore >0) and length(word)=1) desc, ");
+                        sortClauseBuilder.append("score desc, basescore desc, ");
+                    }
                     sortClauseBuilder.append("(length(" + codeCol + ") <= " + (Math.min(codeLen, 5)) + " )*length(" + codeCol + ") desc, ");
                     sortClauseBuilder.append("_id asc");
                     String finalSortClause = sortClauseBuilder.toString();

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/limedb/LimeDB.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/limedb/LimeDB.java
@@ -65,6 +65,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -3330,6 +3331,19 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                     + " (code, title, desc, keyboard, disable, selkey, endkey, spacestyle) "
                     + "select code, title, desc, keyboard, disable, selkey, endkey, spacestyle "
                     + "from sourceDB." + LIME.DB_TABLE_IM);
+                for (String tableName : validTableNames) {
+                    db.execSQL("insert into " + LIME.DB_TABLE_IM
+                        + " (code, title, desc) "
+                        + "select ?, ?, ? where not exists (select 1 from " + LIME.DB_TABLE_IM
+                        + " where code=? and title=?)",
+                        new Object[]{
+                            tableName,
+                            LIME.IM_FULL_NAME,
+                            defaultImFullName(tableName, tableName),
+                            tableName,
+                            LIME.IM_FULL_NAME
+                        });
+                }
             }
 
             // Import related table if requested
@@ -3831,7 +3845,7 @@ public class LimeDB extends LimeSQLiteOpenHelper {
 
                         try {
                             if (!isCinFormat && line.trim().startsWith("@")) {
-                                List<String> metaParts = splitEscapedFields(line, delimiter_symbol, escapedFormat);
+                                List<String> metaParts = splitLimeMetadataFields(line, escapedFormat);
                                 if (metaParts.size() >= 2) {
                                     String metaKey = metaParts.get(0).trim().toLowerCase(Locale.US);
                                     String metaValue = metaParts.get(1).trim();
@@ -3840,7 +3854,6 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                                         continue;
                                     } else if ("@version@".equals(metaKey)) {
                                         version = metaValue;
-                                        if (imname.isEmpty()) imname = version;
                                         continue;
                                     } else if ("@cname@".equals(metaKey)) {
                                         imname = metaValue;
@@ -4034,7 +4047,6 @@ public class LimeDB extends LimeSQLiteOpenHelper {
 
                             if (!escapedMetadataCode && codeLower.equals("%version")) {
                                 version = metadataWord;
-                                if (imname.isEmpty()) imname = version;
                                 continue;
                             } else if (!escapedMetadataCode && codeLower.equals("%cname")) {
                                 imname = metadataWord;
@@ -4123,7 +4135,7 @@ public class LimeDB extends LimeSQLiteOpenHelper {
                     }
                     setImConfig(table, "version", version);
                     if (imname.isEmpty()) {
-                        setImConfig(table, "name", filename.getName());
+                        setImConfig(table, "name", defaultImFullName(table, filename.getName()));
                     } else {
                         setImConfig(table, "name", imname);
                     }
@@ -4296,6 +4308,40 @@ public class LimeDB extends LimeSQLiteOpenHelper {
             return " ";
         }
 
+    }
+
+    private List<String> splitLimeMetadataFields(String line, boolean escapedFormat) {
+        String[] delimiters = {"|", "\t", ",", " "};
+        for (String delimiter : delimiters) {
+            List<String> parts = splitEscapedFields(line, delimiter, escapedFormat);
+            if (parts.size() >= 2 && parts.get(0).trim().startsWith("@")) {
+                if (parts.size() == 2) {
+                    return parts;
+                }
+                List<String> merged = new ArrayList<>();
+                merged.add(parts.get(0));
+                StringBuilder value = new StringBuilder(parts.get(1));
+                for (int i = 2; i < parts.size(); i++) {
+                    value.append(delimiter).append(parts.get(i));
+                }
+                merged.add(value.toString());
+                return merged;
+            }
+        }
+        List<String> fallback = new ArrayList<>();
+        fallback.add(line);
+        return fallback;
+    }
+
+    private String defaultImFullName(String table, String fallback) {
+        if (table != null) {
+            for (int i = 0; i < LIME.IM_CODES.length && i < LIME.IM_FULL_NAMES.length; i++) {
+                if (table.equals(LIME.IM_CODES[i])) {
+                    return LIME.IM_FULL_NAMES[i];
+                }
+            }
+        }
+        return fallback;
     }
 
     private List<String> splitEscapedFields(String line, String delimiter, boolean escapedFormat) {
@@ -5907,23 +5953,76 @@ public class LimeDB extends LimeSQLiteOpenHelper {
             cursor.moveToFirst();
             while (!cursor.isAfterLast()) {
                 //result.add(ImConfig.get(cursor));
-                ImConfig record = new ImConfig();
-                record.setId(getCursorInt(cursor, LIME.DB_IM_COLUMN_ID));
-                record.setCode(getCursorString(cursor, LIME.DB_IM_COLUMN_CODE));
-                record.setTitle(getCursorString(cursor, LIME.DB_IM_COLUMN_TITLE));
-                record.setDesc(getCursorString(cursor, LIME.DB_IM_COLUMN_DESC));
-                record.setKeyboard(getCursorString(cursor, LIME.DB_IM_COLUMN_KEYBOARD));
-                String disableStr = getCursorString(cursor, LIME.DB_IM_COLUMN_DISABLE);
-                record.setDisable(Boolean.parseBoolean(disableStr));
-                record.setSelkey(getCursorString(cursor, LIME.DB_IM_COLUMN_SELKEY));
-                record.setEndkey(getCursorString(cursor, LIME.DB_IM_COLUMN_ENDKEY));
-                record.setSpacestyle(getCursorString(cursor, LIME.DB_IM_COLUMN_SPACESTYLE));
+                ImConfig record = getImConfigFromCursor(cursor);
                 cursor.moveToNext();
                 result.add(record);
             }
             cursor.close();
         }
+        appendLegacyFullNameConfigs(result, code, configEntry);
+        applyFullNameFallbacks(result, configEntry);
         return result;
+    }
+
+    private ImConfig getImConfigFromCursor(Cursor cursor) {
+        ImConfig record = new ImConfig();
+        record.setId(getCursorInt(cursor, LIME.DB_IM_COLUMN_ID));
+        record.setCode(getCursorString(cursor, LIME.DB_IM_COLUMN_CODE));
+        record.setTitle(getCursorString(cursor, LIME.DB_IM_COLUMN_TITLE));
+        record.setDesc(getCursorString(cursor, LIME.DB_IM_COLUMN_DESC));
+        record.setKeyboard(getCursorString(cursor, LIME.DB_IM_COLUMN_KEYBOARD));
+        String disableStr = getCursorString(cursor, LIME.DB_IM_COLUMN_DISABLE);
+        record.setDisable(Boolean.parseBoolean(disableStr));
+        record.setSelkey(getCursorString(cursor, LIME.DB_IM_COLUMN_SELKEY));
+        record.setEndkey(getCursorString(cursor, LIME.DB_IM_COLUMN_ENDKEY));
+        record.setSpacestyle(getCursorString(cursor, LIME.DB_IM_COLUMN_SPACESTYLE));
+        return record;
+    }
+
+    private void appendLegacyFullNameConfigs(List<ImConfig> result, String code, String configEntry) {
+        if (!LIME.IM_FULL_NAME.equals(configEntry)) return;
+
+        Set<String> existingCodes = new HashSet<>();
+        for (ImConfig record : result) {
+            if (record != null && record.getCode() != null) {
+                existingCodes.add(record.getCode());
+            }
+        }
+
+        for (int i = 0; i < LIME.IM_CODES.length && i < LIME.IM_FULL_NAMES.length; i++) {
+            String imCode = LIME.IM_CODES[i];
+            if (code != null && code.length() > 1 && !imCode.equals(code)) continue;
+            if (existingCodes.contains(imCode)) continue;
+            ImConfig legacy = getFirstImConfigForCode(imCode);
+            if (legacy == null) continue;
+            legacy.setTitle(LIME.IM_FULL_NAME);
+            legacy.setDesc(LIME.IM_FULL_NAMES[i]);
+            result.add(legacy);
+        }
+    }
+
+    private void applyFullNameFallbacks(List<ImConfig> result, String configEntry) {
+        if (!LIME.IM_FULL_NAME.equals(configEntry)) return;
+        for (ImConfig record : result) {
+            if (record == null) continue;
+            String desc = record.getDesc();
+            if (desc == null || desc.isEmpty()) {
+                record.setDesc(defaultImFullName(record.getCode(), record.getCode()));
+            }
+        }
+    }
+
+    private ImConfig getFirstImConfigForCode(String code) {
+        Cursor cursor = db.query(LIME.DB_TABLE_IM, null,
+                LIME.DB_IM_COLUMN_CODE + " = ?",
+                new String[]{code}, null, null, LIME.DB_IM_COLUMN_ID + " ASC", "1");
+        if (cursor == null) return null;
+        try {
+            if (!cursor.moveToFirst()) return null;
+            return getImConfigFromCursor(cursor);
+        } finally {
+            cursor.close();
+        }
     }
 
     /**

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/ui/LIMESettings.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/ui/LIMESettings.java
@@ -27,6 +27,7 @@ import net.toload.main.hd.ui.controller.SetupImController;
 import net.toload.main.hd.ui.dialog.HelpDialog;
 import net.toload.main.hd.ui.dialog.NewsDialog;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.material.color.DynamicColors;
 import com.google.android.material.navigationrail.NavigationRailView;
 import net.toload.main.hd.ui.view.LIMESettingsView;
 
@@ -144,6 +145,7 @@ public class LIMESettings extends AppCompatActivity implements LIMESettingsView 
      */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        DynamicColors.applyToActivityIfAvailable(this);
         super.onCreate(savedInstanceState);
         // Register back gesture/press callback for AndroidX
         getOnBackPressedDispatcher().addCallback(this, new androidx.activity.OnBackPressedCallback(true) {

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/ui/LIMESettings.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/ui/LIMESettings.java
@@ -22,6 +22,7 @@ import net.toload.main.hd.R;
 import net.toload.main.hd.SearchServer;
 import net.toload.main.hd.global.LIME;
 import net.toload.main.hd.global.LIMEPreferenceManager;
+import net.toload.main.hd.global.SystemAccentColor;
 import net.toload.main.hd.ui.controller.ManageImController;
 import net.toload.main.hd.ui.controller.SetupImController;
 import net.toload.main.hd.ui.dialog.HelpDialog;
@@ -145,7 +146,7 @@ public class LIMESettings extends AppCompatActivity implements LIMESettingsView 
      */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        DynamicColors.applyToActivityIfAvailable(this);
+        DynamicColors.applyToActivityIfAvailable(this, SystemAccentColor.dynamicColorOptions(this));
         super.onCreate(savedInstanceState);
         // Register back gesture/press callback for AndroidX
         getOnBackPressedDispatcher().addCallback(this, new androidx.activity.OnBackPressedCallback(true) {

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/ui/controller/ManageImController.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/ui/controller/ManageImController.java
@@ -412,8 +412,8 @@ public class ManageImController extends BaseController {
      * Updates one editable IM metadata field.
      *
      * @param table the IM table / code
-     * @param field either {@code name} or {@code version}
-     * @param value the value to store; blank is allowed only for version
+     * @param field either {@code name}, {@code version}, or {@code limeendkey}
+     * @param value the value to store; blank is allowed for version and limeendkey
      * @return true when the value was persisted
      */
     public boolean updateIMMetadataField(String table, String field, String value) {
@@ -421,7 +421,9 @@ public class ManageImController extends BaseController {
         String trimmedField = field == null ? "" : field.trim();
         String trimmedValue = value == null ? "" : value.trim();
         if (trimmedTable.isEmpty()) return false;
-        if (!"name".equals(trimmedField) && !"version".equals(trimmedField)) return false;
+        if (!"name".equals(trimmedField)
+                && !"version".equals(trimmedField)
+                && !LIME.IM_LIME_ENDKEY.equals(trimmedField)) return false;
         if ("name".equals(trimmedField) && trimmedValue.isEmpty()) return false;
 
         try {

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/ui/view/ImDetailFragment.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/ui/view/ImDetailFragment.java
@@ -32,6 +32,7 @@ import com.google.android.material.switchmaterial.SwitchMaterial;
 import net.toload.main.hd.R;
 import net.toload.main.hd.data.ImConfig;
 import net.toload.main.hd.data.Keyboard;
+import net.toload.main.hd.global.LIME;
 import net.toload.main.hd.ui.LIMESettings;
 import net.toload.main.hd.ui.controller.ManageImController;
 
@@ -58,6 +59,7 @@ public class ImDetailFragment extends Fragment {
     private TextView tvImName;
     private TextView tvImRecords;
     private TextView txtImVersion;
+    private TextView txtImEndkey;
     private TextView tvKeyboardValue;
     private TextView tvHeading;
 
@@ -129,6 +131,7 @@ public class ImDetailFragment extends Fragment {
         tvImName = rootView.findViewById(R.id.tv_im_name);
         tvImRecords = rootView.findViewById(R.id.tv_im_records);
         txtImVersion = rootView.findViewById(R.id.txtImVersion);
+        txtImEndkey = rootView.findViewById(R.id.txtImEndkey);
         tvKeyboardValue = rootView.findViewById(R.id.tv_keyboard_value);
 
         if (imDesc != null) {
@@ -137,6 +140,7 @@ public class ImDetailFragment extends Fragment {
 
         LinearLayout rowName = rootView.findViewById(R.id.row_name);
         LinearLayout rowVersion = rootView.findViewById(R.id.row_version);
+        LinearLayout rowEndkey = rootView.findViewById(R.id.row_endkey);
 
         // Keyboard row click -> show picker
         LinearLayout rowKeyboard = rootView.findViewById(R.id.row_keyboard);
@@ -164,13 +168,16 @@ public class ImDetailFragment extends Fragment {
             View sectionKeyboard = rootView.findViewById(R.id.section_keyboard);
             View sectionOptions = rootView.findViewById(R.id.section_options);
             View dividerVersion = rootView.findViewById(R.id.divider_version);
+            View dividerEndkey = rootView.findViewById(R.id.divider_endkey);
             View editNameIcon = rootView.findViewById(R.id.iv_edit_name);
             TextView tvSectionTableLabel = rootView.findViewById(R.id.tv_section_table_label);
             TextView tvManageTableLabel = rootView.findViewById(R.id.tv_manage_table_label);
             if (sectionKeyboard != null) sectionKeyboard.setVisibility(View.GONE);
             if (sectionOptions != null) sectionOptions.setVisibility(View.GONE);
             if (rowVersion != null) rowVersion.setVisibility(View.GONE);
+            if (rowEndkey != null) rowEndkey.setVisibility(View.GONE);
             if (dividerVersion != null) dividerVersion.setVisibility(View.GONE);
+            if (dividerEndkey != null) dividerEndkey.setVisibility(View.GONE);
             if (editNameIcon != null) editNameIcon.setVisibility(View.GONE);
             if (tvSectionTableLabel != null) tvSectionTableLabel.setText(R.string.im_detail_section_related);
             if (tvManageTableLabel != null) tvManageTableLabel.setText(R.string.im_detail_manage_related);
@@ -188,6 +195,12 @@ public class ImDetailFragment extends Fragment {
                 rowVersion.setFocusable(true);
                 applySelectableBackground(rowVersion);
                 rowVersion.setOnClickListener(v -> showMetadataFieldEditor("version"));
+            }
+            if (rowEndkey != null) {
+                rowEndkey.setClickable(true);
+                rowEndkey.setFocusable(true);
+                applySelectableBackground(rowEndkey);
+                rowEndkey.setOnClickListener(v -> showMetadataFieldEditor(LIME.IM_LIME_ENDKEY));
             }
         }
 
@@ -285,13 +298,16 @@ public class ImDetailFragment extends Fragment {
         // Load version from IM metadata, retaining legacy SharedPreferences fallback.
         if (tableCode != null) {
             String version = "";
+            String endkey = "";
             try {
                 if (manageImController != null && manageImController.getSearchServer() != null) {
                     net.toload.main.hd.SearchServer searchServer = manageImController.getSearchServer();
                     version = searchServer.getImConfig(tableCode, "version");
+                    endkey = searchServer.getImConfig(tableCode, LIME.IM_LIME_ENDKEY);
                 }
             } catch (Exception ignored) {
                 version = "";
+                endkey = "";
             }
             if (version == null || version.isEmpty()) {
                 android.content.SharedPreferences versionSp = androidx.preference.PreferenceManager.getDefaultSharedPreferences(requireContext());
@@ -317,6 +333,8 @@ public class ImDetailFragment extends Fragment {
             }
             if (version == null || version.isEmpty()) version = "-";
             if (txtImVersion != null) txtImVersion.setText(version);
+            if (endkey == null || endkey.isEmpty()) endkey = "-";
+            if (txtImEndkey != null) txtImEndkey.setText(endkey);
         }
 
         // Share button (plain ImageButton overlaying toolbar — direct click handler)
@@ -423,7 +441,8 @@ public class ImDetailFragment extends Fragment {
         if (activity == null || tableCode == null || "related".equals(tableCode)) return;
         final boolean editingName = "name".equals(field);
         final boolean editingVersion = "version".equals(field);
-        if (!editingName && !editingVersion) return;
+        final boolean editingEndkey = LIME.IM_LIME_ENDKEY.equals(field);
+        if (!editingName && !editingVersion && !editingEndkey) return;
 
         LinearLayout form = new LinearLayout(activity);
         form.setOrientation(LinearLayout.VERTICAL);
@@ -432,18 +451,27 @@ public class ImDetailFragment extends Fragment {
 
         EditText valueInput = new EditText(activity);
         valueInput.setSingleLine(true);
-        valueInput.setHint(editingName ? R.string.im_detail_label_name : R.string.im_detail_label_version);
+        valueInput.setHint(editingName
+                ? R.string.im_detail_label_name
+                : (editingVersion ? R.string.im_detail_label_version : R.string.im_detail_label_endkey));
         valueInput.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
-        CharSequence currentText = editingName
-                ? (tvImName != null ? tvImName.getText() : "")
-                : (txtImVersion != null ? txtImVersion.getText() : "");
+        CharSequence currentText;
+        if (editingName) {
+            currentText = tvImName != null ? tvImName.getText() : "";
+        } else if (editingVersion) {
+            currentText = txtImVersion != null ? txtImVersion.getText() : "";
+        } else {
+            currentText = txtImEndkey != null ? txtImEndkey.getText() : "";
+        }
         String currentValue = currentText == null ? "" : currentText.toString();
         valueInput.setText(!editingName && "-".equals(currentValue) ? "" : currentValue);
         form.addView(valueInput, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
 
         AlertDialog dialog = new AlertDialog.Builder(activity)
-                .setTitle(editingName ? R.string.im_detail_edit_name_title : R.string.im_detail_edit_version_title)
+                .setTitle(editingName
+                        ? R.string.im_detail_edit_name_title
+                        : (editingVersion ? R.string.im_detail_edit_version_title : R.string.im_detail_edit_endkey_title))
                 .setView(form)
                 .setNegativeButton(R.string.dialog_cancel, null)
                 .setPositiveButton(R.string.manage_im_save, null)
@@ -473,8 +501,10 @@ public class ImDetailFragment extends Fragment {
                         imDesc = editedValue;
                         if (tvImName != null) tvImName.setText(editedValue);
                         if (tvHeading != null) tvHeading.setText(editedValue);
-                    } else if (txtImVersion != null) {
+                    } else if (editingVersion && txtImVersion != null) {
                         txtImVersion.setText(editedValue.isEmpty() ? "-" : editedValue);
+                    } else if (editingEndkey && txtImEndkey != null) {
+                        txtImEndkey.setText(editedValue.isEmpty() ? "-" : editedValue);
                     }
                     refreshListPane();
                     dialog.dismiss();

--- a/LimeStudio/app/src/main/res/layout/fragment_db_manager.xml
+++ b/LimeStudio/app/src/main/res/layout/fragment_db_manager.xml
@@ -46,9 +46,9 @@
             android:layout_height="48dp"
             android:text="備份資料庫"
             android:textAllCaps="false"
-            android:textColor="@color/material_blue"
+            android:textColor="?attr/colorPrimary"
             app:icon="@drawable/ic_upload_24"
-            app:iconTint="@color/material_blue"
+            app:iconTint="?attr/colorPrimary"
             app:iconGravity="textStart"
             app:iconPadding="8dp"
  />

--- a/LimeStudio/app/src/main/res/layout/fragment_im_detail.xml
+++ b/LimeStudio/app/src/main/res/layout/fragment_im_detail.xml
@@ -373,7 +373,7 @@
                         android:layout_height="22dp"
                         android:layout_marginEnd="12dp"
                         android:src="@drawable/ic_grid_on_24"
-                        app:tint="@color/material_blue"
+                        app:tint="?attr/colorPrimary"
                         android:contentDescription="@null" />
 
                     <TextView

--- a/LimeStudio/app/src/main/res/layout/fragment_im_detail.xml
+++ b/LimeStudio/app/src/main/res/layout/fragment_im_detail.xml
@@ -165,6 +165,48 @@
                         android:layout_height="1dp"
                         android:background="?android:attr/listDivider" />
 
+                    <!-- 結束鍵 row -->
+                    <LinearLayout
+                        android:id="@+id/row_endkey"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:paddingTop="10dp"
+                        android:paddingBottom="10dp">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/im_detail_label_endkey"
+                            android:textAppearance="?attr/textAppearanceBody2" />
+
+                        <TextView
+                            android:id="@+id/txtImEndkey"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="2"
+                            android:textAppearance="?attr/textAppearanceBody2"
+                            android:textColor="?android:attr/textColorSecondary"
+                            android:gravity="end"
+                            android:text="-" />
+
+                        <ImageView
+                            android:id="@+id/iv_edit_endkey"
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:layout_marginStart="6dp"
+                            android:src="@drawable/ic_chevron_right"
+                            app:tint="?android:attr/textColorSecondary"
+                            android:contentDescription="@string/im_detail_edit_endkey_title" />
+                    </LinearLayout>
+
+                    <View
+                        android:id="@+id/divider_endkey"
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:background="?android:attr/listDivider" />
+
                     <!-- 筆數 row -->
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/LimeStudio/app/src/main/res/layout/fragment_im_detail.xml
+++ b/LimeStudio/app/src/main/res/layout/fragment_im_detail.xml
@@ -477,15 +477,47 @@
                     app:cardCornerRadius="10dp"
                     app:strokeWidth="0dp">
 
-                    <android.widget.Spinner
-                        android:id="@+id/spinnerAutoCommit"
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:paddingStart="8dp"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:minHeight="56dp"
+                        android:paddingStart="16dp"
                         android:paddingEnd="8dp"
-                        android:paddingTop="6dp"
-                        android:paddingBottom="6dp"
-                        android:entries="@array/auto_commit_labels" />
+                        android:paddingTop="10dp"
+                        android:paddingBottom="10dp">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical"
+                            android:paddingEnd="12dp">
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/auto_commit"
+                                android:textColor="?android:attr/textColorPrimary"
+                                android:textSize="15sp" />
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="2dp"
+                                android:text="@string/auto_commit_summary"
+                                android:textColor="?android:attr/textColorSecondary"
+                                android:textSize="12sp" />
+                        </LinearLayout>
+
+                        <android.widget.Spinner
+                            android:id="@+id/spinnerAutoCommit"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minWidth="88dp"
+                            android:entries="@array/auto_commit_labels" />
+                    </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
             </LinearLayout>
 

--- a/LimeStudio/app/src/main/res/layout/fragment_im_list.xml
+++ b/LimeStudio/app/src/main/res/layout/fragment_im_list.xml
@@ -34,7 +34,7 @@
         android:layout_margin="16dp"
         android:contentDescription="@string/im_list_action_install"
         android:src="@drawable/ic_add"
-        app:backgroundTint="@color/material_blue"
+        app:backgroundTint="?attr/colorPrimary"
         app:tint="@android:color/white" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/LimeStudio/app/src/main/res/layout/fragment_manage_im.xml
+++ b/LimeStudio/app/src/main/res/layout/fragment_manage_im.xml
@@ -104,7 +104,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/manage_im_previous"
                 android:id="@+id/btnManageImPrevious"
-                android:textColor="@color/material_blue"
+                android:textColor="?attr/colorPrimary"
                 android:textAllCaps="false"
                 android:paddingRight="12dp"
                 android:paddingLeft="12dp" />
@@ -126,7 +126,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/manage_im_next"
                 android:id="@+id/btnManageImNext"
-                android:textColor="@color/material_blue"
+                android:textColor="?attr/colorPrimary"
                 android:textAllCaps="false"
                 android:paddingLeft="12dp"
                 android:paddingRight="12dp" />

--- a/LimeStudio/app/src/main/res/layout/fragment_manage_related.xml
+++ b/LimeStudio/app/src/main/res/layout/fragment_manage_related.xml
@@ -78,7 +78,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/manage_related_previous"
                 android:id="@+id/btnManageRelatedPrevious"
-                android:textColor="@color/material_blue"
+                android:textColor="?attr/colorPrimary"
                 android:textAllCaps="false"
                 android:paddingRight="12dp"
                 android:paddingLeft="12dp" />
@@ -100,7 +100,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/manage_related_next"
                 android:id="@+id/btnManageRelatedNext"
-                android:textColor="@color/material_blue"
+                android:textColor="?attr/colorPrimary"
                 android:textAllCaps="false"
                 android:paddingLeft="12dp"
                 android:paddingRight="12dp" />

--- a/LimeStudio/app/src/main/res/layout/fragment_setup.xml
+++ b/LimeStudio/app/src/main/res/layout/fragment_setup.xml
@@ -233,7 +233,7 @@
                         android:layout_weight="1"
                         android:gravity="end"
                         android:text="版權聲明"
-                        android:textColor="@color/material_blue"
+                        android:textColor="?attr/colorPrimary"
                         android:clickable="true"
                         android:focusable="true" />
 
@@ -265,7 +265,7 @@
                         android:layout_weight="1"
                         android:gravity="end"
                         android:text="@string/url_github_limeime"
-                        android:textColor="@color/material_blue"
+                        android:textColor="?attr/colorPrimary"
                         android:clickable="true"
                         android:focusable="true" />
 

--- a/LimeStudio/app/src/main/res/layout/sheet_manage_im_add.xml
+++ b/LimeStudio/app/src/main/res/layout/sheet_manage_im_add.xml
@@ -22,7 +22,7 @@
         android:text="@string/dialog_cancel"
         android:layout_marginBottom="8dp"
         app:cornerRadius="4dp"
-        app:strokeColor="@color/material_blue"
+        app:strokeColor="?attr/colorPrimary"
         app:strokeWidth="1dp" />
 
     <TextView
@@ -125,7 +125,7 @@
         android:layout_height="wrap_content"
         android:text="@string/manage_editor_confirm_add"
         app:cornerRadius="4dp"
-        app:strokeColor="@color/material_blue"
+        app:strokeColor="?attr/colorPrimary"
         app:strokeWidth="1dp" />
 
     </LinearLayout>

--- a/LimeStudio/app/src/main/res/layout/sheet_manage_im_edit.xml
+++ b/LimeStudio/app/src/main/res/layout/sheet_manage_im_edit.xml
@@ -22,7 +22,7 @@
         android:text="@string/dialog_cancel"
         android:layout_marginBottom="8dp"
         app:cornerRadius="4dp"
-        app:strokeColor="@color/material_blue"
+        app:strokeColor="?attr/colorPrimary"
         app:strokeWidth="1dp" />
 
     <TextView
@@ -135,7 +135,7 @@
         android:layout_height="wrap_content"
         android:text="@string/manage_im_save"
         app:cornerRadius="4dp"
-        app:strokeColor="@color/material_blue"
+        app:strokeColor="?attr/colorPrimary"
         app:strokeWidth="1dp" />
 
     </LinearLayout>

--- a/LimeStudio/app/src/main/res/layout/sheet_manage_related_add.xml
+++ b/LimeStudio/app/src/main/res/layout/sheet_manage_related_add.xml
@@ -22,7 +22,7 @@
         android:text="@string/dialog_cancel"
         android:layout_marginBottom="8dp"
         app:cornerRadius="4dp"
-        app:strokeColor="@color/material_blue"
+        app:strokeColor="?attr/colorPrimary"
         app:strokeWidth="1dp" />
 
     <TextView
@@ -125,7 +125,7 @@
         android:layout_height="wrap_content"
         android:text="@string/manage_editor_confirm_add"
         app:cornerRadius="4dp"
-        app:strokeColor="@color/material_blue"
+        app:strokeColor="?attr/colorPrimary"
         app:strokeWidth="1dp" />
 
     </LinearLayout>

--- a/LimeStudio/app/src/main/res/layout/sheet_manage_related_edit.xml
+++ b/LimeStudio/app/src/main/res/layout/sheet_manage_related_edit.xml
@@ -22,7 +22,7 @@
         android:text="@string/dialog_cancel"
         android:layout_marginBottom="8dp"
         app:cornerRadius="4dp"
-        app:strokeColor="@color/material_blue"
+        app:strokeColor="?attr/colorPrimary"
         app:strokeWidth="1dp" />
 
     <TextView
@@ -135,7 +135,7 @@
         android:layout_height="wrap_content"
         android:text="@string/manage_related_save"
         app:cornerRadius="4dp"
-        app:strokeColor="@color/material_blue"
+        app:strokeColor="?attr/colorPrimary"
         app:strokeWidth="1dp" />
 
     </LinearLayout>

--- a/LimeStudio/app/src/main/res/values/strings_settings.xml
+++ b/LimeStudio/app/src/main/res/values/strings_settings.xml
@@ -709,7 +709,7 @@
     <string name="auto_chinese_symbol_summary">無候選字詞時顯示中文標點選項</string>
 
     <!-- 自動上屏設定 -->
-    <string name="auto_commit">電話鍵盤自動上屏</string>
+    <string name="auto_commit">自動上屏</string>
     <string name="auto_commit_summary">當輸入字根符合設定數則自動送出組字</string>
     <string-array name="auto_commit_labels">
         <item>無</item>

--- a/LimeStudio/app/src/main/res/values/strings_settings.xml
+++ b/LimeStudio/app/src/main/res/values/strings_settings.xml
@@ -815,9 +815,11 @@
     <string name="im_detail_manage_related">瀏覽 / 編輯關聯字庫</string>
     <string name="im_detail_keyboard_picker_title">選擇鍵盤佈局</string>
     <string name="im_detail_label_version">版本</string>
+    <string name="im_detail_label_endkey">結束鍵</string>
     <string name="im_detail_edit_metadata_title">編輯輸入法資訊</string>
     <string name="im_detail_edit_name_title">編輯名稱</string>
     <string name="im_detail_edit_version_title">編輯版本</string>
+    <string name="im_detail_edit_endkey_title">編輯結束鍵</string>
     <string name="im_detail_edit_metadata_empty_name">名稱不能為空</string>
     <string name="im_detail_edit_metadata_failed">無法儲存輸入法資訊</string>
     <string name="im_list_header_installed">已安裝的輸入法</string>

--- a/LimeStudio/app/src/main/res/values/themes.xml
+++ b/LimeStudio/app/src/main/res/values/themes.xml
@@ -33,7 +33,7 @@
     <!-- Action bar follows surface/background — not affected by colorPrimary -->
     <item name="actionBarStyle">@style/LIME.ActionBarStyle</item>
     <item name="actionBarTheme">@style/LIME.ToolbarContentTheme</item>
-    <!-- Blue active tabs + buttons; green switches — matches iOS LIME brand -->
+    <!-- Fallback accents; DynamicColors overrides these on supported devices. -->
     <item name="colorPrimary">@color/material_blue</item>
     <item name="colorPrimaryVariant">@color/material_blue</item>
     <item name="colorSecondary">@color/lime_green</item>
@@ -51,7 +51,7 @@
     <!-- Action bar follows surface/background — not affected by colorPrimary -->
     <item name="actionBarStyle">@style/LIME.ActionBarStyle</item>
     <item name="actionBarTheme">@style/LIME.ToolbarContentTheme</item>
-    <!-- Blue active tabs + buttons; green switches — matches iOS LIME brand -->
+    <!-- Fallback accents; DynamicColors overrides these on supported devices. -->
     <item name="colorPrimary">@color/material_blue</item>
     <item name="colorPrimaryVariant">@color/material_blue</item>
     <item name="colorSecondary">@color/lime_green</item>

--- a/LimeStudio/app/src/main/res/xml/lime_dayi_sym_shift.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_dayi_sym_shift.xml
@@ -30,17 +30,17 @@
 
 
 	<Row>
-		<Key limehd:codes="33" limehd:keyLabel="!\n言" 
+		<Key limehd:codes="33" limehd:keyLabel="!" 
 			 limehd:keyEdgeFlags="left" />
-		<Key limehd:codes="64" limehd:keyLabel="\@\n牛" />
-		<Key limehd:codes="35" limehd:keyLabel="\#\n目" />
-		<Key limehd:codes="36" limehd:keyLabel="$\n四" />
-		<Key limehd:codes="37" limehd:keyLabel="%\n王" />
-		<Key limehd:codes="94" limehd:keyLabel="^\n門" />
-		<Key limehd:codes="38" limehd:keyLabel="&amp;\n田" />
-		<Key limehd:codes="42" limehd:keyLabel="*\n米" />
-		<Key limehd:codes="40" limehd:keyLabel="(\n足" />
-		<Key limehd:codes="41" limehd:keyLabel=")\n金" limehd:keyEdgeFlags="right" />
+		<Key limehd:codes="64" limehd:keyLabel="\@" />
+		<Key limehd:codes="35" limehd:keyLabel="\#" />
+		<Key limehd:codes="36" limehd:keyLabel="$" />
+		<Key limehd:codes="37" limehd:keyLabel="%" />
+		<Key limehd:codes="94" limehd:keyLabel="^" />
+		<Key limehd:codes="38" limehd:keyLabel="&amp;" />
+		<Key limehd:codes="42" limehd:keyLabel="*" />
+		<Key limehd:codes="40" limehd:keyLabel="(" />
+		<Key limehd:codes="41" limehd:keyLabel=")" limehd:keyEdgeFlags="right" />
 	</Row>
 	
 	<Row>
@@ -66,7 +66,7 @@
 		<Key limehd:codes="74" limehd:keyLabel="J\n月" />
 		<Key limehd:codes="75" limehd:keyLabel="K\n立" />
 		<Key limehd:codes="76" limehd:keyLabel="L\n女" />
-		<Key limehd:codes="58" limehd:keyLabel=":\n虫" limehd:keyEdgeFlags="right" />
+		<Key limehd:codes="58" limehd:keyLabel=":" limehd:keyEdgeFlags="right" />
 	</Row>
 
 	<Row>
@@ -77,10 +77,10 @@
 		<Key limehd:codes="66" limehd:keyLabel="B\n馬" />
 		<Key limehd:codes="78" limehd:keyLabel="N\n魚" />
 		<Key limehd:codes="77" limehd:keyLabel="M\n雨" />
-		<Key limehd:codes="60" limehd:keyLabel="&lt;\n力" />
-		<Key limehd:codes="62" limehd:keyLabel="&gt;\n舟"
+		<Key limehd:codes="60" limehd:keyLabel="&lt;" />
+		<Key limehd:codes="62" limehd:keyLabel="&gt;"
 			limehd:popupKeyboard="@xml/popup_punctuation" />
-		<Key limehd:codes="63" limehd:keyLabel="\?\n竹" limehd:keyEdgeFlags="right" />
+		<Key limehd:codes="63" limehd:keyLabel="\?" limehd:keyEdgeFlags="right" />
 	</Row>
 	<Row limehd:rowEdgeFlags="bottom">
 		<Key limehd:codes="-3"  limehd:keyIcon="@drawable/sym_keyboard_done_light" limehd:isModifier="true"

--- a/LimeStudio/app/src/main/res/xml/lime_et_41_shift.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_et_41_shift.xml
@@ -29,16 +29,16 @@
 	limehd:verticalGap="0px" limehd:keyHeight="@dimen/key_height">
 
 	<Row>
-	<Key limehd:codes="33" limehd:keyLabel="!\n˙"  limehd:keyEdgeFlags="left" />
-		<Key limehd:codes="64" limehd:keyLabel="\@\nˊ" />
-		<Key limehd:codes="35" limehd:keyLabel="\#\nˇ" />
-		<Key limehd:codes="36" limehd:keyLabel="$\nˋ" />
+	<Key limehd:codes="33" limehd:keyLabel="!"  limehd:keyEdgeFlags="left" />
+		<Key limehd:codes="64" limehd:keyLabel="\@" />
+		<Key limehd:codes="35" limehd:keyLabel="\#" />
+		<Key limehd:codes="36" limehd:keyLabel="$" />
 		<Key limehd:codes="37" limehd:keyLabel="%" />
 		<Key limehd:codes="94" limehd:keyLabel="^" />
-		<Key limehd:codes="38" limehd:keyLabel="&amp;\nㄑ" />
-		<Key limehd:codes="42" limehd:keyLabel="*\nㄢ" />
-		<Key limehd:codes="40" limehd:keyLabel="(\nㄣ" />
-		<Key limehd:codes="41" limehd:keyLabel=")\nㄤ" limehd:keyEdgeFlags="right" />
+		<Key limehd:codes="38" limehd:keyLabel="&amp;" />
+		<Key limehd:codes="42" limehd:keyLabel="*" />
+		<Key limehd:codes="40" limehd:keyLabel="(" />
+		<Key limehd:codes="41" limehd:keyLabel=")" limehd:keyEdgeFlags="right" />
 	</Row>
 
 
@@ -64,7 +64,7 @@
 		<Key limehd:codes="74" limehd:keyLabel="J\nㄖ" />
 		<Key limehd:codes="75" limehd:keyLabel="K\nㄎ" />
 		<Key limehd:codes="76" limehd:keyLabel="L\nㄌ" />
-		<Key limehd:codes="58" limehd:keyLabel=":\nㄗ" limehd:keyEdgeFlags="right" />
+		<Key limehd:codes="58" limehd:keyLabel=":" limehd:keyEdgeFlags="right" />
 	</Row>
 
 	<Row>
@@ -77,19 +77,19 @@
 		<Key limehd:codes="66" limehd:keyLabel="B\nㄅ" />
 		<Key limehd:codes="78" limehd:keyLabel="N\nㄋ" />
 		<Key limehd:codes="77" limehd:keyLabel="M\nㄇ" />
-		<Key limehd:codes="34" limehd:keyLabel="&quot;\nㄘ"/>
+		<Key limehd:codes="34" limehd:keyLabel="&quot;"/>
 		<Key limehd:codes="-5" limehd:keyIcon="@drawable/sym_keyboard_delete_light" limehd:isModifier="true"
 			 limehd:keyEdgeFlags="right"	limehd:isRepeatable="true" />
 	</Row>
 
-		<Key limehd:codes="44" limehd:keyLabel=",\nㄓ"/>
+		<Key limehd:codes="44" limehd:keyLabel=","/>
 		<Key limehd:codes="46" 
-				limehd:keyLabel=".\nㄔ"
+				limehd:keyLabel="."
 				 limehd:popupKeyboard="@xml/popup_c_punctuation"   
 				limehd:keyWidth="10%p" />
-		<Key limehd:codes="47" limehd:keyLabel="/\nㄕ" />
-		<Key limehd:codes="45" limehd:keyLabel="-\nㄥ" />
-		<Key limehd:codes="61" limehd:keyLabel="=\nㄦ" />
+		<Key limehd:codes="47" limehd:keyLabel="/" />
+		<Key limehd:codes="45" limehd:keyLabel="-" />
+		<Key limehd:codes="61" limehd:keyLabel="=" />
 
 	<Row limehd:rowEdgeFlags="bottom">
 		<Key limehd:codes="-3"  limehd:keyIcon="@drawable/sym_keyboard_done_light" limehd:isModifier="true"
@@ -100,13 +100,13 @@
 				/>
 		<Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"
 				limehd:keyWidth="15%p" limehd:isRepeatable="true" />
-		<Key limehd:codes="60" limehd:keyLabel="&lt;\nㄓ" limehd:keyWidth="10%p" />
-		<Key limehd:codes="62" limehd:keyLabel="&gt;\nㄔ" 
+		<Key limehd:codes="60" limehd:keyLabel="&lt;" limehd:keyWidth="10%p" />
+		<Key limehd:codes="62" limehd:keyLabel="&gt;" 
 								 limehd:popupKeyboard="@xml/popup_punctuation"  
 								limehd:keyWidth="10%p" />
-		<Key limehd:codes="63" limehd:keyLabel="\?\nㄕ" limehd:keyWidth="10%p" />
-		<Key limehd:codes="95" limehd:keyLabel="_\nㄥ" />
-		<Key limehd:codes="43" limehd:keyLabel="+\nㄦ" />
+		<Key limehd:codes="63" limehd:keyLabel="\?" limehd:keyWidth="10%p" />
+		<Key limehd:codes="95" limehd:keyLabel="_" />
+		<Key limehd:codes="43" limehd:keyLabel="+" />
 		<Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true"
 				limehd:keyEdgeFlags="right" />
 	</Row>

--- a/LimeStudio/app/src/main/res/xml/lime_ez_shift.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_ez_shift.xml
@@ -33,17 +33,17 @@
     
    
     <Row>
-      	<Key limehd:codes="33" limehd:keyLabel="!儿\n|" 
+      	<Key limehd:codes="33" limehd:keyLabel="!" 
 			 limehd:keyEdgeFlags="left" />
-		<Key limehd:codes="64" limehd:keyLabel="\@\n車" />
-		<Key limehd:codes="35" limehd:keyLabel="\#\n糸" />
-		<Key limehd:codes="36" limehd:keyLabel="$\n言" />
-		<Key limehd:codes="37" limehd:keyLabel="%\n貝" />
-		<Key limehd:codes="94" limehd:keyLabel="^\n雨" />
-		<Key limehd:codes="38" limehd:keyLabel="&amp;\nㄇ" />
-		<Key limehd:codes="42" limehd:keyLabel="*\n八" />
-		<Key limehd:codes="40" limehd:keyLabel="(\n耳" />
-		<Key limehd:codes="41" limehd:keyLabel=")\n鳥" limehd:keyEdgeFlags="right" />
+		<Key limehd:codes="64" limehd:keyLabel="\@" />
+		<Key limehd:codes="35" limehd:keyLabel="\#" />
+		<Key limehd:codes="36" limehd:keyLabel="$" />
+		<Key limehd:codes="37" limehd:keyLabel="%" />
+		<Key limehd:codes="94" limehd:keyLabel="^" />
+		<Key limehd:codes="38" limehd:keyLabel="&amp;" />
+		<Key limehd:codes="42" limehd:keyLabel="*" />
+		<Key limehd:codes="40" limehd:keyLabel="(" />
+		<Key limehd:codes="41" limehd:keyLabel=")" limehd:keyEdgeFlags="right" />
     </Row>
     
     <Row>
@@ -70,7 +70,7 @@
         <Key limehd:codes="74" limehd:keyLabel="J\n十"/>
         <Key limehd:codes="75" limehd:keyLabel="K\n大"/>
         <Key limehd:codes="76" limehd:keyLabel="L\n中" />
-        <Key limehd:codes="58"  limehd:keyLabel=":\n寸" limehd:keyEdgeFlags="right"/>
+        <Key limehd:codes="58"  limehd:keyLabel=":" limehd:keyEdgeFlags="right"/>
     </Row>
     
          
@@ -93,11 +93,11 @@
         <Key limehd:codes="-3"  limehd:keyIcon="@drawable/sym_keyboard_done_light" limehd:isModifier="true" limehd:keyWidth="15%p" limehd:keyEdgeFlags="left"/>
         <Key limehd:codes="-9" limehd:keyLabel="EN"  limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"  limehd:keyWidth="25%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="60" limehd:keyLabel="&lt;\n／" limehd:keyWidth="10%p" />
-		<Key limehd:codes="62" limehd:keyLabel="&gt;\n＼"								 
+        <Key limehd:codes="60" limehd:keyLabel="&lt;" limehd:keyWidth="10%p" />
+		<Key limehd:codes="62" limehd:keyLabel="&gt;"								 
 								limehd:popupKeyboard="@xml/popup_punctuation"  
 								limehd:keyWidth="10%p" />
-		<Key limehd:codes="63" limehd:keyLabel="\?\nㄥ" limehd:keyWidth="10%p" />
+		<Key limehd:codes="63" limehd:keyLabel="\?" limehd:keyWidth="10%p" />
         <Key limehd:codes="-2" limehd:keyLabel="123" limehd:isModifier="true"/>
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true" limehd:keyWidth="10%p" limehd:keyEdgeFlags="right"/>
     </Row>

--- a/LimeStudio/app/src/main/res/xml/lime_phonetic_shift.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_phonetic_shift.xml
@@ -33,16 +33,16 @@
 
     
     <Row>
-    	<Key limehd:codes="33" limehd:keyLabel="!\nㄅ"  limehd:keyEdgeFlags="left" />
-		<Key limehd:codes="64" limehd:keyLabel="\@\nㄉ" />
-		<Key limehd:codes="35" limehd:keyLabel="\#\nˇ" />
-		<Key limehd:codes="36" limehd:keyLabel="$\nˋ" />
-		<Key limehd:codes="37" limehd:keyLabel="%\nㄓ" />
-		<Key limehd:codes="94" limehd:keyLabel="^\nˊ" />
-		<Key limehd:codes="38" limehd:keyLabel="&amp;\n˙" />
-		<Key limehd:codes="42" limehd:keyLabel="*\nㄚ" />
-		<Key limehd:codes="40" limehd:keyLabel="(\nㄞ" />
-		<Key limehd:codes="41" limehd:keyLabel=")\nㄢ" limehd:keyEdgeFlags="right" />
+    	<Key limehd:codes="33" limehd:keyLabel="!"  limehd:keyEdgeFlags="left" />
+		<Key limehd:codes="64" limehd:keyLabel="\@" />
+		<Key limehd:codes="35" limehd:keyLabel="\#" />
+		<Key limehd:codes="36" limehd:keyLabel="$" />
+		<Key limehd:codes="37" limehd:keyLabel="%" />
+		<Key limehd:codes="94" limehd:keyLabel="^" />
+		<Key limehd:codes="38" limehd:keyLabel="&amp;" />
+		<Key limehd:codes="42" limehd:keyLabel="*" />
+		<Key limehd:codes="40" limehd:keyLabel="(" />
+		<Key limehd:codes="41" limehd:keyLabel=")" limehd:keyEdgeFlags="right" />
 		
     </Row>
     
@@ -69,7 +69,7 @@
         <Key limehd:codes="74" limehd:keyLabel="J\nㄨ"/>
         <Key limehd:codes="75" limehd:keyLabel="K\nㄜ"/>
         <Key limehd:codes="76" limehd:keyLabel="L\nㄠ"/>
-        <Key limehd:codes="58" limehd:keyLabel=":\nㄤ" limehd:keyEdgeFlags="right"/>
+        <Key limehd:codes="58" limehd:keyLabel=":" limehd:keyEdgeFlags="right"/>
     </Row>
     
    <Row>
@@ -80,9 +80,9 @@
         <Key limehd:codes="66" limehd:keyLabel="B\nㄖ" />
         <Key limehd:codes="78" limehd:keyLabel="N\nㄙ" />
         <Key limehd:codes="77" limehd:keyLabel="M\nㄩ" />
-        <Key limehd:codes="60" limehd:keyLabel="&lt;\nㄝ" />
-        <Key limehd:codes="62" limehd:keyLabel="&gt;\nㄡ" limehd:popupKeyboard="@xml/popup_punctuation"/>
-        <Key limehd:codes="63" limehd:keyLabel="\?\nㄥ" limehd:keyEdgeFlags="right"/>
+        <Key limehd:codes="60" limehd:keyLabel="&lt;" />
+        <Key limehd:codes="62" limehd:keyLabel="&gt;" limehd:popupKeyboard="@xml/popup_punctuation"/>
+        <Key limehd:codes="63" limehd:keyLabel="\?" limehd:keyEdgeFlags="right"/>
     </Row>    
     
     
@@ -95,7 +95,7 @@
 			limehd:popupKeyboard="@xml/popup_symbol_mode"  
 			limehd:isModifier="true"  />
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"  limehd:keyWidth="20%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="95" limehd:keyLabel="_\nㄦ"/>
+        <Key limehd:codes="95" limehd:keyLabel="_"/>
         <Key limehd:codes="-5" limehd:keyWidth="15%p" limehd:keyIcon="@drawable/sym_keyboard_delete_light" limehd:isModifier="true" limehd:isRepeatable="true"/>
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true" limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>
     </Row>

--- a/docs/#91_ISSUE.md
+++ b/docs/#91_ISSUE.md
@@ -17,9 +17,17 @@ Evidence: the issue includes a screenshot showing the `vmi` duplicate-code candi
 
 ## Current classification
 
-Plausible Android bug in `.cin` import / candidate ordering.
+Android bug in `.cin` import / candidate ordering.
 
 This is distinct from a product request for learning-based sorting: the reporter explicitly says the selection sorting preference is disabled, so same-code candidates should remain stable in source-file order unless another enabled feature intentionally reorders them.
+
+## Android implementation status
+
+Implemented in Android source on branch `android-next-release-all-fixes`.
+
+- Added regression coverage for duplicate-code `.cin` source order when selection sorting is disabled.
+- Updated Android candidate query ordering so score/base-score priority applies only when sorting is enabled; sorting-disabled same-code exact matches fall back to `_id ASC` / source insertion order.
+- Status after source implementation: awaiting full branch verification, review APK build, and reporter retest with 哈哈倉頡 `vmi`.
 
 ## Relevant code observed
 
@@ -58,7 +66,7 @@ A second area to confirm is whether 哈哈倉頡 is being imported into `custom`
 
 ## Follow-up questions
 
-Current report is probably sufficient to start investigation. If a first fix cannot reproduce with a minimal fixture, ask the reporter for:
+Current report was sufficient for the Android source fix. If reporter retest still fails in a review APK, ask for:
 
 - the exact 哈哈倉頡 `.cin` source file/version they imported;
 - whether the table was imported into a clean custom IM or over an existing table with learned records;

--- a/docs/#93_ISSUE.md
+++ b/docs/#93_ISSUE.md
@@ -15,6 +15,15 @@ Follow-up maintainer context also adds an Android scope: Android can import a `.
 - Live assignee: `jrywu`
 - Public acknowledgement: maintainer follow-up posted in https://github.com/lime-ime/limeime/issues/93#issuecomment-4556745511 to record Android metadata parsing scope.
 
+## Android implementation status
+
+Implemented in Android source on branch `android-next-release-all-fixes`.
+
+- Android `.lime` delimiter detection now ignores blank/comment lines so leading Array10-style `#` comments do not skew parsing.
+- Android `.lime` parsing skips `#` comment lines and persists `@cname@` / `@version@`.
+- Regression coverage imports an Array10-style `.lime` fixture with comments and verifies metadata persistence.
+- iOS installed-list registration remains a separate pending #93 fix. Keep iOS behavior aligned with Android metadata/comment semantics where applicable, but do not mark iOS complete from this Android branch.
+
 ## Code paths inspected
 
 - `LimeIME-iOS/Shared/Database/LimeDB.swift`
@@ -41,7 +50,7 @@ The iOS text-import path writes mappings and metadata for the imported table wit
 
 ### Android metadata parsing / persistence
 
-The Android failure path is still pending code inspection. The current suspected failure is separate from the iOS installed-list registration path: successful `.lime` import may not correctly parse or persist `@version@` / `@cname@`, potentially related to whether `#`-prefixed lines are skipped like `.cin` comments. The intended `.lime` behavior for `#` lines should be documented before tests lock in the expected parser behavior.
+The Android failure path was separate from the iOS installed-list registration path: successful `.lime` import could miss `@version@` / `@cname@` when `#`-prefixed lines affected parsing/delimiter detection. The Android branch now documents and tests `.lime` `#` comments as skipped parser comments.
 
 ## Proposed fix / investigation plan
 
@@ -60,7 +69,7 @@ The Android failure path is still pending code inspection. The current suspected
 3. Revisit `seedCustomIM()` / `registerIM(...)` early-return behavior so metadata-only rows do not prevent creation of the required seed/keyboard registration. Registration may need to run before metadata writes, use a narrower existing-row check, or merge the missing keyboard/seed data into existing rows.
 4. Consider updating `getAllImConfigs()` so metadata keys such as `source`, `amount`, and `import` are not mistaken for seed rows, while still supporting legacy/imported rows.
 5. After registration changes, rebuild/sync keyboard state as needed so the keyboard extension can see the imported IM.
-6. For Android, add/verify regression coverage using an Array10-style `.lime` file that includes several `#` comment lines before/around `@version@` and `@cname@`; document whether the `.lime` parser is expected to treat `#` as a comment marker, then confirm import success, cname/version persistence, and exported/displayed metadata.
+6. Android source implementation is complete in `android-next-release-all-fixes`; remaining #93 work is iOS installed-list registration plus final Android APK verification.
 
 ## Verification plan
 

--- a/docs/#94_ISSUE.md
+++ b/docs/#94_ISSUE.md
@@ -66,6 +66,16 @@ Root cause for this reproduced path is now sufficiently identified:
 
 This does **not** mean the entire backup implementation is generally broken. Existing tests and #88 still show backup/restore can work in other paths. #94 is specifically a missing-journal/error-propagation bug in the Android backup path.
 
+## Android implementation status
+
+Implemented in Android source on branch `android-next-release-all-fixes`.
+
+- This branch supersedes/recreates the relevant PR #97 behavior instead of depending on a separate PR merge.
+- `lime.db-journal` is included only when it exists, because it is a transient SQLite rollback journal.
+- Backup failures propagate to callers instead of allowing UI success status after ZIP/copy failure.
+- Regression coverage verifies backup succeeds without `lime.db-journal` and propagates output-write failure.
+- Status after source implementation: awaiting full branch verification, review APK build, and reporter retest for non-empty ZIP creation/restoration.
+
 ## Code paths to fix
 
 ### Backup implementation
@@ -137,4 +147,4 @@ Developer-side checks for the fix:
 
 A concise public reply was posted after the logcat attachment to confirm that the log identified the likely failure path and that no more logs are needed before a fix.
 
-Do not ask the reporter for another generic APK retest until a newer APK contains a targeted #94 backup fix.
+Do not ask the reporter for another generic APK retest until a newer APK contains this targeted #94 backup fix.

--- a/docs/#96_ISSUE.md
+++ b/docs/#96_ISSUE.md
@@ -1,4 +1,4 @@
-# #96 — Chinese keyboard comma/period punctuation and end-key behavior
+# #96 — Table IM Lime end-key behavior
 
 ## Live issue state
 
@@ -11,13 +11,30 @@
 
 ## Problem statement
 
-The discussion has two related but separate scopes:
+Implement generic, opt-in Lime end-key behavior for table IMs without changing candidate ordering or adding punctuation-specific handling.
 
-1. **Bug scope — direct punctuation mappings should be selectable correctly.**
-   When an IM table defines direct mappings such as `, = ，` and `. = 。`, LIME should highlight/select the first direct match (`，` / `。`) instead of leaving the composing-code record (`，` candidate path represented by the typed code) as the effective first selection. Simply swapping `,` with `，` in the candidate order is not the right model because the first row is generally a composing-code record, not an ordinary candidate.
+- Android keeps conventional `.cin %endkey` / `.lime @endkey@` as compatibility metadata only.
+- LimeIME runtime commit behavior uses Lime-specific metadata: `.cin %limeendkey ...` and `.lime @limeendkey@ |...`.
+- Configured Lime end-key characters should finish the current composition and commit through the same candidate-confirm semantics as existing confirmation keys.
+- Tables without Lime end-key metadata remain unchanged. Keys such as `,` and `.` may still be ordinary roots/composing codes.
+- Search/candidate construction must not special-case Chinese punctuation for this feature.
 
-2. **Feature scope — `%endkey ,.` / `@endkey@` support.**
-   Some table IMs expect `,` and `.` to finish composition directly when the table also maps them to `，` and `。`. This requires explicit end-key metadata, for example `.cin` `%endkey ,.` and a future `.lime` `@endkey@` equivalent. Tables that use `,` / `.` as roots, such as 行列30 or 大易, must not opt into those end keys because direct punctuation output would break root/short-phrase compatibility.
+## Android implementation status
+
+Implemented in Android source on branch `android-next-release-all-fixes`.
+
+Feature scope:
+
+- Android imports and persists `.cin %endkey` / `.lime @endkey@` as conventional compatibility metadata.
+- Android imports and persists `.cin %limeendkey` / `.lime @limeendkey@` as Lime runtime commit metadata.
+- LIME Settings IM detail shows an editable `limeendkey` metadata row labeled `結束鍵`.
+- Android runtime treats the active table's configured Lime end-key characters as opt-in commit triggers.
+- Tables without Lime end-key metadata remain unchanged; roots are not globally converted or reordered.
+
+Official table-data scope:
+
+- This branch implements engine/settings support only. Packaged Android table data is represented by database resources rather than editable `.cin`/`.lime` source tables in this branch, so official table metadata/mapping updates are deferred to separate table-data release coordination.
+- iOS/table-format parity remains pending and should align with the Android implementation when addressed.
 
 ## Reporter and maintainer clarifications
 
@@ -28,7 +45,7 @@ The discussion has two related but separate scopes:
   - 行列30 and 大易 use `,` / `.` as roots, so they should not directly output punctuation.
   - 行列10, 嘸蝦米, and 倉頡 are closer to direct punctuation output expectations.
   - A practical distinction is whether `,` / `.` are defined as roots in the table.
-- Maintainer clarification posted in https://github.com/lime-ime/limeime/issues/96#issuecomment-4556916179 records that direct-match highlighting is a bug, while `%endkey ,.` / `@endkey@` is the compatible feature mechanism.
+- Android now separates conventional `%endkey` / `@endkey@` metadata from the Lime-specific `%limeendkey` / `@limeendkey@` runtime feature mechanism to avoid conflict with historical CIN semantics.
 
 ## Source evidence inspected
 
@@ -55,48 +72,38 @@ Relevant code area on current `master`:
 
 - `LIMEService.java` lines 1664–1678: `commitTyped(...)` requires a selected candidate and commits its `word`.
 
-## Likely root cause
-
-The direct-match bug is likely caused by the inspected candidate-list construction path placing the composing-code record before exact table mappings, including punctuation-key direct matches. For codes such as `,` or `.`, if the DB returns exact mappings to `，` or `。`, the selection/highlight logic still sees the composing-code record first.
-
-This should not be fixed by globally swapping punctuation candidates. The fix should distinguish ordinary composing-code fallback from exact direct mappings that should be selected first for that table.
-
 ## Proposed solution / investigation plan
 
-1. Add or adjust candidate-order logic so exact direct matches for `,` / `.` can be highlighted/selected ahead of the composing-code fallback when the active table defines those mappings.
-2. Preserve compatibility for tables where `,` / `.` are roots or short-phrase codes. Do not globally force punctuation output.
-3. Add metadata parsing/runtime support for explicit end-key behavior:
-   - `.cin`: `%endkey ,.`
-   - `.lime`: `@endkey@` equivalent; for opt-in tables such as official 行列10, this likely also requires table-level punctuation mappings such as `,|，` and `.|。`.
-4. For tables with `,` / `.` as roots, do not put those keys in endkey metadata. Direct `，` / `。` output should remain unavailable unless the table explicitly opts in, so users' personal tables without `@endkey@` are not changed.
+1. Add metadata parsing/runtime support for explicit Lime end-key behavior:
+   - `.cin`: `%limeendkey ...`
+   - `.lime`: `@limeendkey@` equivalent.
+2. Preserve conventional `%endkey` / `@endkey@` as imported/exported compatibility metadata.
+3. Keep candidate-list ordering unchanged. The composing-code fallback remains item 0.
+4. For tables with any potential end-key character as a root, do not put that character in Lime end-key metadata unless the table intentionally opts in.
 
 ## Verification plan
 
-- Android table with direct mappings only:
-  - Add/import mappings `, = ，` and `. = 。`.
-  - Type `,` and `.`.
-  - Verify the first direct match `，` / `。` is highlighted/selected instead of the composing-code record.
 - Android table using `,` / `.` as roots:
   - Verify root input remains available and direct punctuation behavior is not forced.
-- `%endkey ,.` / `@endkey@` feature:
-  - Import a `.cin` with `%endkey ,.` plus punctuation mappings.
-  - Import a `.lime` equivalent once supported, including opt-in metadata and punctuation mappings such as `@endkey@ |,.`, `,|，`, and `.|。`.
-  - Verify pressing `,` / `.` commits according to the table metadata without requiring extra Space/Enter.
+- `%limeendkey ,.` / `@limeendkey@` feature:
+  - Import a `.cin` with `%limeendkey ;/`.
+  - Import a `.lime` equivalent with `@limeendkey@ |;/`.
+  - Verify pressing configured end-key characters commits according to table metadata without requiring extra Space/Enter.
 - Regression:
-  - Confirm existing custom `,` / `.` root/short-phrase mappings still work when endkey is not configured.
+  - Confirm existing custom `,` / `.` root/short-phrase mappings still work when Lime endkey is not configured.
 
 ## Platform impact analysis
 
 ### Android
 
-Confirmed relevant platform for #96. The inspected Android search/candidate path shows a plausible mechanism for the direct-match bug: composing-code `self` is inserted ahead of exact table mappings.
+Confirmed relevant platform for #96. Android runtime/settings/import support is implemented for Lime-specific end-key metadata without SearchServer candidate-order changes.
 
 ### iOS / table format
 
-No concrete iOS runtime evidence has been inspected for the same highlight behavior yet. The table-format feature request (`%endkey ,.` and `.lime @endkey@`) can affect both Android and iOS if both platforms import and honor the same table metadata. iOS parity should be assessed separately before claiming the Android candidate-order bug exists there.
+The Lime-specific table-format feature request (`%limeendkey ...` and `.lime @limeendkey@`) can affect both Android and iOS if both platforms import and honor the same table metadata. iOS parity should be assessed separately and aligned with Android later.
 
 ## Follow-up status
 
 - Public clarification posted: https://github.com/lime-ime/limeime/issues/96#issuecomment-4556916179
-- Current classification: mixed bug + enhancement/product work.
-- Next action: implement/fix Android direct-match candidate selection first, then design `%endkey ,.` / `.lime @endkey@` support without breaking tables that use `,` / `.` as roots.
+- Current classification: enhancement/product work for generic table IM end-key behavior.
+- Next action: include Android support in review APK; address iOS/table-data coordination later.

--- a/docs/#96_ISSUE.md
+++ b/docs/#96_ISSUE.md
@@ -15,7 +15,7 @@ Implement generic, opt-in Lime end-key behavior for table IMs without changing c
 
 - Android keeps conventional `.cin %endkey` / `.lime @endkey@` as compatibility metadata only.
 - LimeIME runtime commit behavior uses Lime-specific metadata: `.cin %limeendkey ...` and `.lime @limeendkey@ |...`.
-- Configured Lime end-key characters should finish the current composition and commit through the same candidate-confirm semantics as existing confirmation keys.
+- Configured Lime end-key characters should finish the current composition and commit through the same candidate-confirm semantics as existing confirmation keys, even if the asynchronous candidate strip has not yet marked candidates as shown.
 - Tables without Lime end-key metadata remain unchanged. Keys such as `,` and `.` may still be ordinary roots/composing codes.
 - Search/candidate construction must not special-case Chinese punctuation for this feature.
 
@@ -28,7 +28,7 @@ Feature scope:
 - Android imports and persists `.cin %endkey` / `.lime @endkey@` as conventional compatibility metadata.
 - Android imports and persists `.cin %limeendkey` / `.lime @limeendkey@` as Lime runtime commit metadata.
 - LIME Settings IM detail shows an editable `limeendkey` metadata row labeled `結束鍵`.
-- Android runtime treats the active table's configured Lime end-key characters as opt-in commit triggers.
+- Android runtime treats the active table's configured Lime end-key characters as opt-in commit triggers and resolves the current composing candidates when needed before committing.
 - Tables without Lime end-key metadata remain unchanged; roots are not globally converted or reordered.
 
 Official table-data scope:
@@ -91,6 +91,7 @@ Relevant code area on current `master`:
   - Verify pressing configured end-key characters commits according to table metadata without requiring extra Space/Enter.
 - Regression:
   - Confirm existing custom `,` / `.` root/short-phrase mappings still work when Lime endkey is not configured.
+  - Confirm endkey resolves candidates for the exact current composing buffer and does not consume a stale prefix candidate from an older candidate strip update.
 
 ## Platform impact analysis
 

--- a/docs/ANDROID_IPHONE_KEYBOARD.md
+++ b/docs/ANDROID_IPHONE_KEYBOARD.md
@@ -157,9 +157,11 @@ Shared Android/iOS codes:
 
 Android and iOS both expose shift as `code = -1`, but the runtime touch model differs. The desired user-visible state machine is the same:
 
-- Tap and release shift once: enter one-shot shift. The shift key shows active/blue, the shifted keyboard is visible, the next character is shifted, then shift returns to off.
+- Tap and release shift once from unshifted: enter one-shot shift. The shift key shows active/blue, the shifted keyboard is visible, the next character is shifted, then shift returns to off.
+- Tap and release shift once from shifted: return to unshifted. Repeated single taps must only toggle shifted/unshifted and must not promote into caps lock.
+- Double-tap shift: enter caps lock. Shifted output continues until shift is tapped again.
+- Tap and release shift once from caps lock: exit caps lock and return to unshifted.
 - Press and hold shift: show shifted keys while the physical shift touch is down. Every tapped key while shift is held outputs shifted content. Releasing shift returns the key state and keyboard view to unshifted.
-- Tap shift twice: enter caps lock. Shifted output continues until shift is tapped again, which returns to unshifted.
 
 iOS implementation notes:
 
@@ -167,7 +169,7 @@ iOS implementation notes:
 - Do not rebuild/remove the pressed shift button while the shift touch is still down. `KeyboardView.previewLayout(_:)` restyles the existing buttons with the shifted layout so UIKit can still deliver the original shift release event.
 - A held shift reset happens on release after shift modified at least one character. A one-shot shift reset happens after the first character when shift is no longer physically held.
 - iPad dual-label keys use `longPressCode` as their shifted output while a physical shift hold is active.
-- Repeated shift press events during one physical hold are ignored so they do not promote the state into caps lock.
+- Repeated shift press events during one physical hold are ignored so they do not promote the state into caps lock. Caps lock requires an actual double-tap gesture, not the old three-state repeated-single-tap cycle.
 
 Android-only or Android-specific codes:
 

--- a/docs/ANDROID_NR_0530.md
+++ b/docs/ANDROID_NR_0530.md
@@ -2,9 +2,9 @@
 
 > **For Hermes:** Use `subagent-driven-development` to implement this plan task-by-task. Keep this as one Android next-release feature/fix train, but use small commits and review gates so regressions are isolated.
 
-**Goal:** Finish the confirmed Android bug fixes and confirmed Android new-feature backlog in one coordinated next-release branch/APK.
+**Goal:** Finish the confirmed Android bug fixes, confirmed Android new-feature backlog, and Android side of the new Shift-key behavior request in one coordinated next-release branch/APK.
 
-**Architecture:** Treat import parsing, candidate ordering, backup/restore, keyboard theming, and keyboard-layout resources as separate vertical slices with their own regression tests, then run a full Android compile/test/release-candidate verification pass before building the APK. Do not expand into unconfirmed #90 button-layout customization scope; only implement the confirmed Android backlog items.
+**Architecture:** Treat import parsing, candidate ordering, backup/restore, keyboard theming, Shift-key state handling, and keyboard-layout resources as separate vertical slices with their own regression tests, then run a full Android compile/test/release-candidate verification pass before building the APK. Do not expand into unconfirmed #90 button-layout customization scope; only implement the confirmed Android backlog items.
 
 **Tech Stack:** Android Java, SQLite, XML keyboard resources, Android instrumentation tests (`connectedDebugAndroidTest`), Gradle under `LimeStudio/`.
 
@@ -24,12 +24,17 @@
 - #96 — support explicit Lime table end-key behavior for `.cin %limeendkey` and `.lime @limeendkey@` on Android, without breaking tables where `,` / `.` are roots.
 - #96 — audit bundled/official Android table assets, if any, and either add opt-in Lime end-key metadata plus direct punctuation mappings for the tables Jeremy confirms or document that table-data release coordination is separate from the engine change.
 - #99 — shifted symbol-keyboard layouts should remove Chinese IM root sub-labels only from non-alphabet shifted keys such as `!@#...`; shifted capital-letter keys may keep root sub-labels because `A-Z` can still be valid roots.
+- Unfiled — Android side of the cross-platform Shift-key behavior change: single tap toggles only shifted/unshifted, double tap enters Shift Lock, and single tap exits Shift Lock to unshifted.
 
 ### Explicitly out of scope for this plan
 
 - #90 button visibility/repositioning (`中英／123`, Emoji, voice) and old-style layout customization; this remains product-evaluation scope.
-- iOS #86/#93/#96/#99 implementation. Mention parity in docs/backlog only if Android changes define shared table-format semantics.
+- iOS #86/#93/#96/#99 implementation. For the unfiled Shift-key behavior request, this plan covers Android implementation and docs/parity tracking only; implement iOS in the matching iOS work item unless Jeremy explicitly expands this Android APK branch.
 - Public GitHub issue replies until a test APK exists and Jeremy approves wording.
+
+### Visual verification requirement
+
+Any task that changes visible Android UI, keyboard layout, keyboard state indicators, candidate highlighting/selection, settings screens, dialogs, themes, colors, labels, or other user-visible presentation must run `android-visual-verify` with Computer Use after build/install. Capture and retain screenshot/inspection notes with the task or APK verification notes.
 
 ---
 
@@ -206,6 +211,7 @@ Run only `LimeDBTest` first and confirm this test fails before Task 4.
 - #91 test passes.
 - Existing `LimeDBTest` ordering/search tests pass.
 - Manual test with 哈哈倉頡 `vmi`: expected `狀`, `绒`, `戕` when selection sorting is disabled.
+- Because this affects candidate ordering in the visible candidate strip, run `android-visual-verify` with Computer Use and inspect the candidate order screenshot before signing off.
 
 **Commit:**
 
@@ -360,6 +366,7 @@ public void updateIMMetadataFieldAllowsLimeEndkey() {
 
 **Manual acceptance examples:**
 
+- Required visual verification: run `android-visual-verify` with Computer Use and inspect screenshots for the IM detail row, edit dialog, saved value, and cleared-value `-` state.
 - LIME Settings → 輸入法 → IM detail shows editable rows for 名稱, 版本, and Endkey/結束鍵.
 - Tapping Endkey opens an edit dialog prefilled with the current `limeendkey` metadata value such as `;/`.
 - Saving `;/` persists `getImConfig(table, "limeendkey") == ";/"`; reopening the screen shows `;/`.
@@ -488,6 +495,7 @@ git commit -m "feat(android): support table end-key commit trigger"
 
 **Manual verification:**
 
+- Required visual verification: run `android-visual-verify` with Computer Use after building/installing the APK. Capture/inspect screenshots for the keyboard and LIME Settings app before signing off on this task.
 - Android 12+ device/emulator: set keyboard theme to `系統設定`, change wallpaper/accent, restart/reopen keyboard if needed, confirm LIME highlights/selection accents follow the system accent while light/dark still follows system theme.
 - Android 12+ device/emulator: open LIME Settings app and confirm navigation selected state, switches, buttons, tabs, and text fields use the system accent family.
 - Android 11 or older emulator: confirm no crash and existing fallback accents remain acceptable.
@@ -544,10 +552,11 @@ The helper should inspect each `<Key>` where `limehd:codes` emits a non-alphabet
 
 **Manual verification:**
 
+- Required visual verification: run `android-visual-verify` with Computer Use for at least one edited shifted IM layout, and inspect screenshots to confirm symbol labels changed without damaging alphabet-root labels.
 - 注音 + Shift: symbol keys such as `!@#$...` no longer show 注音 root sub-labels.
 - Shifted capital-letter keys still show their root sub-labels.
 - The same symbol keys still input symbols exactly as before.
-- Shift/caps-lock behavior and candidate lookup are unchanged.
+- This #99 task does not change Shift/caps-lock behavior or candidate lookup; Task 11 owns the separate Shift gesture behavior change.
 
 **Commit:**
 
@@ -559,7 +568,81 @@ git commit -m "feat(android): remove root labels from shifted symbol keys"
 
 ---
 
-## Task 11: Documentation/backlog synchronization
+## Task 11: Simplify Android Shift key cycle and use double-tap for Shift Lock
+
+**Objective:** Change Android Shift handling so repeated single taps no longer cycle through Shift Lock. A single Shift tap toggles between shifted and unshifted. A double tap enters Shift Lock. While Shift Lock is active, a single Shift tap exits Shift Lock and returns to unshifted.
+
+**Files:**
+- Inspect/modify: `LimeStudio/app/src/main/java/net/toload/main/hd/keyboard/PointerTracker.java` for multi-tap/double-tap dispatch behavior.
+- Inspect/modify: `LimeStudio/app/src/main/java/net/toload/main/hd/keyboard/LIMEKeyboardBaseView.java` for keyboard view Shift/touch state callbacks if the double-tap signal is handled there.
+- Inspect/modify: `LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java` for final `KEYCODE_SHIFT` state transitions.
+- Inspect/modify: `LimeStudio/app/src/main/java/net/toload/main/hd/keyboard/LIMEBaseKeyboard.java` / `LimeKeyboard.java` only if the current Shift Lock visual state is tied directly to the old three-state single-tap cycle.
+- Test: `LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java` or the closest existing Android keyboard/input test class.
+
+**Behavior requirements:**
+
+1. Starting unshifted, one Shift tap enters shifted one-shot state and shows the existing shifted keyboard/active Shift indicator.
+2. Starting shifted, one Shift tap returns to unshifted. It must not enter Shift Lock.
+3. Starting unshifted or shifted, a double tap on Shift enters Shift Lock and shows the existing Shift Lock/caps visual indicator.
+4. Starting Shift Lock, one Shift tap exits Shift Lock and returns to unshifted.
+5. Existing held-Shift behavior, shifted layouts, caps/lock visual indicators, and normal character output semantics must remain unchanged except for the tap gesture/state transition.
+6. Do not change #99 shifted-symbol label edits as part of this task; this task owns only Shift gesture/state behavior.
+
+**Test requirements:**
+
+Add focused state-machine coverage where the existing Android test harness can drive Shift events:
+
+```java
+@Test
+public void singleShiftTapTogglesBetweenShiftedAndUnshiftedOnly() {
+    pressShift();
+    assertShifted();
+    assertNotShiftLocked();
+
+    pressShift();
+    assertUnshifted();
+    assertNotShiftLocked();
+
+    pressShift();
+    assertShifted();
+    assertNotShiftLocked();
+}
+
+@Test
+public void doubleShiftTapEntersShiftLockAndSingleTapUnlocks() {
+    doubleTapShift();
+    assertShiftLocked();
+
+    pressShift();
+    assertUnshifted();
+    assertNotShiftLocked();
+}
+```
+
+If the current test surface cannot synthesize real double-tap timing, extract the Shift transition logic behind a package-visible helper or controller that can be tested directly, then keep one manual APK smoke test for the Android touch/timing path.
+
+**Manual verification:**
+
+- Required visual verification: run `android-visual-verify` with Computer Use and inspect screenshots for unshifted, shifted, and Shift Lock visual states.
+- Android IM keyboard from unshifted: tap Shift once, confirm shifted keyboard; tap Shift again, confirm unshifted and not locked.
+- Android IM keyboard from unshifted: double-tap Shift, confirm Shift Lock visual state and repeated shifted output.
+- Android IM keyboard from Shift Lock: tap Shift once, confirm unshifted.
+- Android English keyboard and at least one Chinese IM keyboard both follow the same transitions.
+- Long/held Shift still previews shifted output while held and returns to the correct non-locked state on release.
+
+**Commit:**
+
+```bash
+git add LimeStudio/app/src/main/java/net/toload/main/hd/keyboard/PointerTracker.java \
+        LimeStudio/app/src/main/java/net/toload/main/hd/keyboard/LIMEKeyboardBaseView.java \
+        LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java \
+        LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
+git commit -m "feat(android): use double tap for shift lock"
+```
+
+---
+
+## Task 12: Documentation/backlog synchronization
 
 **Objective:** Keep public repo docs aligned with the implementation without exposing local automation state.
 
@@ -569,7 +652,8 @@ git commit -m "feat(android): remove root labels from shifted symbol keys"
 - Modify: `docs/#93_ISSUE.md`
 - Modify: `docs/#94_ISSUE.md`
 - Modify: `docs/#96_ISSUE.md`
-- Modify/create: `docs/ANDROID_NR.md` (this plan)
+- Modify: `docs/ANDROID_NR_0530.md` (this plan)
+- Modify: `docs/ANDROID_IPHONE_KEYBOARD.md` after Shift behavior implementation, documenting the final Android behavior and the iOS parity status.
 - Modify: `docs/CIN_LIME_SPEC.md` if `%endkey` / `@endkey@` semantics changed
 - Modify: `docs/ANDROID_THEME.md` if dynamic-color architecture is implemented
 
@@ -580,21 +664,24 @@ git commit -m "feat(android): remove root labels from shifted symbol keys"
 3. For #96, keep bug and feature scopes separate:
    - direct mapping selection fix;
    - opt-in end-key feature.
-4. For #90, state only dynamic-color/accent support was implemented; leave button/layout customization out of backlog until confirmed.
-5. Do not update local-only `github-mutable-state.md` in this repo commit; that lives outside the repo and should be updated separately after the APK/release state changes.
-6. For #96 end-key support, document whether bundled Android table assets existed in the repo and whether any official table metadata/mapping updates were included or deferred for separate table-data coordination.
+4. When updating `docs/BACKLOG.md` for a fix/feature that impacts both Android and iOS, mark only the Android side complete for this Android branch. Add a note that iOS remains to be addressed later and should stay aligned with the Android implementation.
+5. For #90, state only dynamic-color/accent support was implemented; leave button/layout customization out of backlog until confirmed.
+6. Do not update local-only `github-mutable-state.md` in this repo commit; that lives outside the repo and should be updated separately after the APK/release state changes.
+7. For #96 end-key support, document whether bundled Android table assets existed in the repo and whether any official table metadata/mapping updates were included or deferred for separate table-data coordination.
+8. For the unfiled Shift-key behavior request, update `docs/ANDROID_IPHONE_KEYBOARD.md` after the Android implementation is finished so the shared keyboard reference says: single tap toggles shifted/unshifted, double tap enters Shift Lock, and single tap exits Shift Lock. In `docs/BACKLOG.md`, mark only Android complete for this branch and state that iOS should be addressed later and aligned with the Android implementation.
 
 **Commit:**
 
 ```bash
 git add docs/BACKLOG.md docs/#91_ISSUE.md docs/#93_ISSUE.md docs/#94_ISSUE.md \
-        docs/#96_ISSUE.md docs/ANDROID_NR.md docs/CIN_LIME_SPEC.md docs/ANDROID_THEME.md
+        docs/#96_ISSUE.md docs/ANDROID_NR_0530.md docs/ANDROID_IPHONE_KEYBOARD.md \
+        docs/CIN_LIME_SPEC.md docs/ANDROID_THEME.md
 git commit -m "docs: update Android next-release plan and issue status"
 ```
 
 ---
 
-## Task 12: Full Android verification pass
+## Task 13: Full Android verification pass
 
 **Objective:** Prove the branch is ready for Jeremy review and APK build.
 
@@ -616,6 +703,8 @@ ANDROID_HOME=$HOME/Android/Sdk ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew :app
 Expected: all connected Android tests pass. If a device is unavailable, record that as the only blocked verification item.
 
 **Manual smoke tests:**
+
+For all visual-related smoke tests below, run `android-visual-verify` with Computer Use and retain the screenshot/inspection notes with the APK verification notes.
 
 1. Backup:
    - create backup;
@@ -639,11 +728,16 @@ Expected: all connected Android tests pass. If a device is unavailable, record t
 7. Shifted symbol labels:
    - shifted symbol keys such as `!@#$...` no longer show Chinese IM root sub-labels;
    - shifted capital-letter keys still keep useful root sub-labels;
-   - Shift/caps-lock behavior and candidate lookup are unchanged.
+   - candidate lookup is unchanged by the label-only edits.
+8. Shift key behavior:
+   - single Shift taps toggle shifted/unshifted only;
+   - double-tap Shift enters Shift Lock;
+   - single Shift tap exits Shift Lock to unshifted;
+   - held Shift behavior still works.
 
 ---
 
-## Task 13: Build review APK and prepare retest notes
+## Task 14: Build review APK and prepare retest notes
 
 **Objective:** Produce a single Android APK for Jeremy review and later reporter retest.
 
@@ -662,7 +756,8 @@ Expected: release APK produced under `LimeStudio/app/build/outputs/apk/release/`
 - #94: ask reporter to retest non-empty backup creation and restore.
 - #96: ask reporters to retest direct punctuation mappings and, if they have an opt-in endkey table, direct comma/period commit.
 - #90: describe as new optional dynamic/accent theme behavior, not a bug retest request.
-- #99: describe the shifted-symbol-label UI clarification; no retest request for input behavior because Shift/Caps Lock behavior is unchanged by design.
+- #99: describe the shifted-symbol-label UI clarification; keep any Shift/Caps Lock input retest under the separate unfiled Shift behavior item.
+- Unfiled Shift behavior: ask Jeremy to retest single-tap toggle, double-tap Shift Lock, and single-tap unlock on Android; note iOS parity status separately if iOS has not yet been updated.
 - #93 is maintainer-created; no community retest needed unless Jeremy asks.
 
 ---
@@ -674,6 +769,6 @@ Expected: release APK produced under `LimeStudio/app/build/outputs/apk/release/`
 - [ ] Tests compile and targeted regression tests pass.
 - [ ] Connected Android tests run, or lack of device/emulator is explicitly documented.
 - [ ] Manual APK smoke tests are recorded.
-- [ ] `docs/BACKLOG.md` and issue docs match branch state.
+- [ ] `docs/BACKLOG.md`, `docs/ANDROID_IPHONE_KEYBOARD.md`, and issue docs match branch state.
 - [ ] No local-only automation state is committed into the repo.
 - [ ] Jeremy reviews before merge/release/public replies.

--- a/docs/ANDROID_NR_0530.md
+++ b/docs/ANDROID_NR_0530.md
@@ -376,7 +376,7 @@ public void updateIMMetadataFieldAllowsLimeEndkey() {
 
 ## Task 8: Implement Android end-key runtime behavior
 
-**Objective:** Implement `limeendkey` as a general per-table commit trigger. When the user presses **any key in the active table's end-key list** while composing, LIME should end composition immediately and commit the currently highlighted candidate item, matching the existing confirm behavior for Space and Enter. This is not a comma/period-only feature.
+**Objective:** Implement `limeendkey` as a general per-table commit trigger. When the user presses **any key in the active table's end-key list** while composing, LIME should end composition immediately and commit the current candidate selection, resolving the current composing candidates first if the asynchronous candidate strip has not yet marked candidates as shown. This is not a comma/period-only feature.
 
 **Files:**
 - Modify: `LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java` around key input / composing dispatch / Space/Enter candidate-confirm behavior / `commitTyped(...)`
@@ -390,10 +390,10 @@ public void updateIMMetadataFieldAllowsLimeEndkey() {
 2. If currently composing and the pressed key is in the active table's `limeendkey` set:
    - do **not** append the end-key character to the composing code;
    - do **not** query for a special direct punctuation mapping unless the existing Space/Enter confirm path already does so;
-   - immediately commit the currently highlighted candidate item using the same selected-candidate path as Space/Enter;
+   - immediately commit the current selected/resolved candidate item using the same selected-candidate path as Space/Enter;
    - clear composing state;
    - consume the key event so the raw end-key character is not emitted afterward.
-3. If there is no highlighted candidate but the normal Space/Enter path has an established fallback, reuse that fallback exactly. Do not invent a separate end-key-specific fallback.
+3. Resolve candidates for the exact current composing code before committing when the candidate strip has not yet shown current candidates or the stored selected candidate belongs to an older prefix. Do not append the end-key character to composing while waiting for the async strip update.
 4. If no Lime end-key metadata exists, preserve current behavior exactly.
 5. If the active table uses any potential end-key character as a normal root but does not opt into end keys, preserve root input.
 6. Do not change candidate-list ordering; the first candidate remains composing-code fallback. Endkey changes commit behavior only.
@@ -403,17 +403,18 @@ public void updateIMMetadataFieldAllowsLimeEndkey() {
 
 - Regression test with a table whose end-key list contains more than comma/period, e.g. `%limeendkey ;/` or `@limeendkey@ |;/`:
   - type a composing code that shows candidates;
-  - move/highlight a non-first candidate if the test seam allows;
+  - move/highlight a non-first candidate if the test seam allows, and separately cover the case where the candidate strip has not yet marked candidates shown;
   - press `;` or `/`;
   - assert the highlighted candidate is committed and composing is cleared;
   - assert the raw `;` or `/` is not committed.
+- Regression test stale candidate strip timing: after the composing buffer advances from `a` to `aa`, pressing a Lime end key must ignore any stale `a` selected/highlighted candidate, resolve `aa`, commit that candidate, and clear composing.
 - Compatibility test for comma/period as normal roots with no Lime end-key metadata: they remain input roots and are not treated as commit triggers.
 - Test that Space/Enter behavior remains unchanged after refactoring shared confirm logic.
 
 **Manual acceptance examples:**
 
-- Required visual verification: run `android-visual-verify` with Computer Use and inspect the composing/candidate strip before and after the end-key press, confirming the highlighted candidate commits and composing clears.
-- Table with `%limeendkey ;/`: after typing a code and highlighting a candidate, pressing `;` or `/` commits that highlighted candidate immediately, just like pressing Space/Enter would.
+- Required visual verification: run `android-visual-verify` with Computer Use and inspect the composing/candidate strip before and after the end-key press, confirming the current candidate commits and composing clears.
+- Table with `%limeendkey ;/`: after typing a code, pressing `;` or `/` commits the current selected/resolved candidate immediately, just like pressing Space/Enter would.
 - `.lime` with `@limeendkey@ |,.`: comma/period are only examples of keys in the list; they should use the same general end-key path.
 - 行列30/大易 style table without endkey metadata: comma/period or any other punctuation roots remain usable roots.
 

--- a/docs/ANDROID_NR_0530.md
+++ b/docs/ANDROID_NR_0530.md
@@ -17,13 +17,12 @@
 - #91 — `.cin` duplicate-code import/query order should preserve source-file order when selection sorting is disabled.
 - #94 / PR #97 — backup must not create/report a 0 B `limeBackup.zip`; missing transient `lime.db-journal` must not break backup.
 - #93 — Android `.lime` import should read/persist `@cname@` and `@version@`, including Array10-style files with `#` comments.
-- #96 — direct `,` / `.` table mappings should highlight/select the direct full-width punctuation match before the composing-code fallback.
 
 ### Confirmed Android features
 
 - #90 — keyboard theme option should optionally follow Android system accent / dynamic colors, not only system light/dark.
-- #96 — support explicit table end-key behavior for `.cin %endkey` and `.lime @endkey@` on Android, without breaking tables where `,` / `.` are roots.
-- #96 — audit bundled/official Android table assets, if any, and either add opt-in end-key metadata plus direct punctuation mappings for the tables Jeremy confirms or document that table-data release coordination is separate from the engine change.
+- #96 — support explicit Lime table end-key behavior for `.cin %limeendkey` and `.lime @limeendkey@` on Android, without breaking tables where `,` / `.` are roots.
+- #96 — audit bundled/official Android table assets, if any, and either add opt-in Lime end-key metadata plus direct punctuation mappings for the tables Jeremy confirms or document that table-data release coordination is separate from the engine change.
 - #99 — shifted symbol-keyboard layouts should remove Chinese IM root sub-labels only from non-alphabet shifted keys such as `!@#...`; shifted capital-letter keys may keep root sub-labels because `A-Z` can still be valid roots.
 
 ### Explicitly out of scope for this plan
@@ -298,13 +297,13 @@ git commit -m "fix(android): parse lime metadata with comments"
 
 ---
 
-## Task 7: Add end-key metadata model, parser tests, and editable IM detail field for #96
+## Task 7: Add Lime end-key metadata model, parser tests, and editable IM detail field for #96
 
-**Objective:** Define Android runtime representation for `%endkey` / `@endkey@`, expose it as editable per-IM metadata in LIME Settings IM detail view, and document the setting before implementing key behavior.
+**Objective:** Define Android runtime representation for Lime-specific `%limeendkey` / `@limeendkey@`, expose it as editable per-IM metadata in LIME Settings IM detail view, and document how it differs from conventional `%endkey` / `@endkey@` compatibility metadata before implementing key behavior.
 
 **Files:**
 - Modify: `LimeStudio/app/src/main/java/net/toload/main/hd/limedb/LimeDB.java`
-- Modify: `LimeStudio/app/src/main/java/net/toload/main/hd/global/LIME.java` if a constant for `endkey` is missing
+- Modify: `LimeStudio/app/src/main/java/net/toload/main/hd/global/LIME.java` if a constant for `limeendkey` is missing
 - Modify: `LimeStudio/app/src/main/java/net/toload/main/hd/ui/controller/ManageImController.java:411-444`
 - Modify: `LimeStudio/app/src/main/java/net/toload/main/hd/ui/view/ImDetailFragment.java:58-191,285-320,422-485`
 - Modify: `LimeStudio/app/src/main/res/layout/fragment_im_detail.xml:86-192`
@@ -320,15 +319,15 @@ Add tests for both import formats:
 
 ```java
 @Test
-public void cinImportPersistsEndkeyMetadata() throws Exception {
-    // Fixture includes "%endkey ;/".
-    // Assert getImConfig(table, "endkey") returns ";/".
+public void cinImportPersistsLimeEndkeyMetadata() throws Exception {
+    // Fixture includes "%limeendkey ;/".
+    // Assert getImConfig(table, "limeendkey") returns ";/".
 }
 
 @Test
-public void limeImportPersistsEndkeyMetadata() throws Exception {
-    // Fixture includes "@endkey@ |;/".
-    // Assert getImConfig(table, "endkey") returns ";/".
+public void limeImportPersistsLimeEndkeyMetadata() throws Exception {
+    // Fixture includes "@limeendkey@ |;/".
+    // Assert getImConfig(table, "limeendkey") returns ";/".
 }
 ```
 
@@ -336,41 +335,41 @@ Add controller/UI-seam coverage where practical:
 
 ```java
 @Test
-public void updateIMMetadataFieldAllowsEndkey() {
-    assertTrue(controller.updateIMMetadataField("custom", "endkey", ";/"));
-    assertEquals(";/", searchServer.getImConfig("custom", "endkey"));
+public void updateIMMetadataFieldAllowsLimeEndkey() {
+    assertTrue(controller.updateIMMetadataField("custom", "limeendkey", ";/"));
+    assertEquals(";/", searchServer.getImConfig("custom", "limeendkey"));
 }
 ```
 
 **Implementation requirements:**
 
 1. Normalize metadata value by stripping optional delimiter/prefix whitespace.
-2. Persist as `setImConfig(table, "endkey", normalizedValue)`.
-3. Do not infer end keys from direct punctuation mappings. End-key behavior must be explicit.
-4. Update `ManageImController.updateIMMetadataField(...)` so editable metadata fields include `name`, `version`, and `endkey`.
+2. Persist as `setImConfig(table, "limeendkey", normalizedValue)`.
+3. Do not infer Lime end keys from direct punctuation mappings or conventional `endkey` metadata. Lime end-key behavior must be explicit.
+4. Update `ManageImController.updateIMMetadataField(...)` so editable metadata fields include `name`, `version`, and `limeendkey`.
    - `name` remains required/non-empty.
-   - `version` and `endkey` may be blank; blank `endkey` means no end-key commit triggers for that table.
+   - `version` and `limeendkey` may be blank; blank `limeendkey` means no Lime runtime end-key commit triggers for that table.
    - Trim leading/trailing whitespace, but do **not** sort or deduplicate characters unless the runtime parser also does so consistently.
 5. Add an **Endkey / 結束鍵** row in `fragment_im_detail.xml` under the same 輸入法資訊 card as 名稱 and 版本, using the same tappable/editable row pattern and chevron icon.
-6. In `ImDetailFragment`, load `getImConfig(tableCode, "endkey")`, display `-` when empty, and open the same metadata edit dialog for field `"endkey"`.
-7. Editing `endkey` saves immediately through `updateIMMetadataField(table, "endkey", editedValue)`, updates the row text, and refreshes any metadata/cache needed by the active IM.
+6. In `ImDetailFragment`, load `getImConfig(tableCode, "limeendkey")`, display `-` when empty, and open the same metadata edit dialog for field `"limeendkey"`.
+7. Editing the Endkey row saves immediately through `updateIMMetadataField(table, "limeendkey", editedValue)`, updates the row text, and refreshes any metadata/cache needed by the active IM.
 8. Hide the Endkey row for the synthetic `related` table just like editable name/version rows.
-9. Document `.lime @endkey@ |;/` and `.cin %endkey ;/` as opt-in metadata in `docs/CIN_LIME_SPEC.md`.
+9. Document `.lime @limeendkey@ |;/` and `.cin %limeendkey ;/` as opt-in Lime runtime metadata in `docs/CIN_LIME_SPEC.md`; document `.cin %endkey` / `.lime @endkey@` as conventional compatibility metadata.
 10. Update `docs/LIME_SETTINGS.md` so the LIME Settings IM detail view spec includes an editable Endkey metadata field alongside cname/name and version. Explain that users can view or edit the table's end-key list there, and that empty means disabled.
 11. Search the repo for bundled `.lime`, `.cin`, or generated table assets. If Android ships official table data in this repo, list affected tables and add opt-in metadata/mappings only for tables Jeremy confirms should support one-key commit triggers. If no bundled table assets exist, record that table-data coordination is separate from the engine change.
 
 **Manual acceptance examples:**
 
 - LIME Settings → 輸入法 → IM detail shows editable rows for 名稱, 版本, and Endkey/結束鍵.
-- Tapping Endkey opens an edit dialog prefilled with the current `endkey` metadata value such as `;/`.
-- Saving `;/` persists `getImConfig(table, "endkey") == ";/"`; reopening the screen shows `;/`.
+- Tapping Endkey opens an edit dialog prefilled with the current `limeendkey` metadata value such as `;/`.
+- Saving `;/` persists `getImConfig(table, "limeendkey") == ";/"`; reopening the screen shows `;/`.
 - Clearing the Endkey field persists an empty value and the detail row displays `-`.
 
 ---
 
 ## Task 8: Implement Android end-key runtime behavior
 
-**Objective:** Implement `endkey` as a general per-table commit trigger. When the user presses **any key in the active table's end-key list** while composing, LIME should end composition immediately and commit the currently highlighted candidate item, matching the existing confirm behavior for Space and Enter. This is not a comma/period-only feature.
+**Objective:** Implement `limeendkey` as a general per-table commit trigger. When the user presses **any key in the active table's end-key list** while composing, LIME should end composition immediately and commit the currently highlighted candidate item, matching the existing confirm behavior for Space and Enter. This is not a comma/period-only feature.
 
 **Files:**
 - Modify: `LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java` around key input / composing dispatch / Space/Enter candidate-confirm behavior / `commitTyped(...)`
@@ -380,34 +379,35 @@ public void updateIMMetadataFieldAllowsEndkey() {
 
 **Implementation requirements:**
 
-1. Load active table end-key metadata when the active IM/table changes. Treat it as a character set/list, not as special handling for comma and period.
-2. If currently composing and the pressed key is in the active table's `endkey` set:
+1. Load active table Lime end-key metadata when the active IM/table changes. Treat it as a character set/list, not as special handling for comma and period.
+2. If currently composing and the pressed key is in the active table's `limeendkey` set:
    - do **not** append the end-key character to the composing code;
    - do **not** query for a special direct punctuation mapping unless the existing Space/Enter confirm path already does so;
    - immediately commit the currently highlighted candidate item using the same selected-candidate path as Space/Enter;
    - clear composing state;
    - consume the key event so the raw end-key character is not emitted afterward.
 3. If there is no highlighted candidate but the normal Space/Enter path has an established fallback, reuse that fallback exactly. Do not invent a separate end-key-specific fallback.
-4. If no end-key metadata exists, preserve current behavior exactly.
+4. If no Lime end-key metadata exists, preserve current behavior exactly.
 5. If the active table uses any potential end-key character as a normal root but does not opt into end keys, preserve root input.
 6. Do not change candidate-list ordering; the first candidate remains composing-code fallback. Endkey changes commit behavior only.
 7. Keep physical-keyboard and soft-keyboard behavior consistent unless code inspection shows separate intentional paths.
 
 **Test requirements:**
 
-- Regression test with a table whose end-key list contains more than comma/period, e.g. `%endkey ;/` or `@endkey@ |;/`:
+- Regression test with a table whose end-key list contains more than comma/period, e.g. `%limeendkey ;/` or `@limeendkey@ |;/`:
   - type a composing code that shows candidates;
   - move/highlight a non-first candidate if the test seam allows;
   - press `;` or `/`;
   - assert the highlighted candidate is committed and composing is cleared;
   - assert the raw `;` or `/` is not committed.
-- Compatibility test for comma/period as normal roots with no end-key metadata: they remain input roots and are not treated as commit triggers.
+- Compatibility test for comma/period as normal roots with no Lime end-key metadata: they remain input roots and are not treated as commit triggers.
 - Test that Space/Enter behavior remains unchanged after refactoring shared confirm logic.
 
 **Manual acceptance examples:**
 
-- Table with `%endkey ;/`: after typing a code and highlighting a candidate, pressing `;` or `/` commits that highlighted candidate immediately, just like pressing Space/Enter would.
-- `.lime` with `@endkey@ |,.`: comma/period are only examples of keys in the list; they should use the same general end-key path.
+- Required visual verification: run `android-visual-verify` with Computer Use and inspect the composing/candidate strip before and after the end-key press, confirming the highlighted candidate commits and composing clears.
+- Table with `%limeendkey ;/`: after typing a code and highlighting a candidate, pressing `;` or `/` commits that highlighted candidate immediately, just like pressing Space/Enter would.
+- `.lime` with `@limeendkey@ |,.`: comma/period are only examples of keys in the list; they should use the same general end-key path.
 - 行列30/大易 style table without endkey metadata: comma/period or any other punctuation roots remain usable roots.
 
 **Commit:**
@@ -631,8 +631,8 @@ Expected: all connected Android tests pass. If a device is unavailable, record t
 4. Direct punctuation:
    - table with `, = ，`, `. = 。` highlights direct punctuation first.
 5. Endkey:
-   - opt-in table with `%endkey ,.` / `@endkey@ |,.` commits punctuation directly;
-   - table without endkey still treats `,` / `.` as roots if defined.
+   - opt-in table with `%limeendkey ,.` / `@limeendkey@ |,.` commits punctuation directly;
+   - table without Lime endkey still treats `,` / `.` as roots if defined.
 6. Dynamic color:
    - theme 0-6 unchanged;
    - new dynamic/accent theme follows accent where supported and falls back safely where not.

--- a/docs/ANDROID_THEME.md
+++ b/docs/ANDROID_THEME.md
@@ -1,7 +1,7 @@
 # Android Theming — LimeIME Architecture Notes
 
 **Date:** 2026-04-19
-**Status:** Implemented in v6.1
+**Status:** Implemented in v6.1; Android dynamic-accent follow-system updates added on `android-next-release-all-fixes`
 
 ---
 
@@ -21,6 +21,8 @@ LimeIME supports 6 keyboard themes (indices 0–5) plus a 7th virtual theme (ind
 | 5     | RelaxGreen     | `R.style.LIMETheme_RelaxGreen` |
 
 Index 6 (`系統設定`) is a **virtual theme** — it is not in the array and has no dedicated style. At runtime it resolves to index 1 (dark) or index 0 (light) based on `Configuration.UI_MODE_NIGHT_MASK`.
+
+In the Android next-release branch, index 6 also resolves a system/dynamic accent color for highlight surfaces when Android exposes one. Fixed themes 0–5 remain fixed and do not inherit system accent colors.
 
 ### Theme application flow
 
@@ -70,11 +72,21 @@ boolean isDark = (uiMode == Configuration.UI_MODE_NIGHT_YES);
 
 These are system styles available on API 21+ and require no custom resource definitions.
 
+### Dynamic accent in follow-system mode
+
+`LIMEService.currentEmojiPanelColors()` now resolves a system accent only when `mKeyboardThemeIndex == 6`. The service checks Material/system theme attributes in this order:
+
+1. `com.google.android.material.R.attr.colorPrimary`
+2. `com.google.android.material.R.attr.colorSecondary`
+3. `android.R.attr.colorAccent`
+
+If no usable accent is available, it falls back to the existing light/dark highlight colors. The resolved accent is applied as a translucent selected/highlight overlay for the follow-system keyboard/emoji UI path. Fixed themes `0-5` continue using their existing theme-specific colors.
+
 ---
 
 ## 3. App UI — Follow System (MainActivity + Settings)
 
-The main app UI (`MainActivity`) and the Settings screen (`LIMEPreference`) both follow the system day/night mode. This is independent of the keyboard's theme setting — the app chrome always tracks the OS, while the keyboard honors the user-chosen theme index.
+The main app UI (`MainActivity`) and the Settings screen (`LIMEPreference` / `LIMESettings`) both follow the system day/night mode. This is independent of the keyboard's theme setting — the app chrome always tracks the OS, while the keyboard honors the user-chosen theme index.
 
 ### Mechanism
 
@@ -125,6 +137,10 @@ controller.setAppearanceLightNavigationBars(isLight);
 - `setAppearanceLightStatusBars(true)` = **dark** icons on a **light** bar (day mode).
 - `setAppearanceLightStatusBars(false)` = **light** icons on a **dark** bar (night mode).
 
+### Material dynamic color in LIME Settings
+
+`LIMESettings.onCreate(...)` applies `DynamicColors.applyToActivityIfAvailable(this)` before `super.onCreate(...)`. On Android versions/devices with Material dynamic color, bottom navigation, buttons, switches, and related Material surfaces can follow the system accent family. The explicit `colorPrimary` / `colorSecondary` values in `themes.xml` remain fallback accents for unsupported devices or contexts where dynamic color is unavailable.
+
 ---
 
 ## 4. Gotchas Hit During Implementation
@@ -166,3 +182,4 @@ Verified on Android 16 emulator (API 36, system in dark mode):
 - LIMEPreference: dark ActionBar, dark preference list, white text, dark dialogs (for ListPreference pickers).
 - News/Help dialogs in MainActivity: dark background, white text.
 - Keyboard with Theme 6 selected: follows system dark/light including popup menus.
+- Android next-release dynamic-accent check: LIME Settings rendered cleanly in dark mode after `DynamicColors.applyToActivityIfAvailable(...)`; focused regression tests verified follow-system emoji/category highlights use the supplied system accent while fixed themes ignore it.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -36,12 +36,6 @@ Last reviewed: 2026-06-02
   - Current state: Android import can succeed but cname/version metadata may not be read or saved correctly; Array10 `.lime` includes several `#` comment lines, so comment-line support must be verified.
   - Next action: Verify whether `.lime` supports `#`-prefixed comments like `.cin`, then fix metadata parsing/persistence and add regression coverage.
 
-- #96 — Android — direct `,` / `.` table mappings should highlight the direct full-width punctuation match
-  - Status: Open bug + enhancement/question/usability issue, assigned to `jrywu`.
-  - Current state: If a table defines direct mappings such as `, = ，` and `. = 。`, the current Android candidate path can still keep the composing-code record as the effective first selection instead of the direct match.
-  - Next action: Fix Android candidate selection so direct exact mappings are highlighted/selected before the composing-code fallback when appropriate, without globally forcing punctuation for tables that use `,`/`.` as roots; add regression coverage, then ship a newer APK and ask the reporter to retest.
-
-
 ## Confirmed feature / product work
 
 - #90 — Android — keyboard theme should optionally follow system accent/dynamic colors
@@ -50,9 +44,9 @@ Last reviewed: 2026-06-02
   - Next action: Evaluate Android dynamic color / system accent color support for the keyboard theme, then design it so it remains optional and compatible with existing fixed light/dark/color themes.
 
 - #96 — Android + iOS/table-format — support end-key punctuation behavior for table IMs
-  - Status: Open enhancement/question/usability issue with related Android bug scope tracked above.
-  - Current state: Reporter clarified that 行列30/大易 may use `,`/`.` as roots, while 行列10/嘸蝦米/倉頡 expect punctuation behavior; prior discussion identified `.cin` `%endkey ,.` and future `.lime` `@endkey@` as the likely compatible feature direction. Community follow-up noted official 行列10 currently lacks `,|，` / `.|。` rows and would need explicit opt-in metadata plus mappings if the table should support one-key punctuation.
-  - Next action: Design configurable end-key support that preserves tables where `,`/`.` are defined roots, then implement `.cin %endkey` and `.lime @endkey@` parsing/runtime behavior; for opt-in official tables, coordinate table metadata/mapping additions separately from the engine feature.
+  - Status: Android engine/settings support implemented on `android-next-release-all-fixes`; iOS and official table-data coordination remain pending.
+  - Current state: Android parses and persists conventional `.cin %endkey` / `.lime @endkey@` metadata for compatibility, parses Lime-specific `.cin %limeendkey` / `.lime @limeendkey@` for runtime commit behavior, exposes editable per-IM `limeendkey` metadata in LIME Settings, and commits the highlighted candidate only when an active table opts into a Lime end key. Tables without Lime end-key metadata still keep `,`/`.` roots usable.
+  - Next action: Include Android support in the review APK. iOS should be addressed later and aligned with the Android implementation. Official table metadata/mapping updates, such as adding opt-in 行列10 punctuation rows, are deferred to separate table-data release coordination.
 
 - #99 — Android — shifted keyboard layouts should hide non-alphabet IM root labels
   - Status: Closed question/enhancement/usability issue; product scope confirmed for backlog by maintainer direction.
@@ -82,4 +76,3 @@ Last reviewed: 2026-06-02
 
 - Closed/source-fixed items such as #92
   - Reason: Do not list as pending backlog unless Jeremy wants a separate iOS TestFlight/release-QA tracking item.
-

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,19 +2,19 @@
 
 Public backlog for confirmed pending fixes and new-feature/product work. Issue-specific investigation details stay in `docs/#NN_ISSUE.md`; mutable automation state stays outside the repo.
 
-Last reviewed: 2026-06-02
+Last reviewed: 2026-06-03
 
 ## Pending fixes
 
 - #91 — Android — `.cin` import should preserve duplicate-code candidate order from the source file
-  - Status: Open bug, assigned to `jrywu`.
-  - Current state: Reporter showed `vmi` candidates from 哈哈倉頡 changing from source order `狀 绒 戕` to `狀 戕 绒` even with `啟動選取排序` disabled.
-  - Next action: Fix Android `.cin` import/query ordering so same-code candidates can follow source-file order when selection sorting is disabled, then ship in a newer APK and ask reporter to retest.
+  - Status: Implemented in Android source on `android-next-release-all-fixes`; awaiting review APK and reporter retest.
+  - Current state: Android now keeps same-code `.cin` exact matches in source insertion order when selection sorting is disabled, with regression coverage for the `vmi` / `狀 绒 戕` case shape.
+  - Next action: Include in the next Android review APK, then ask reporter to retest 哈哈倉頡 `vmi`.
 
 - #94 / PR #97 — Android — backup must not create a 0 B `limeBackup.zip` while reporting success
-  - Status: Open bug with open fix PR #97.
-  - Current state: Logcat traced the failure to treating missing transient SQLite rollback journal `lime.db-journal` as fatal, while the UI could still report success and leave a 0 B backup file.
-  - Next action: Review/merge PR #97, ship a newer APK, then ask reporter to confirm backup creates a non-empty ZIP and can restore normally.
+  - Status: Implemented in Android source on `android-next-release-all-fixes`; PR #97 behavior is superseded/recreated in this branch pending APK retest.
+  - Current state: Backup no longer requires a missing transient `lime.db-journal`, failure propagates instead of reporting success, and regression coverage verifies non-empty backup output plus output-write failure propagation.
+  - Next action: Include in the next Android review APK, then ask reporter to confirm backup creates a non-empty ZIP and restores normally.
 
 - #86 — iOS — keyboard extension should see restored IM tables immediately after successful DB restore
   - Status: Open maintainer-created bug, assigned to `jrywu`.
@@ -32,16 +32,16 @@ Last reviewed: 2026-06-02
   - Next action: Fix iOS text-import registration/fallback naming so successful imports create visible installed IM configs, then verify import and keyboard availability.
 
 - #93 — Android — `.lime` import should correctly read `@cname@` and `@version@` metadata
-  - Status: Open maintainer-created bug scope, assigned to `jrywu`.
-  - Current state: Android import can succeed but cname/version metadata may not be read or saved correctly; Array10 `.lime` includes several `#` comment lines, so comment-line support must be verified.
-  - Next action: Verify whether `.lime` supports `#`-prefixed comments like `.cin`, then fix metadata parsing/persistence and add regression coverage.
+  - Status: Implemented in Android source on `android-next-release-all-fixes`; maintainer-created issue still needs final Android APK verification and separate iOS work.
+  - Current state: Android `.lime` import now skips `#` comment lines during delimiter detection/parsing and persists `@cname@` / `@version@`, with Array10-style regression coverage.
+  - Next action: Include in the Android review APK. iOS #93 remains pending separately and should stay aligned with Android metadata semantics where applicable.
 
 ## Confirmed feature / product work
 
 - #90 — Android — keyboard theme should optionally follow system accent/dynamic colors
-  - Status: Open enhancement/usability issue; product scope confirmed for backlog by maintainer direction.
-  - Current state: The 6.1 `系統設定` keyboard theme follows the system light/dark mode only. Reporter tested on motorola razr60 / Android 16 and clarified that it does not apply the system theme/accent color.
-  - Next action: Evaluate Android dynamic color / system accent color support for the keyboard theme, then design it so it remains optional and compatible with existing fixed light/dark/color themes.
+  - Status: Implemented in Android source on `android-next-release-all-fixes`; awaiting APK review.
+  - Current state: Existing `6 = 系統設定` remains the only follow-system theme option. Android now applies Material dynamic color to LIME Settings where available and uses resolved system accent for follow-system keyboard/emoji highlights while fixed themes `0-5` remain fixed.
+  - Next action: Include in the next Android review APK and visually verify dynamic/accent behavior on supported Android versions. Button/layout customization remains outside the backlog until confirmed.
 
 - #96 — Android + iOS/table-format — support end-key punctuation behavior for table IMs
   - Status: Android engine/settings support implemented on `android-next-release-all-fixes`; iOS and official table-data coordination remain pending.
@@ -49,11 +49,11 @@ Last reviewed: 2026-06-02
   - Next action: Include Android support in the review APK. iOS should be addressed later and aligned with the Android implementation. Official table metadata/mapping updates, such as adding opt-in 行列10 punctuation rows, are deferred to separate table-data release coordination.
 
 - #99 — Android — shifted keyboard layouts should hide non-alphabet IM root labels
-  - Status: Closed question/enhancement/usability issue; product scope confirmed for backlog by maintainer direction.
-  - Current state: Shift / caps-lock behavior remains by design so users can enter uppercase letters and symbols in hybrid input. The improvement is only about what the shifted keyboard layout displays: non-alphabet keys such as number/symbol positions should not continue showing Chinese IM root labels when those shifted keys now input symbols.
+  - Status: Implemented in Android source on `android-next-release-all-fixes`; awaiting APK visual verification.
+  - Current state: Shifted Android phonetic/EZ/ET41/Dayi symbol layouts remove root sub-labels from non-alphabet shifted symbol keys while preserving shifted alphabet-key root labels. Shift/caps-lock runtime behavior is handled by the separate unfiled Shift item.
   - Scope: Layout/label adjustment only. Do not change input handling, composing-code logic, candidate lookup, Shift/caps-lock behavior, or hybrid symbol input behavior.
   - Expected behavior: Alphabet keys may continue showing alphabet/root labels as appropriate, because `abc...` -> `ABC...` can still be meaningful for some IM roots. Only non-alphabet shifted keys should remove or adjust IM root labels to avoid suggesting they still input the original Chinese IM roots.
-  - Next action: Update the Android shifted keyboard layout resources/labels for affected IM layouts so non-alphabet shifted keys no longer show misleading IM root labels; verify the visual layout and confirm no runtime code change is needed.
+  - Next action: Include in the next Android review APK and visually verify at least one edited shifted layout.
 
 - #99 — iOS — shifted keyboard layouts should hide non-alphabet IM root labels
   - Status: Cross-platform feature parity backlog item from the #99 Android discussion.
@@ -63,11 +63,11 @@ Last reviewed: 2026-06-02
   - Next action: Audit iOS shifted keyboard layout assets/resources and update labels where applicable; verify the visual layout and confirm no runtime code change is needed.
 
 - Unfiled — Android + iOS — simplify Shift key cycle and use double-click for Shift Lock
-  - Status: New cross-platform feature request from maintainer direction.
-  - Current state: Shift currently cycles through three states by repeated single taps: first tap = shifted, second tap = Shift Lock, third tap = unshifted, then repeats.
+  - Status: Android implemented on `android-next-release-all-fixes`; iOS remains pending.
+  - Current state: Android single Shift taps now toggle shifted/unshifted only, double-tap enters Shift Lock, and a single Shift tap exits Shift Lock. Regression coverage locks the Android state machine. iOS still needs the matching implementation later.
   - Expected behavior: Single tap should only toggle between shifted and unshifted. Double tap should enter Shift Lock. When Shift Lock is active, a single tap should leave Shift Lock and return to unshifted.
   - Scope: Update Shift key state-machine/input handling on both Android and iOS. Preserve existing shifted keyboard layouts, caps/lock visual indicators, and normal key output semantics except for the tap gesture/state transition change.
-  - Next action: Audit Android and iOS Shift key handling, add regression coverage or focused manual test cases for single-tap toggle, double-tap lock, and single-tap unlock, then update both platforms consistently.
+  - Next action: Include Android in the review APK and visually verify the Shift states. Address iOS later and keep its behavior aligned with the Android implementation.
 
 ## Not in backlog yet
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -45,7 +45,7 @@ Last reviewed: 2026-06-03
 
 - #96 — Android + iOS/table-format — support end-key punctuation behavior for table IMs
   - Status: Android engine/settings support implemented on `android-next-release-all-fixes`; iOS and official table-data coordination remain pending.
-  - Current state: Android parses and persists conventional `.cin %endkey` / `.lime @endkey@` metadata for compatibility, parses Lime-specific `.cin %limeendkey` / `.lime @limeendkey@` for runtime commit behavior, exposes editable per-IM `limeendkey` metadata in LIME Settings, and commits the highlighted candidate only when an active table opts into a Lime end key. Tables without Lime end-key metadata still keep `,`/`.` roots usable.
+  - Current state: Android parses and persists conventional `.cin %endkey` / `.lime @endkey@` metadata for compatibility, parses Lime-specific `.cin %limeendkey` / `.lime @limeendkey@` for runtime commit behavior, exposes editable per-IM `limeendkey` metadata in LIME Settings, and commits the exact current selected/resolved candidate when an active table opts into a Lime end key. The end-key path rejects stale prefix candidates from an older composing buffer, so pressing the configured key ends the current composition instead of partially committing. Tables without Lime end-key metadata still keep `,`/`.` roots usable.
   - Next action: Include Android support in the review APK. iOS should be addressed later and aligned with the Android implementation. Official table metadata/mapping updates, such as adding opt-in 行列10 punctuation rows, are deferred to separate table-data release coordination.
 
 - #99 — Android — shifted keyboard layouts should hide non-alphabet IM root labels

--- a/docs/CIN_LIME_SPEC.md
+++ b/docs/CIN_LIME_SPEC.md
@@ -15,6 +15,7 @@ This file is the format contract only. Implementation tasks and test coverage ar
 %cname My IM Display Name
 %selkey 123456789
 %endkey abcdefghijklmnopqrstuvwxyz
+%limeendkey ;/
 %spacestyle 0
 %keyname begin
 a A
@@ -39,6 +40,7 @@ Supported CIN metadata:
 %cname My IM Display Name
 %selkey 123456789
 %endkey ...
+%limeendkey ...
 %spacestyle ...
 ```
 
@@ -46,7 +48,9 @@ Behavior:
 
 - `%version` stores the IM version metadata.
 - `%cname` stores the display name and is also used as version fallback when `%version` is absent.
-- `%selkey`, `%endkey`, and `%spacestyle` store IM selection/end/space behavior metadata.
+- `%selkey`, `%endkey`, and `%spacestyle` store conventional CIN selection/end/space behavior metadata.
+- `%limeendkey` stores LimeIME's runtime end-key commit triggers. Empty or absent Lime end-key metadata means no Lime runtime end-key commit triggers for the table.
+- `%endkey` remains import/export compatibility metadata and does not by itself enable LimeIME's runtime end-key commit path.
 - Metadata values may contain spaces after the metadata key.
 
 ### 1.4 `%keyname` Block
@@ -113,6 +117,7 @@ For the phonetic table, `code3r` is derived by removing tone characters `[3467 ]
 @cname@|My IM Display Name
 @selkey@|123456789
 @endkey@|abcdefghijklmnopqrstuvwxyz
+@limeendkey@|;/
 @spacestyle@|0
 %chardef begin
 code|word|score|basescore
@@ -150,6 +155,7 @@ LIME-style metadata uses the active delimiter. With pipe delimiter:
 @cname@|My IM Display Name
 @selkey@|123456789
 @endkey@|...
+@limeendkey@|...
 @spacestyle@|...
 ```
 
@@ -159,6 +165,7 @@ An import line is metadata when the parsed `code` field starts with `@`. Support
 - `@cname@`
 - `@selkey@`
 - `@endkey@`
+- `@limeendkey@`
 - `@spacestyle@`
 - `@imkeys@`
 - `@imkeynames@`
@@ -171,8 +178,11 @@ Metadata meaning:
 - `@format@|lime-text-v2` enables escaped field parsing for the rest of the file.
 - `@version@` stores the IM version metadata.
 - `@cname@` stores the IM display name, equivalent to CIN `%cname`.
-- `@selkey@`, `@endkey@`, and `@spacestyle@` store IM selection/end/space behavior metadata.
+- `@selkey@`, `@endkey@`, and `@spacestyle@` store conventional IM selection/end/space behavior metadata.
+- `@limeendkey@` stores LimeIME's runtime end-key commit triggers.
 - `@imkeys@` and `@imkeynames@` store the same key mapping metadata as the `imkeys` and `imkeynames` rows in the `im` table.
+- `@endkey@` remains import/export compatibility metadata and does not by itself enable LimeIME's runtime end-key commit path.
+- Empty or absent `@limeendkey@` metadata means no Lime runtime end-key commit triggers for the table.
 
 When both `@version@` and `@cname@` are present, `@version@` remains the version value and `@cname@` is the display name value.
 
@@ -260,6 +270,7 @@ Regular table export writes:
 @cname@|...
 @selkey@|...
 @endkey@|...
+@limeendkey@|...
 @spacestyle@|...
 @imkeys@|...
 @imkeynames@|...
@@ -294,7 +305,7 @@ Important consequences:
 - In tab-delimited `.lime`, literal tab cannot safely appear inside fields.
 - In space-delimited `.cin` or `.lime`, literal spaces cannot safely appear inside mapping fields.
 - A `.lime` mapping whose `code` begins with `@` is treated as LIME metadata and skipped.
-- A CIN mapping whose `code` begins with `%version`, `%cname`, `%selkey`, `%endkey`, or `%spacestyle` is treated as metadata and skipped.
+- A CIN mapping whose `code` begins with `%version`, `%cname`, `%selkey`, `%endkey`, `%limeendkey`, or `%spacestyle` is treated as metadata and skipped.
 
 Literal `@` is safe in a `.lime` `word` field today, but not as the first character of the parsed `code` field.
 

--- a/docs/CIN_LIME_SPEC.md
+++ b/docs/CIN_LIME_SPEC.md
@@ -48,10 +48,22 @@ Behavior:
 
 - `%version` stores the IM version metadata.
 - `%cname` stores the display name and is also used as version fallback when `%version` is absent.
+- When `%cname` is absent, importers store the built-in full name for the target IM table as the display name. Unknown target tables fall back to the import filename.
 - `%selkey`, `%endkey`, and `%spacestyle` store conventional CIN selection/end/space behavior metadata.
 - `%limeendkey` stores LimeIME's runtime end-key commit triggers. Empty or absent Lime end-key metadata means no Lime runtime end-key commit triggers for the table.
 - `%endkey` remains import/export compatibility metadata and does not by itself enable LimeIME's runtime end-key commit path.
 - Metadata values may contain spaces after the metadata key.
+
+### 1.3.1 Lime Runtime End-Key Behavior
+
+`%limeendkey` is a LimeIME runtime extension. It is intentionally separate from conventional CIN `%endkey`.
+
+When a pressed key is listed in `%limeendkey`, LimeIME uses the table's `imkeys` metadata to decide how to finish composition:
+
+- If the key is also present in `imkeys`, LimeIME appends the key to the active composing buffer, resolves candidates for the full composing code, commits the highlighted candidate, and consumes the trigger key.
+- If the key is not present in `imkeys`, LimeIME first commits the highlighted candidate for the active composing buffer, then processes the trigger key as a fresh composing key. If that fresh key resolves to table candidates, LimeIME commits the highlighted candidate for that key as well. If it has no table candidate, normal raw-key fallback applies.
+
+This rule is generic. It must not depend on Chinese punctuation-specific handling.
 
 ### 1.4 `%keyname` Block
 
@@ -183,10 +195,13 @@ Metadata meaning:
 - `@imkeys@` and `@imkeynames@` store the same key mapping metadata as the `imkeys` and `imkeynames` rows in the `im` table.
 - `@endkey@` remains import/export compatibility metadata and does not by itself enable LimeIME's runtime end-key commit path.
 - Empty or absent `@limeendkey@` metadata means no Lime runtime end-key commit triggers for the table.
+- When `@cname@` is absent, importers store the built-in full name for the target IM table as the display name. Unknown target tables fall back to the import filename.
 
 When both `@version@` and `@cname@` are present, `@version@` remains the version value and `@cname@` is the display name value.
 
 `@imkeynames@` often contains literal `|` separators inside the value. When exporting such values, use `@format@|lime-text-v2` and escape those literal pipes as `\|`.
+
+`@limeendkey@` uses the same runtime behavior as CIN `%limeendkey`: keys also present in `@imkeys@` are appended before committing; keys absent from `@imkeys@` first finish the active composing buffer and are then processed as a fresh key.
 
 ### 2.4.1 Escaped v2 Fields
 

--- a/docs/CIN_LIME_SPEC.md
+++ b/docs/CIN_LIME_SPEC.md
@@ -123,6 +123,8 @@ ab|試|0|456
 
 Importers accept `.lime` mapping lines with or without `%chardef begin/end`. Exporters include the block for readability and compatibility.
 
+Lines beginning with `#` are skipped as comments and are ignored during delimiter detection.
+
 ### 2.2 Encoding
 
 Exporters write UTF-8. Use UTF-8 text for imports. Importers accept a UTF-8 BOM on the first line.

--- a/docs/LIME_SETTINGS.md
+++ b/docs/LIME_SETTINGS.md
@@ -432,6 +432,9 @@ NavigationStack (continued)
         │   ├── Editable row "版本"    DBServer.getImConfig(tableNick, "version") ?? legacy mapping_version ?? "—"
         │   │   └── tap → single-field editor "編輯版本" → ManageImController.updateIMMetadataField(tableNick, "version", value)
         │   │       → DBServer.setImConfig(tableNick, "version", value) → im table row title="version"
+        │   ├── Editable row "結束鍵"  DBServer.getImConfig(tableNick, "limeendkey") ?? "—"
+        │   │   └── tap → single-field editor "編輯結束鍵" → ManageImController.updateIMMetadataField(tableNick, "limeendkey", value)
+        │   │       → DBServer.setImConfig(tableNick, "limeendkey", value) → im table row title="limeendkey"
         │   └── LabeledContent "筆數"    manageImController.countRecords(table: im.tableNick) — fetched in .task
         ├── Section "軟鍵盤配置"  (hidden when im.tableNick == "related")
         │   └── NavigationLink "鍵盤佈局：\(currentKeyboard.name)" → KeyboardPickerView(im:)
@@ -466,12 +469,12 @@ NavigationStack (continued)
 ```
 
 **Editable metadata rows**:
-- `名稱` and `版本` stay as independent rows, not a combined editor.
+- `名稱`, `版本`, and `結束鍵` stay as independent rows, not a combined editor.
 - Each row must show an edit/disclosure affordance (`chevron.right` on iOS, trailing chevron row on Android) so users can tell the field is editable.
-- `名稱` cannot be empty; `版本` may be empty, displayed as `—`, and still persists an empty `title="version"` value when saved.
+- `名稱` cannot be empty; `版本` and `結束鍵` may be empty, displayed as `—`, and still persist empty `title="version"` / `title="limeendkey"` values when saved. Empty `limeendkey` means the table has no Lime runtime end-key commit triggers.
 - Saving writes only the tapped field through the Controller → `DBServer.setImConfig(...)` path. UI code must not write directly to `LimeDB`.
 - After a successful save, the detail page updates immediately and the IM list refreshes so the list label uses the edited name.
-- The synthetic `related` row is read-only for metadata and hides the version row.
+- The synthetic `related` row is read-only for metadata and hides the version/endkey rows.
 
 **Synthetic 關聯字庫 row**: `IMRow(id: -1, imName: "related", label: "關聯字庫", tableNick: "related", ...)` — constructed inline in `IMListView`; `.task` skips keyboard loading for this row.
 

--- a/docs/keyboard-type-field-test.html
+++ b/docs/keyboard-type-field-test.html
@@ -114,7 +114,32 @@
 
     <label>
       Search
-      <input type="search" inputmode="search" autocomplete="off" placeholder="搜尋或輸入文字">
+      <input type="search" inputmode="search" enterkeyhint="search" autocomplete="off" placeholder="搜尋或輸入文字">
+    </label>
+
+    <label>
+      Send return key
+      <input type="text" enterkeyhint="send" autocomplete="off" placeholder="Expected return key: Send">
+    </label>
+
+    <label>
+      Next return key
+      <input type="text" enterkeyhint="next" autocomplete="off" placeholder="Expected return key: Next">
+    </label>
+
+    <label>
+      Go return key
+      <input type="url" inputmode="url" enterkeyhint="go" autocomplete="off" placeholder="Expected return key: Go">
+    </label>
+
+    <label>
+      Done return key
+      <input type="text" enterkeyhint="done" autocomplete="off" placeholder="Expected return key: Done">
+    </label>
+
+    <label>
+      Enter return key
+      <textarea enterkeyhint="enter" autocomplete="off" placeholder="Expected return key: default Enter"></textarea>
     </label>
   </main>
 </body>


### PR DESCRIPTION
## Summary

- Android fixes/features for #90, #91, #93, #94, #96, and #99, including backup safety, `.cin` duplicate-code order, `.lime` metadata parsing, Lime-specific end-key behavior, system accent color support, and shifted symbol-label cleanup.
- iOS parity/fix work for #93, #96, #99, #100, plus Shift double-tap behavior and selected DB/search/backup alignment.
- Adds the `docs/keyboard-type-field-test.html` contextual return-key fields needed to visually verify #100 once merged to the GitHub Pages source branch.

## Verification

- Android #90 focused resource test passed for settings accent layout references.
- Android debug install and visual verification were performed for system accent behavior in LIME Settings.
- iOS focused #100 regression test was run red/green and passed after the fix.
- iOS `KeyboardViewControllerTest` broader run passed the new #100 test, but still has an unrelated existing failure: `testIMDetailShareButtonUsesConstrainedLayoutTrailingSlot`.
- `git diff --check` passed before PR creation.

## Notes

- One local IDE metadata file remains dirty and is not part of this PR: `LimeStudio/.idea/gradle.xml`.
