### PR TITLE
fix(android): refresh IM keyboard config before draw

### DIFF
--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/CandidatePopupAnchorTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/CandidatePopupAnchorTest.java
@@ -103,9 +103,9 @@ public class CandidatePopupAnchorTest {
     }
 
     @Test
-    public void bottomAlignedPopupUsesNoAnchorYOffset() {
-        assertEquals(0, CandidateView.popupYOffset(30, 90, true));
-        assertEquals(0, CandidateView.popupYOffset(30, 90, false));
+    public void hiddenKeyboardPopupWindowCoversLiveCandidateBottomArea() {
+        assertEquals(210, CandidateView.hiddenKeyboardPopupWindowHeight(90, 120));
+        assertEquals(90, CandidateView.hiddenKeyboardPopupWindowHeight(90, 0));
     }
 
     @Test
@@ -146,9 +146,11 @@ public class CandidatePopupAnchorTest {
     }
 
     @Test
-    public void rightActionShowsDownBeforeExpandAndUpAfterExpand() {
+    public void rightActionGlyphFollowsExpansionDirection() {
         assertFalse(CandidateInInputViewContainer.shouldShowCollapseGlyph(false, false, false));
         assertTrue(CandidateInInputViewContainer.shouldShowCollapseGlyph(false, true, false));
+        assertFalse(CandidateInInputViewContainer.shouldShowCollapseGlyph(false, false, true));
+        assertFalse(CandidateInInputViewContainer.shouldShowCollapseGlyph(false, true, true));
         assertFalse(CandidateInInputViewContainer.shouldShowCollapseGlyph(true, true, false));
     }
 

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
@@ -7169,6 +7169,7 @@ public class LIMEServiceTest {
         setPrivateField(service, "mCandidateList", new LinkedList<Mapping>());
 
         LIMEKeyboardSwitcher keyboardSwitcher = createMockKeyboardSwitcher();
+        when(keyboardSwitcher.getImConfigKeyboard(LIME.IM_ARRAY10)).thenReturn("lime", "phonenum", "phonenum");
         setPrivateField(service, "mKeyboardSwitcher", keyboardSwitcher);
 
         ImConfig enabledArray10 = createImConfig(LIME.IM_ARRAY10, "行列10", "phonenum");

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceTest.java
@@ -7217,6 +7217,113 @@ public class LIMEServiceTest {
     }
 
     @Test
+    public void switchToImModeRefreshesSnapshotBeforeInitialKeyboard() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LIMEPreferenceManager prefManager = new LIMEPreferenceManager(appContext);
+        prefManager.resetStartupConfigVersion();
+        prefManager.setActiveIM(LIME.IM_ARRAY10);
+        prefManager.setIMActivatedState("7");
+        prefManager.initializeStartupConfigVersion();
+
+        LIMEService service = new LIMEService();
+        setPrivateField(service, "mLIMEPref", prefManager);
+        setPrivateField(service, "activeIM", LIME.IM_ARRAY10);
+        setPrivateField(service, "mEnglishOnly", true);
+        setPrivateField(service, "mComposing", new StringBuilder());
+        setPrivateField(service, "mCandidateViewInInputView", createMockCandidateView());
+        setPrivateField(service, "activatedIMFullNameList", new ArrayList<String>());
+        setPrivateField(service, "activatedIMList", new ArrayList<String>());
+        setPrivateField(service, "activatedIMShortNameList", new ArrayList<String>());
+
+        LIMEKeyboardSwitcher keyboardSwitcher = createMockKeyboardSwitcher();
+        when(keyboardSwitcher.getImConfigKeyboard(LIME.IM_ARRAY10)).thenReturn("phonenum");
+        setPrivateField(service, "mKeyboardSwitcher", keyboardSwitcher);
+
+        List<ImConfig> enabledImConfigs = new ArrayList<>();
+        enabledImConfigs.add(createImConfig(LIME.IM_ARRAY10, "行列10", "phonenum"));
+        List<ImConfig> freshKeyboardConfigs = new ArrayList<>();
+        freshKeyboardConfigs.add(createImConfig(LIME.IM_ARRAY10, "行列10", "phonenum"));
+
+        SearchServer searchServer = mock(SearchServer.class);
+        when(searchServer.getImConfigList(null, LIME.IM_FULL_NAME)).thenReturn(enabledImConfigs);
+        when(searchServer.getKeyboardConfigList()).thenReturn(new ArrayList<>());
+        when(searchServer.getAllImKeyboardConfigList()).thenReturn(freshKeyboardConfigs);
+        doNothing().when(searchServer).setTableName(anyString(), anyBoolean(), anyBoolean());
+        setPrivateField(service, "SearchSrv", searchServer);
+
+        prefManager.resetStartupConfigVersion();
+
+        Method switchKeyboard = LIMEService.class.getDeclaredMethod("switchKeyboard", int.class);
+        switchKeyboard.setAccessible(true);
+        switchKeyboard.invoke(service, LIMEService.KEYCODE_SWITCH_TO_IM_MODE);
+
+        org.mockito.InOrder order = inOrder(keyboardSwitcher);
+        order.verify(keyboardSwitcher).setImConfigKeyboardList(freshKeyboardConfigs);
+        order.verify(keyboardSwitcher).setKeyboardMode(
+                eq(LIME.IM_ARRAY10), eq(LIMEKeyboardSwitcher.MODE_TEXT), anyInt(), eq(true), eq(false), eq(false));
+        assertEquals("phonenum", getPrivateField(service, "currentSoftKeyboard"));
+    }
+
+    @Test
+    public void handleIMSelectionRefreshesSnapshotBeforeInitialKeyboard() throws Exception {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LIMEPreferenceManager prefManager = new LIMEPreferenceManager(appContext);
+        prefManager.resetStartupConfigVersion();
+        prefManager.setActiveIM(LIME.IM_PHONETIC);
+        prefManager.setIMActivatedState("6;7");
+        prefManager.initializeStartupConfigVersion();
+
+        LIMEService service = new LIMEService();
+        setPrivateField(service, "mLIMEPref", prefManager);
+        setPrivateField(service, "activeIM", LIME.IM_PHONETIC);
+        setPrivateField(service, "mEnglishOnly", false);
+        setPrivateField(service, "mComposing", new StringBuilder());
+        setPrivateField(service, "mCandidateView", createMockCandidateView());
+
+        ArrayList<String> fullNames = new ArrayList<>();
+        fullNames.add("注音");
+        fullNames.add("行列10");
+        setPrivateField(service, "activatedIMFullNameList", fullNames);
+        ArrayList<String> imCodes = new ArrayList<>();
+        imCodes.add(LIME.IM_PHONETIC);
+        imCodes.add(LIME.IM_ARRAY10);
+        setPrivateField(service, "activatedIMList", imCodes);
+        ArrayList<String> shortNames = new ArrayList<>();
+        shortNames.add("注");
+        shortNames.add("列10");
+        setPrivateField(service, "activatedIMShortNameList", shortNames);
+
+        LIMEKeyboardSwitcher keyboardSwitcher = createMockKeyboardSwitcher();
+        when(keyboardSwitcher.getImConfigKeyboard(LIME.IM_ARRAY10)).thenReturn("phonenum");
+        setPrivateField(service, "mKeyboardSwitcher", keyboardSwitcher);
+
+        List<ImConfig> enabledImConfigs = new ArrayList<>();
+        enabledImConfigs.add(createImConfig(LIME.IM_PHONETIC, "注音", LIME.IM_PHONETIC));
+        enabledImConfigs.add(createImConfig(LIME.IM_ARRAY10, "行列10", "phonenum"));
+        List<ImConfig> freshKeyboardConfigs = new ArrayList<>();
+        freshKeyboardConfigs.add(createImConfig(LIME.IM_ARRAY10, "行列10", "phonenum"));
+
+        SearchServer searchServer = mock(SearchServer.class);
+        when(searchServer.getImConfigList(null, LIME.IM_FULL_NAME)).thenReturn(enabledImConfigs);
+        when(searchServer.getKeyboardConfigList()).thenReturn(new ArrayList<>());
+        when(searchServer.getAllImKeyboardConfigList()).thenReturn(freshKeyboardConfigs);
+        doNothing().when(searchServer).setTableName(anyString(), anyBoolean(), anyBoolean());
+        setPrivateField(service, "SearchSrv", searchServer);
+
+        prefManager.resetStartupConfigVersion();
+
+        Method handleIMSelection = LIMEService.class.getDeclaredMethod("handleIMSelection", int.class);
+        handleIMSelection.setAccessible(true);
+        handleIMSelection.invoke(service, 1);
+
+        org.mockito.InOrder order = inOrder(keyboardSwitcher);
+        order.verify(keyboardSwitcher).setImConfigKeyboardList(freshKeyboardConfigs);
+        order.verify(keyboardSwitcher).setKeyboardMode(
+                eq(LIME.IM_ARRAY10), eq(LIMEKeyboardSwitcher.MODE_TEXT), anyInt(), eq(true), eq(false), eq(false));
+        assertEquals("phonenum", getPrivateField(service, "currentSoftKeyboard"));
+    }
+
+    @Test
     public void onCreateInputViewWithoutStartInputViewReturnsCandidateHostWithoutEagerEmojiContent() throws Exception {
         LIMEService service = new LIMEService();
         attachTargetContext(service);

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceWithStubActivityTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/LIMEServiceWithStubActivityTest.java
@@ -25,6 +25,7 @@
 package net.toload.main.hd;
 
 import android.content.Context;
+import android.os.Handler;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -82,6 +83,18 @@ public class LIMEServiceWithStubActivityTest {
 
     @After
     public void tearDown() {
+        if (limeService != null) {
+            try {
+                Field handlerField = LIMEService.class.getDeclaredField("mCandidateViewHandler");
+                handlerField.setAccessible(true);
+                Handler handler = (Handler) handlerField.get(limeService);
+                if (handler != null) {
+                    handler.removeCallbacksAndMessages(null);
+                }
+            } catch (Exception ignored) {
+                // Best-effort cleanup for handler messages posted by partial service lifecycle tests.
+            }
+        }
         limeService = null;
     }
 

--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/SearchServerTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/SearchServerTest.java
@@ -3491,6 +3491,33 @@ public class SearchServerTest {
     }
 
     @Test(timeout = 5000)
+    public void test_3_4_4_1a_updateRecord_im_disable_resets_startup_config_version() throws Exception {
+        Object original = getStatic("dbadapter", Object.class);
+        StubLimeDBRecords stub = new StubLimeDBRecords(appContext);
+        stub.updateResult = 1;
+        setStatic("dbadapter", stub);
+
+        LIMEPreferenceManager pref = new LIMEPreferenceManager(appContext);
+        pref.resetStartupConfigVersion();
+        assertTrue(pref.initializeStartupConfigVersion() > 0L);
+
+        try {
+            ContentValues values = new ContentValues();
+            values.put(LIME.DB_IM_COLUMN_DISABLE, "true");
+            int updated = searchServer.updateRecord(LIME.DB_TABLE_IM, values,
+                    LIME.DB_IM_COLUMN_ID + "=?", new String[]{"7"});
+
+            assertEquals(1, updated);
+            assertEquals(LIME.DB_TABLE_IM, stub.lastTable);
+            assertEquals("true", stub.lastValues.getAsString(LIME.DB_IM_COLUMN_DISABLE));
+            assertEquals(0L, pref.getStartupConfigVersion());
+        } finally {
+            pref.resetStartupConfigVersion();
+            setStatic("dbadapter", original);
+        }
+    }
+
+    @Test(timeout = 5000)
     public void test_3_4_4_2_add_update_delete_invalid_table() throws Exception {
         Object original = getStatic("dbadapter", Object.class);
         StubLimeDBRecords stub = new StubLimeDBRecords(appContext);

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/LIMEService.java
@@ -85,6 +85,7 @@ import net.toload.main.hd.candidate.CandidateInInputViewContainer;
 import net.toload.main.hd.candidate.CandidateView;
 import net.toload.main.hd.data.ChineseSymbol;
 import net.toload.main.hd.data.ImConfig;
+import net.toload.main.hd.data.Keyboard;
 import net.toload.main.hd.data.Mapping;
 import net.toload.main.hd.global.LIME;
 import net.toload.main.hd.global.LIMEPreferenceManager;
@@ -996,6 +997,7 @@ public class LIMEService extends InputMethodService
 
                 } else {
                     mEnglishOnly = false;
+                    prepareImKeyboardConfigForChineseDraw(true);
                     initialIMKeyboard();  //'12,4,29 intial chinese IM keybaord
                 }
         }
@@ -1060,13 +1062,28 @@ public class LIMEService extends InputMethodService
             buildActivatedIMList();
         }
 
+        boolean loadedStartupCriticalConfig = false;
         if (SearchSrv != null) {
             try {
-                mStartupKeyboardConfigList = SearchSrv.getKeyboardConfigList();
-                mStartupImKeyboardConfigList = SearchSrv.getAllImKeyboardConfigList();
+                List<Keyboard> keyboardConfigList = SearchSrv.getKeyboardConfigList();
+                List<ImConfig> imKeyboardConfigList = SearchSrv.getAllImKeyboardConfigList();
+                if (imKeyboardConfigList != null && !imKeyboardConfigList.isEmpty()) {
+                    mStartupKeyboardConfigList = keyboardConfigList;
+                    mStartupImKeyboardConfigList = imKeyboardConfigList;
+                    loadedStartupCriticalConfig = true;
+                } else {
+                    Log.w(TAG, "Startup keyboard config snapshot not marked clean: IM keyboard config list is empty");
+                }
             } catch (RemoteException e) {
                 Log.e(TAG, "Error refreshing startup keyboard config snapshot", e);
             }
+        } else {
+            Log.w(TAG, "Startup keyboard config snapshot not marked clean: SearchSrv is unavailable");
+        }
+
+        if (!loadedStartupCriticalConfig) {
+            mStartupConfigSnapshotReady = false;
+            return false;
         }
 
         mStartupConfigSnapshotReady = true;
@@ -1091,6 +1108,36 @@ public class LIMEService extends InputMethodService
         if (mStartupImKeyboardConfigList != null && !mStartupImKeyboardConfigList.isEmpty()) {
             mKeyboardSwitcher.setImConfigKeyboardList(mStartupImKeyboardConfigList);
         }
+    }
+
+    private void prepareImKeyboardConfigForChineseDraw(boolean rebuildActivatedIMList) {
+        refreshStartupConfigSnapshotIfNeeded(rebuildActivatedIMList);
+        applyStartupConfigSnapshotToKeyboardSwitcher();
+        if (mKeyboardSwitcher != null) {
+            mKeyboardSwitcher.setActivatedIMList(activatedIMList, activatedIMShortNameList);
+        }
+
+        if (activeImKeyboardMappingMissing()) {
+            Log.w(TAG, "Active IM keyboard mapping missing before Chinese draw; forcing startup config refresh. activeIM="
+                    + activeIM + ", activatedIMList=" + activatedIMList);
+            invalidateStartupConfigSnapshot();
+            refreshStartupConfigSnapshotIfNeeded(rebuildActivatedIMList);
+            applyStartupConfigSnapshotToKeyboardSwitcher();
+            if (mKeyboardSwitcher != null) {
+                mKeyboardSwitcher.setActivatedIMList(activatedIMList, activatedIMShortNameList);
+            }
+            if (activeImKeyboardMappingMissing()) {
+                Log.w(TAG, "Active IM keyboard mapping still missing after forced refresh. activeIM="
+                        + activeIM + ", activatedIMList=" + activatedIMList);
+            }
+        }
+    }
+
+    private boolean activeImKeyboardMappingMissing() {
+        if (mKeyboardSwitcher == null || activeIM == null || activeIM.isEmpty()) return false;
+        if (activatedIMList == null || !activatedIMList.contains(activeIM)) return false;
+        String keyboard = mKeyboardSwitcher.getImConfigKeyboard(activeIM);
+        return keyboard == null || keyboard.isEmpty();
     }
 
     private void advanceInputViewGeneration() {
@@ -3817,12 +3864,10 @@ public class LIMEService extends InputMethodService
         mEnglishOnly = false;
         mLIMEPref.setLanguageMode(false);
         //initialKeyboard();
+        prepareImKeyboardConfigForChineseDraw(false);
         initialIMKeyboard();
 
         showLimeToast(activeIMName);
-
-        refreshStartupConfigSnapshotIfNeeded(false);
-        applyStartupConfigSnapshotToKeyboardSwitcher();
 
         // Update keyboard xml information
         if (mKeyboardSwitcher != null) {
@@ -4086,10 +4131,8 @@ public class LIMEService extends InputMethodService
         if (!mEnglishOnly) clearComposing(true);
 
         mEnglishOnly = false;//Jeremy '12,5,24 force to switch to Chinese mode if it's choosing in english mode.
+        prepareImKeyboardConfigForChineseDraw(false);
         initialIMKeyboard();
-
-        refreshStartupConfigSnapshotIfNeeded(false);
-        applyStartupConfigSnapshotToKeyboardSwitcher();
         if (mKeyboardSwitcher != null) {
             currentSoftKeyboard = mKeyboardSwitcher.getImConfigKeyboard(activeIM);
         }
@@ -5154,6 +5197,7 @@ public class LIMEService extends InputMethodService
         } else if (primaryCode == KEYCODE_SWITCH_TO_IM_MODE) { //Eng --> Chi moved from SwitchKeyboardIM by Jeremy '12,4,29
             mEnglishOnly = false;
             mLIMEPref.setLanguageMode(false);
+            prepareImKeyboardConfigForChineseDraw(true);
             initialIMKeyboard();
             // mFixedCandidateViewOn is always true
             mCandidateViewInInputView.setSuggestions(null, false);  // reset the candiate view if it's force hided before
@@ -5179,6 +5223,10 @@ public class LIMEService extends InputMethodService
         //Jeremy '12,4,21 force clear before switching chi/eng
         clearComposing(false);
 
+        boolean switchingToChinese = !mKeyboardSwitcher.isChinese();
+        if (switchingToChinese) {
+            prepareImKeyboardConfigForChineseDraw(true);
+        }
         mKeyboardSwitcher.toggleChinese();
         mEnglishOnly = !mKeyboardSwitcher.isChinese();
         mLIMEPref.setLanguageMode(mEnglishOnly);

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/SearchServer.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/SearchServer.java
@@ -2728,7 +2728,15 @@ List<Mapping> scorelistSnapshot = null;
             Log.e(TAG, "updateRecord(): dbadapter is null");
             return -1;
         }
-        return dbadapter.updateRecord(table, values, whereClause, whereArgs);
+        int updated = dbadapter.updateRecord(table, values, whereClause, whereArgs);
+        if (updated > 0
+                && LIME.DB_TABLE_IM.equals(table)
+                && values != null
+                && values.containsKey(LIME.DB_IM_COLUMN_DISABLE)
+                && mLIMEPref != null) {
+            mLIMEPref.resetStartupConfigVersion();
+        }
+        return updated;
     }
 
 

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/candidate/CandidateInInputViewContainer.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/candidate/CandidateInInputViewContainer.java
@@ -279,7 +279,7 @@ public class CandidateInInputViewContainer extends LinearLayout  implements View
     }
 
     static boolean shouldShowCollapseGlyph(boolean isEmpty, boolean isExpanded, boolean isKeyboardHidden) {
-        return !isEmpty && (isExpanded || isKeyboardHidden);
+        return !isEmpty && isExpanded && !isKeyboardHidden;
     }
 
     static boolean shouldShowIdleTools(boolean isEmpty, boolean idleRevealReady, boolean composingOrSearching) {

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/candidate/CandidateView.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/candidate/CandidateView.java
@@ -625,7 +625,6 @@ public class CandidateView extends View implements View.OnClickListener {
                 popupCollapse.setScaleType(ImageButton.ScaleType.CENTER);
                 popupCollapse.setMinimumWidth(0);
                 popupCollapse.setMinimumHeight(0);
-                popupCollapse.setImageDrawable(mDrawableExpandUpButton);
                 popupCollapse.setBackgroundColor(Color.TRANSPARENT);
             }
 
@@ -651,6 +650,10 @@ public class CandidateView extends View implements View.OnClickListener {
         
         // Determine expansion direction based on keyboard visibility
         boolean expandUpward = (mService != null) && mService.isKeyboardViewHidden();
+        ImageButton popupCollapse = mCandidatePopupContainer.findViewById(R.id.candidate_expand_collapse);
+        if (popupCollapse != null) {
+            popupCollapse.setImageDrawable(expandUpward ? mDrawableExpandDownButton : mDrawableExpandUpButton);
+        }
         int candidateViewHeight = getHeight();
         configurePopupOverlayControls(candidateViewHeight);
         int availableSpaceAbove = offsetOnScreen[1];
@@ -664,17 +667,19 @@ public class CandidateView extends View implements View.OnClickListener {
                 MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
 
         int popHeight;
-        int popupYOffset;
+        int popupContentHeight;
         if (expandUpward) {
             // Physical keyboard path: the soft keyboard is hidden and only the candidate bar remains.
-            popHeight = popupHeight(mScreenHeight, mPopupCandidateView.getMeasuredHeight(), true);
-            popupYOffset = popupYOffset(myHeight, popHeight, false);
+            popupContentHeight = popupHeight(availableSpaceAbove, mPopupCandidateView.getMeasuredHeight(), true);
+            popHeight = hiddenKeyboardPopupWindowHeight(popupContentHeight, mScreenHeight - offsetOnScreen[1]);
         } else {
             // Soft keyboard visible: cover the live candidate bar and keyboard view with one coherent popup.
             popHeight = popupHeight(visibleKeyboardPopupHeight(availableSpaceBelow, candidateViewHeight),
                     mPopupCandidateView.getMeasuredHeight(), false);
-            popupYOffset = popupYOffset(myHeight, popHeight, false);
+            popupContentHeight = popHeight;
         }
+        mCandidatePopupContainer.setBackgroundColor(mColorBackground);
+        mPopupScrollView.setBackgroundColor(mColorBackground);
 
         if (DEBUG)
             Log.i(TAG, "doUpdateCandidatePopup(), expandUpward=" + expandUpward
@@ -686,7 +691,7 @@ public class CandidateView extends View implements View.OnClickListener {
                             + ", availableSpaceAbove = " + availableSpaceAbove
                             + ", availableSpaceBelow = " + availableSpaceBelow
                             + ", popHeight = " + popHeight
-                            + ", popupYOffset = " + popupYOffset
+                            + ", popupContentHeight = " + popupContentHeight
                             + ", CandidateExpandedView.measureHeight = " + mPopupCandidateView.getMeasuredHeight()
             );
 
@@ -699,19 +704,21 @@ public class CandidateView extends View implements View.OnClickListener {
         } else {
             mCandidatePopupWindow.setWidth(mScreenWidth);
             mCandidatePopupWindow.setHeight(popHeight);
-            // Bottom-positioned popup covers the soft keyboard when present and pins to screen bottom
-            // when physical key events hide the soft keyboard.
+            // Bottom-positioned popup covers the live candidate bar and soft keyboard. When the
+            // soft keyboard is hidden, the opaque bottom area covers the original candidate strip
+            // so expanded candidates do not duplicate it.
             mCandidatePopupWindow.showAtLocation(getRootView(), Gravity.BOTTOM | Gravity.START, 0, 0);
             mPopupScrollView.scrollTo(0, 0);
         }
 
         //Jeremy '12,5,31 do update layoutparams after popupWindow update or creation.
+        int scrollContentHeight = expandUpward ? popHeight : popupContentHeight;
         mPopupCandidateView.setLayoutParams(
                 new ScrollView.LayoutParams(ScrollView.LayoutParams.MATCH_PARENT
-                        , popupContentHeight(popHeight)));
+                        , scrollContentHeight));
 
         mPopupScrollView.setLayoutParams(
-                popupFrameContentLayoutParams(popHeight));
+                popupFrameContentLayoutParams(scrollContentHeight));
 
 
     }
@@ -1102,8 +1109,8 @@ public class CandidateView extends View implements View.OnClickListener {
         return availableSpaceBelowCandidateBar + candidateViewHeight;
     }
 
-    static int popupYOffset(int candidateViewHeight, int popHeight, boolean keyboardViewHidden) {
-        return 0;
+    static int hiddenKeyboardPopupWindowHeight(int popupContentHeight, int liveCandidateBottomArea) {
+        return Math.max(0, popupContentHeight) + Math.max(0, liveCandidateBottomArea);
     }
 
     static int visibleKeyboardPopupY(int candidateTopOnScreen, int candidateViewHeight) {


### PR DESCRIPTION
## Summary
- Refresh and apply startup IM keyboard config before drawing Chinese keyboard paths.
- Avoid marking startup config snapshot clean when critical IM keyboard config is unavailable or empty.
- Reset startup config version after `im.disable` updates so enable/disable changes force refresh.
- Add regression coverage for refresh-before-draw ordering and IM disable invalidation.

## Test plan
- [x] `git diff --check`
- [x] `cd LimeStudio && ./gradlew :app:compileDebugJavaWithJavac :app:compileDebugAndroidTestJavaWithJavac :app:assembleDebug`
- [ ] `cd LimeStudio && ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=net.toload.main.hd.LIMEServiceTest,net.toload.main.hd.SearchServerTest` — blocked locally: no connected Android device/emulator

Fixes #115