### PR TITLE
Fix related candidate default selection

### DIFF
--- a/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
@@ -1798,7 +1798,7 @@ final class KeyboardViewController: UIInputViewController {
               !full.isEmpty else { return }
         mCandidateList = full
         hasCandidatesShown = true
-        let idx = LimeEndkeyPolicy.defaultCommitCandidateIndex(full)
+        let idx = LimeEndkeyPolicy.defaultCandidateSelectionIndex(full)
         selectedCandidate = (idx >= 0) ? full[idx] : nil
         candidateBar.appendCandidates(full, selectedIndex: idx)
         // If the expanded grid is currently visible for normal candidates,
@@ -1823,7 +1823,7 @@ final class KeyboardViewController: UIInputViewController {
         // Normal-candidate selection seed (mirrors Android CandidateView.setSuggestions,
         // CandidateView.java:1182–1196). Associated lists (related phrases, punctuation,
         // English) bypass this method entirely and stay at selectedIndex = -1.
-        let selectedIdx = LimeEndkeyPolicy.defaultCommitCandidateIndex(list)
+        let selectedIdx = LimeEndkeyPolicy.defaultCandidateSelectionIndex(list)
         selectedCandidate = (selectedIdx >= 0) ? list[selectedIdx] : nil
         candidateBar.setIdleToolsSuppressed(false)
 
@@ -2401,7 +2401,7 @@ final class KeyboardViewController: UIInputViewController {
                     self.mCandidateList         = related
                     self.hasCandidatesShown     = true
                     self.isShowingRelatedPhrases = true
-                    self.selectedCandidate      = related.first
+                    self.selectedCandidate      = nil
                     self.showCandidates(related)
                 }
             }
@@ -2438,7 +2438,7 @@ final class KeyboardViewController: UIInputViewController {
                 else {
                     self.mCandidateList    = mappings
                     self.hasCandidatesShown = true
-                    self.selectedCandidate = mappings.first
+                    self.selectedCandidate = nil
                     self.showCandidates(mappings)
                 }
             }

--- a/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
+++ b/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
@@ -751,18 +751,41 @@ final class KeyboardViewControllerTest: XCTestCase {
         ))
     }
 
-    func testLimeEndkeyDefaultCandidatePrefersRealCommitCandidate() {
+    func testLimeEndkeyDefaultCandidatePrefersRealCommitCandidateWithoutFallback() {
         let composing = Mapping(id: 0, code: ",", word: ",", score: 0, baseScore: 0,
                                 recordType: Mapping.RecordType.composingCode)
         let exact = Mapping(id: 1, code: ",", word: "，", score: 0, baseScore: 0,
                             recordType: Mapping.RecordType.exactMatchToCode)
         let punctuation = Mapping(id: 2, code: ".", word: "。", score: 0, baseScore: 0,
                                   recordType: Mapping.RecordType.chinesePunctuation)
+        let related = Mapping(id: 3, code: "", word: "了", score: 0, baseScore: 0,
+                              recordType: Mapping.RecordType.relatedPhrase)
 
         XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([composing, exact]), 1)
         XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([composing, punctuation]), 1)
-        XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([composing]), 0)
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([composing]), -1)
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([composing, related]), -1)
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([related]), -1)
         XCTAssertEqual(LimeEndkeyPolicy.defaultCommitCandidateIndex([]), -1)
+    }
+
+    func testDefaultCandidateSelectionKeepsBrowseOnlyListsUnselected() {
+        let composing = Mapping(id: 0, code: "aa", word: "aa", score: 0, baseScore: 0,
+                                recordType: Mapping.RecordType.composingCode)
+        let exact = Mapping(id: 1, code: "aa", word: "昌", score: 0, baseScore: 0,
+                            recordType: Mapping.RecordType.exactMatchToCode)
+        let punctuation = Mapping(id: 2, code: ".", word: "。", score: 0, baseScore: 0,
+                                  recordType: Mapping.RecordType.chinesePunctuation)
+        let related = Mapping(id: 3, code: "", word: "了", score: 0, baseScore: 0,
+                              recordType: Mapping.RecordType.relatedPhrase)
+        let runtimeBuilt = Mapping(id: 4, code: "aa", word: "昌", score: 0, baseScore: 0,
+                                   recordType: Mapping.RecordType.runtimeBuiltPhrase)
+
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCandidateSelectionIndex([composing, exact]), 1)
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCandidateSelectionIndex([composing, punctuation]), 0)
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCandidateSelectionIndex([runtimeBuilt]), 0)
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCandidateSelectionIndex([related]), -1)
+        XCTAssertEqual(LimeEndkeyPolicy.defaultCandidateSelectionIndex([]), -1)
     }
 
     func testKeyboardControllerRoutesLimeEndkeyBeforeNormalCharacterHandling() throws {
@@ -779,16 +802,28 @@ final class KeyboardViewControllerTest: XCTestCase {
         XCTAssertTrue(source.contains("currentSearchID &+= 1"))
     }
 
-    func testNormalCandidateSelectionUsesSameDefaultPolicyAsLimeEndkey() throws {
+    func testNormalCandidateSelectionStaysSeparateFromLimeEndkeyPolicy() throws {
         let source = try String(
             contentsOf: projectFileURL("LimeKeyboard/KeyboardViewController.swift"),
             encoding: .utf8
         )
 
-        XCTAssertTrue(source.contains("let idx = LimeEndkeyPolicy.defaultCommitCandidateIndex(full)"))
-        XCTAssertTrue(source.contains("let selectedIdx = LimeEndkeyPolicy.defaultCommitCandidateIndex(list)"))
+        XCTAssertTrue(source.contains("let idx = LimeEndkeyPolicy.defaultCandidateSelectionIndex(full)"))
+        XCTAssertTrue(source.contains("let selectedIdx = LimeEndkeyPolicy.defaultCandidateSelectionIndex(list)"))
         XCTAssertFalse(source.contains("full.count > 1 && (full[1].isExactMatchToCodeRecord || full[1].isPartialMatchToCodeRecord)"))
         XCTAssertFalse(source.contains("list.count > 1 && (list[1].isExactMatchToCodeRecord || list[1].isPartialMatchToCodeRecord)"))
+    }
+
+    func testBrowseOnlyCandidateListsDoNotSeedSelectedCandidate() throws {
+        let source = try String(
+            contentsOf: projectFileURL("LimeKeyboard/KeyboardViewController.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(source.contains("self.selectedCandidate      = nil"))
+        XCTAssertTrue(source.contains("self.selectedCandidate = nil"))
+        XCTAssertFalse(source.contains("self.selectedCandidate      = related.first"))
+        XCTAssertFalse(source.contains("self.selectedCandidate = mappings.first"))
     }
 
     func testSettingsGroupedSurfacesMatchSetupTabColors() throws {

--- a/LimeIME-iOS/Shared/Models/Mapping.swift
+++ b/LimeIME-iOS/Shared/Models/Mapping.swift
@@ -96,15 +96,24 @@ enum LimeEndkeyPolicy {
         return imkeys.contains(key) || imkeys.contains(key.lowercased())
     }
 
-    static func defaultCommitCandidateIndex(_ suggestions: [Mapping]) -> Int {
+    static func defaultCandidateSelectionIndex(_ suggestions: [Mapping]) -> Int {
         guard !suggestions.isEmpty else { return -1 }
-        if let index = suggestions.firstIndex(where: isDefaultCommitCandidate) {
-            return index
+        if suggestions.count > 1,
+           suggestions[1].isExactMatchToCodeRecord || suggestions[1].isPartialMatchToCodeRecord {
+            return 1
         }
-        return 0
+        let firstCandidate = suggestions[0]
+        if firstCandidate.isComposingCodeRecord || firstCandidate.isRuntimeBuiltPhraseRecord {
+            return 0
+        }
+        return -1
     }
 
-    private static func isDefaultCommitCandidate(_ candidate: Mapping) -> Bool {
+    static func defaultCommitCandidateIndex(_ suggestions: [Mapping]) -> Int {
+        suggestions.firstIndex(where: isEndkeyCommitCandidate) ?? -1
+    }
+
+    private static func isEndkeyCommitCandidate(_ candidate: Mapping) -> Bool {
         !candidate.isComposingCodeRecord
             && (candidate.isExactMatchToCodeRecord
                 || candidate.isPartialMatchToCodeRecord

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
@@ -155,17 +155,42 @@ public class LIMEServiceTest {
     }
 
     @Test
-    public void defaultSelectedCandidatePrefersChinesePunctuationOverRawComposingCode() {
-        Mapping composing = createPlainCandidate(".", ".");
+    public void defaultSelectedCandidateKeepsLegacyCompositionRules() {
+        Mapping composing = createPlainCandidate("aa", "aa");
         composing.setComposingCodeRecord();
+        Mapping exactCandidate = createPlainCandidate("aa", "昌");
+        exactCandidate.setExactMatchToCodeRecord();
+        List<Mapping> exactCandidates = new ArrayList<>();
+        exactCandidates.add(composing);
+        exactCandidates.add(exactCandidate);
+
+        assertEquals(1, LIMEService.defaultSelectedCandidateIndex(exactCandidates, false));
+        assertSame(exactCandidate, LIMEService.defaultSelectedCandidateForSuggestions(exactCandidates, false));
+
+        Mapping punctuationComposing = createPlainCandidate(".", ".");
+        punctuationComposing.setComposingCodeRecord();
         Mapping punctuation = createPlainCandidate(".", "。");
         punctuation.setChinesePunctuationSymbolRecord();
-        List<Mapping> candidates = new ArrayList<>();
-        candidates.add(composing);
-        candidates.add(punctuation);
+        List<Mapping> punctuationCandidates = new ArrayList<>();
+        punctuationCandidates.add(punctuationComposing);
+        punctuationCandidates.add(punctuation);
 
-        assertEquals(1, LIMEService.defaultSelectedCandidateIndex(candidates, false));
-        assertSame(punctuation, LIMEService.defaultSelectedCandidateForSuggestions(candidates, false));
+        assertEquals(0, LIMEService.defaultSelectedCandidateIndex(punctuationCandidates, false));
+        assertSame(punctuationComposing, LIMEService.defaultSelectedCandidateForSuggestions(punctuationCandidates, false));
+    }
+
+    @Test
+    public void relatedPhraseCandidatesHaveNoDefaultSelectionForEnterPassThrough() {
+        Mapping relatedOne = createPlainCandidate("", "了");
+        relatedOne.setRelatedPhraseRecord();
+        Mapping relatedTwo = createPlainCandidate("", "的");
+        relatedTwo.setRelatedPhraseRecord();
+        List<Mapping> relatedCandidates = new ArrayList<>();
+        relatedCandidates.add(relatedOne);
+        relatedCandidates.add(relatedTwo);
+
+        assertEquals(-1, LIMEService.defaultSelectedCandidateIndex(relatedCandidates, false));
+        assertNull(LIMEService.defaultSelectedCandidateForSuggestions(relatedCandidates, false));
     }
 
     @Test
@@ -297,7 +322,8 @@ public class LIMEServiceTest {
         candidates.add(candidate);
         Mapping commaComposing = createCandidate(",", ",");
         commaComposing.setComposingCodeRecord();
-        Mapping commaCandidate = createCandidate(",", "，");
+        Mapping commaCandidate = createPlainCandidate(",", "，");
+        commaCandidate.setChinesePunctuationSymbolRecord();
         LinkedList<Mapping> commaCandidates = new LinkedList<>();
         commaCandidates.add(commaComposing);
         commaCandidates.add(commaCandidate);

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
@@ -2236,7 +2236,7 @@ public class LIMEService extends InputMethodService
                 return null;
             }
             mCandidateList = new LinkedList<>(candidates);
-            selectedCandidate = defaultSelectedCandidateForSuggestions(mCandidateList, hasPhysicalKeyPressed);
+            selectedCandidate = endkeySelectedCandidateForSuggestions(mCandidateList);
             hasMappingList = selectedCandidate != null;
             hasCandidatesShown = selectedCandidate != null;
             return selectedCandidate;
@@ -2275,15 +2275,31 @@ public class LIMEService extends InputMethodService
         if (suggestions == null || suggestions.isEmpty()) {
             return -1;
         }
-        for (int i = 0; i < suggestions.size(); i++) {
-            if (isDefaultCommitCandidate(suggestions.get(i))) {
-                return i;
-            }
+        if (suggestions.size() > 1
+                && (suggestions.get(1).isExactMatchToCodeRecord()
+                || suggestions.get(1).isPartialMatchToCodeRecord())) {
+            return 1;
         }
-        return 0;
+        Mapping firstCandidate = suggestions.get(0);
+        if (firstCandidate.isComposingCodeRecord() || firstCandidate.isRuntimeBuiltPhraseRecord()) {
+            return 0;
+        }
+        return -1;
     }
 
-    private static boolean isDefaultCommitCandidate(Mapping candidate) {
+    private static Mapping endkeySelectedCandidateForSuggestions(List<Mapping> suggestions) {
+        if (suggestions == null || suggestions.isEmpty()) {
+            return null;
+        }
+        for (Mapping candidate : suggestions) {
+            if (isEndkeyCommitCandidate(candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isEndkeyCommitCandidate(Mapping candidate) {
         return candidate != null
                 && !candidate.isComposingCodeRecord()
                 && (candidate.isExactMatchToCodeRecord()

--- a/docs/#104_ISSUE.md
+++ b/docs/#104_ISSUE.md
@@ -74,17 +74,17 @@ Before `35abf08d`, `CandidateView.setSuggestions(...)` explicitly kept related p
 
 So the fix should restore the old no-default-highlight rule for post-commit related/association candidates while preserving the intended #96 behavior for active composition and Lime end-key resolution.
 
-## Proposed fix / investigation plan
+## Fix approach
 
-1. Reproduce with Android `6.1.16` using a table/setting path that leaves related candidates visible after committing a word.
-2. Add focused regression coverage that a related-only candidate list returns no default selected index / no highlighted item, and that Enter with `mComposing.length() == 0` plus related candidates visible passes through rather than committing candidate 0.
-3. Adjust default candidate selection so related/association candidate lists keep `mSelectedIndex = -1`; do not rely only on special-casing Enter after the fact.
-4. Keep existing expected behavior for:
-   - active composing candidate selection,
-   - Space candidate commit behavior,
-   - opt-in end-key behavior from `%limeendkey` / `@limeendkey@`,
-   - physical-keyboard Enter if it shares the same state path.
-5. Verify with normal text/newline fields and browser/search fields because the reporter specifically mentions newline/search actions.
+The source fix restores the pre-`35abf08d` default-highlight rules used by `CandidateView` / visible candidate strips:
+
+1. If the second candidate is an exact/partial match to the current code, default-select index `1`.
+2. Else if the first candidate is the composing-code or runtime-built-phrase record, default-select index `0`.
+3. Else leave no default selected item (`-1`).
+
+That means related/association-only strips, Chinese punctuation-symbol-only strips, and English suggestions do not get an automatic highlighted/default item. Enter/Search/Return can therefore pass through after composition has already ended.
+
+`%limeendkey` / `@limeendkey@` is handled separately: end-key resolution now uses a private end-key candidate resolver that can still choose exact/partial/chinese-punctuation candidates for explicit end-key commits without changing the visible/default candidate selection rules. This keeps #96 behavior decoupled from the candidate-strip default item.
 
 ## Follow-up questions
 
@@ -108,7 +108,7 @@ Not reported. iOS has a separate Swift keyboard implementation, so Android `LIME
 
 ## Verification plan
 
-- Android unit/instrumentation coverage: construct a related-only candidate list and verify `defaultSelectedCandidateIndex(...) == -1` / `CandidateView` has no highlighted item; simulate post-commit related candidates visible with no composing code, press Enter, and verify no related candidate is committed and the editor action/newline path is allowed.
+- Android unit/instrumentation coverage: added coverage for legacy default-selection rules and related-only candidate lists returning `-1` / no default selected candidate. Existing end-key coverage now uses a Chinese-punctuation record (not just an exact-match record) for the fresh trigger candidate.
 - Android manual: in a normal multiline text field, press Enter after committing a word with related candidates visible and confirm a newline occurs.
 - Android manual: in a browser/search field, press Enter/Search after committing a word with related candidates visible and confirm search/action runs.
 - Regression: active composing candidate selection with Space and valid selection keys still works; `%limeendkey`/`@limeendkey@` behavior from #96 remains unchanged.
@@ -116,7 +116,8 @@ Not reported. iOS has a separate Swift keyboard implementation, so Android `LIME
 
 ## Current follow-up status
 
-- Classification: plausible Android bug / regression.
-- Public issue: open, pending source fix.
+- Classification: Android bug / regression.
+- Public issue: open, source fix prepared in branch `fix/issue-104-restore-default-candidate`.
 - Root-cause attribution: `35abf08da89ddec0b221fab5612a44cbd2ea03d4` introduced default-selection fallback `return 0`, which accidentally highlights related-only candidates.
-- Retest condition: wait for a newer Android APK than `6.1.16` containing a targeted Enter/related-candidate fix before asking the reporter to retest.
+- Validation in WSL: Java/app and androidTest compilation pass; connected instrumentation execution is blocked by no attached Android device/emulator.
+- Retest condition: wait for a newer Android APK than `6.1.16` containing the targeted Enter/related-candidate fix before asking the reporter to retest.

--- a/docs/#104_ISSUE.md
+++ b/docs/#104_ISSUE.md
@@ -1,4 +1,4 @@
-# Issue #104 — Android Enter key commits related candidate after 6.1.16
+# Issue #104 — Enter/Return commits related candidate after 6.1.16
 
 ## Problem statement
 
@@ -104,7 +104,13 @@ Confirmed reporter platform. The inspected Android `LIMEService` candidate/Enter
 
 ### iOS
 
-Not reported. iOS has a separate Swift keyboard implementation, so Android `LIMEService.java` state handling does not directly apply. Still, iOS should receive a light parity audit for return-key behavior when related candidates remain visible after commit, especially if the intended product rule is that Enter/Search/Return should pass through once composition has ended.
+iOS has a separate Swift keyboard implementation, but the parity audit found the same class of risk:
+
+- `KeyboardViewController.handleEnterOrSpace(...)` already treats related, Chinese-punctuation, and English-prediction lists as browse-only, so Return/Space should pass through in the direct #104 path.
+- However, `LimeEndkeyPolicy.defaultCommitCandidateIndex(...)` used the same unsafe fallback-to-`0` shape as Android, and normal candidate-strip selection called that helper. This couples `%limeendkey` commit resolution to visible default selection.
+- `updateRelatedPhrase(...)` and `updateEnglishPrediction(...)` displayed browse-only candidates with `showCandidates(..., selectedIndex: -1)` but still set controller `selectedCandidate` to `.first`, leaving stale controller-side selection inconsistent with the unhighlighted UI.
+
+The iOS fix mirrors Android: split visible default selection (`defaultCandidateSelectionIndex`) from end-key commit resolution (`defaultCommitCandidateIndex`), remove the fallback-to-first behavior for end-key resolution, and keep browse-only related/English lists with `selectedCandidate = nil` unless the user explicitly taps one.
 
 ## Verification plan
 
@@ -112,12 +118,13 @@ Not reported. iOS has a separate Swift keyboard implementation, so Android `LIME
 - Android manual: in a normal multiline text field, press Enter after committing a word with related candidates visible and confirm a newline occurs.
 - Android manual: in a browser/search field, press Enter/Search after committing a word with related candidates visible and confirm search/action runs.
 - Regression: active composing candidate selection with Space and valid selection keys still works; `%limeendkey`/`@limeendkey@` behavior from #96 remains unchanged.
-- iOS audit: confirm return/search key behavior with visible related candidates after commit, or document that iOS behavior is already independent.
+- iOS unit coverage: added Swift policy coverage for legacy default candidate-strip selection, related-only no-selection, `%limeendkey` commit selection staying separate, and no fallback to related candidates.
+- iOS manual: with related candidates visible after commit, press Return/Search and confirm the host editor action passes through; explicitly tapping a related candidate should still commit it.
 
 ## Current follow-up status
 
-- Classification: Android bug / regression.
-- Public issue: open, source fix prepared in branch `fix/issue-104-restore-default-candidate`.
+- Classification: Android bug / regression; iOS parity risk found and fixed in the same branch.
+- Public issue: open, source fix prepared in branch `fix/issue-104-restore-default-candidate` / PR #105.
 - Root-cause attribution: `35abf08da89ddec0b221fab5612a44cbd2ea03d4` introduced default-selection fallback `return 0`, which accidentally highlights related-only candidates.
-- Validation in WSL: Java/app and androidTest compilation pass; connected instrumentation execution is blocked by no attached Android device/emulator.
+- Validation in WSL: Java/app and androidTest compilation pass; Swift policy helper compiles/runs with Linux Swift; connected Android instrumentation and full iOS/Xcode builds are blocked by no attached Android device/emulator and no macOS/Xcode toolchain in WSL.
 - Retest condition: wait for a newer Android APK than `6.1.16` containing the targeted Enter/related-candidate fix before asking the reporter to retest.


### PR DESCRIPTION
## Summary
- restore the pre-limeendkey default candidate selection rules for the visible candidate strip
- keep related/association-only candidates unhighlighted so Enter/Search/Return can pass through after composition ends
- split explicit `%limeendkey` resolution from normal/default candidate selection so #96 behavior stays independent
- add regression coverage for legacy default selection, related-only no-default selection, and Chinese-punctuation end-key resolution

## Validation
- `ANDROID_HOME=$HOME/Android/Sdk ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew :app:compileDebugJavaWithJavac :app:compileDebugAndroidTestJavaWithJavac`
- `git diff --check`

Connected instrumentation was attempted for the new #104 regression test but WSL has no connected Android device/emulator (`No connected devices!`).

Fixes #104