### PR TITLE
Fix iOS cloud IM first-switch sync

### DIFF
--- a/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
@@ -444,23 +444,7 @@ final class KeyboardViewController: UIInputViewController {
         mCompletionOn = false
         clearShiftState()
 
-        // Map keyboard type → mEnglishOnly + mPredictionOn (spec §2 table)
-        switch textDocumentProxy.keyboardType ?? .default {
-        case .numberPad, .decimalPad, .asciiCapableNumberPad:
-            mEnglishOnly = true; mPredictionOn = true
-        case .phonePad:
-            mEnglishOnly = true; mPredictionOn = false
-        case .emailAddress:
-            mEnglishOnly = true; mPredictionOn = false
-        default:
-            // Restore persisted language mode if enabled (spec §15)
-            if mPersistentLanguageMode {
-                mEnglishOnly = sharedDefaults?.bool(forKey: "persisted_english_mode") ?? false
-            } else {
-                mEnglishOnly = false
-            }
-            mPredictionOn = true
-        }
+        updateInputModeForCurrentField()
 
         // Restore last-used LIME IM (mirrors Android mLIMEPref.getActiveIM(), key "keyboard_list")
         if !mEnglishOnly {
@@ -481,6 +465,57 @@ final class KeyboardViewController: UIInputViewController {
             }
         }
 
+        applyLayoutForCurrentInputField()
+
+        clearComposing(force: false)
+        tempEnglishWord = ""
+
+    }
+
+    private func updateInputModeForCurrentField() {
+        // Map keyboard type → mEnglishOnly + mPredictionOn (spec §2 table)
+        switch textDocumentProxy.keyboardType ?? .default {
+        case .numberPad, .decimalPad, .asciiCapableNumberPad:
+            mEnglishOnly = true; mPredictionOn = true
+        case .phonePad:
+            mEnglishOnly = true; mPredictionOn = false
+        case .emailAddress:
+            mEnglishOnly = true; mPredictionOn = false
+        default:
+            // Restore persisted language mode if enabled (spec §15)
+            if mPersistentLanguageMode {
+                mEnglishOnly = sharedDefaults?.bool(forKey: "persisted_english_mode") ?? false
+            } else {
+                mEnglishOnly = false
+            }
+            mPredictionOn = true
+        }
+    }
+
+    static func layoutIdForCurrentInputField(keyboardType: UIKeyboardType,
+                                             isEnglishOnly: Bool,
+                                             hasActivatedIMs: Bool,
+                                             englishLayout: String,
+                                             resolvedActiveLayoutId: String) -> String {
+        if keyboardType == .phonePad {
+            return "phone_number"
+        }
+        if keyboardType == .numberPad
+            || keyboardType == .decimalPad
+            || keyboardType == .asciiCapableNumberPad {
+            // Mirror Android's MODE_TEXT + isSymbol path: route number /
+            // decimal fields to the symbols keyboard (digits + punctuation),
+            // not the English-alphabet layout. `.phonePad` already has its
+            // own restricted T9-style layout above.
+            return "symbols1"
+        }
+        if isEnglishOnly || !hasActivatedIMs {
+            return englishLayout
+        }
+        return resolvedActiveLayoutId
+    }
+
+    private func applyLayoutForCurrentInputField() {
         // Match Apple's keyboard: adapt the Enter key icon/label to the host's
         // returnKeyType (e.g. magnifier for URL/search fields, "Go" / "Send" labels).
         // KeyboardView.didSet skips the rebuild if rowViews are empty (initial load)
@@ -488,36 +523,24 @@ final class KeyboardViewController: UIInputViewController {
         // already-updated returnKeyType, so there is no double-build on field focus.
         keyboardView?.returnKeyType = textDocumentProxy.returnKeyType ?? .default
 
-        let kbType        = textDocumentProxy.keyboardType ?? .default
-        let isPhonePad    = kbType == .phonePad
-        let isNumericPad  = kbType == .numberPad
-                         || kbType == .decimalPad
-                         || kbType == .asciiCapableNumberPad
+        let kbType = textDocumentProxy.keyboardType ?? .default
         // English runtime layout is preference-driven; legacy KeyboardConfig engkb fields are DB compatibility data only.
         let englishLayout = numberRowInEnglish ? "lime_english_number" : "lime_english"
-        let layoutName: String
-        if isPhonePad {
-            layoutName = "phone_number"
-        } else if isNumericPad {
-            // Mirror Android's MODE_TEXT + isSymbol path: route number /
-            // decimal fields to the symbols keyboard (digits + punctuation),
-            // not the English-alphabet layout. `.phonePad` already has its
-            // own restricted T9-style layout above.
-            layoutName = "symbols1"
-        } else if mEnglishOnly || activatedIMs.isEmpty {
-            layoutName = englishLayout
-        } else {
-            layoutName = resolvedLayoutId(for: activeIM)
-        }
+        let resolvedActiveLayout = (!mEnglishOnly && !activatedIMs.isEmpty)
+            ? resolvedLayoutId(for: activeIM)
+            : ""
+        let layoutName = Self.layoutIdForCurrentInputField(
+            keyboardType: kbType,
+            isEnglishOnly: mEnglishOnly,
+            hasActivatedIMs: !activatedIMs.isEmpty,
+            englishLayout: englishLayout,
+            resolvedActiveLayoutId: resolvedActiveLayout)
         if let newLayout = LayoutLoader.load(layoutName) ?? LayoutLoader.load(englishLayout),
            newLayout.id != currentLayout.id {
             currentLayout = newLayout
             keyboardView?.setLayout(currentLayout)
             applyHeight()
         }
-
-        clearComposing(force: false)
-        tempEnglishWord = ""
 
         // Record what we just adapted to so textDidChange's field-change
         // detector doesn't re-trigger on the next keystroke.
@@ -598,6 +621,15 @@ final class KeyboardViewController: UIInputViewController {
             self.refreshImKeys()
             self.applyFeedbackSettings()
             self.preloadEmojiCategoryPages()
+
+            // setupDatabase() runs asynchronously and can complete after viewWillAppear()
+            // already chose a layout from stale/empty activatedIMs. Re-read the current
+            // field mode and re-apply the visible layout from the freshly resolved IM
+            // list so first activation after Settings/cloud install does not split
+            // English runtime state from a Chinese IM layout (#121).
+            self.updateInputModeForCurrentField()
+            self.applyLayoutForCurrentInputField()
+            self.updateGlobeAndDismissBindings()
         }
     }
 

--- a/LimeIME-iOS/LimeSettings/IMCatalog.swift
+++ b/LimeIME-iOS/LimeSettings/IMCatalog.swift
@@ -102,7 +102,7 @@ enum IMCatalog {
             description: "快速倉頡輸入法",
             systemIcon: "square.grid.2x2",
             variants: [
-                .init(id: "scj", name: "快倉字根", filename: "scj.zip", tableName: "scj", imName: "scj", label: "速成", keyboardId: "limenum", recordCount: 74_250, compressedKB: 1400),
+                .init(id: "scj", name: "快倉字根", filename: "scj.limedb", tableName: "scj", imName: "scj", label: "速成", keyboardId: "limenum", recordCount: 74_250, compressedKB: 1400),
             ]
         ),
         .init(

--- a/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
+++ b/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
@@ -924,6 +924,65 @@ final class KeyboardViewControllerTest: XCTestCase {
                 recordType: Mapping.RecordType.emoji)
     }
 
+    func testLayoutResolverKeepsEnglishRuntimeOnEnglishLayoutAfterIMRefresh() {
+        let layout = KeyboardViewController.layoutIdForCurrentInputField(
+            keyboardType: .default,
+            isEnglishOnly: true,
+            hasActivatedIMs: true,
+            englishLayout: "lime_english_number",
+            resolvedActiveLayoutId: "lime_cj")
+
+        XCTAssertEqual(layout, "lime_english_number")
+    }
+
+    func testLayoutResolverUsesActiveIMOnlyForChineseRuntimeWithActivatedIMs() {
+        let layout = KeyboardViewController.layoutIdForCurrentInputField(
+            keyboardType: .default,
+            isEnglishOnly: false,
+            hasActivatedIMs: true,
+            englishLayout: "lime_english",
+            resolvedActiveLayoutId: "lime_cj")
+
+        XCTAssertEqual(layout, "lime_cj")
+    }
+
+    func testLayoutResolverUsesEnglishLayoutWhenActivatedIMsAreEmpty() {
+        let layout = KeyboardViewController.layoutIdForCurrentInputField(
+            keyboardType: .default,
+            isEnglishOnly: false,
+            hasActivatedIMs: false,
+            englishLayout: "lime_english",
+            resolvedActiveLayoutId: "lime_cj")
+
+        XCTAssertEqual(layout, "lime_english")
+    }
+
+    func testLayoutResolverPreservesNumericAndPhoneFieldOverrides() {
+        XCTAssertEqual(KeyboardViewController.layoutIdForCurrentInputField(
+            keyboardType: .phonePad,
+            isEnglishOnly: false,
+            hasActivatedIMs: true,
+            englishLayout: "lime_english",
+            resolvedActiveLayoutId: "lime_cj"), "phone_number")
+        XCTAssertEqual(KeyboardViewController.layoutIdForCurrentInputField(
+            keyboardType: .numberPad,
+            isEnglishOnly: false,
+            hasActivatedIMs: true,
+            englishLayout: "lime_english",
+            resolvedActiveLayoutId: "lime_cj"), "symbols1")
+    }
+
+    func testDatabaseSetupReconcilesInputModeAndLayoutAfterAsyncIMRefresh() throws {
+        let source = try String(contentsOf: projectFileURL("LimeKeyboard/KeyboardViewController.swift"),
+                                encoding: .utf8)
+
+        XCTAssertTrue(source.contains("private func updateInputModeForCurrentField()"))
+        XCTAssertTrue(source.contains("private func applyLayoutForCurrentInputField()"))
+        XCTAssertTrue(source.contains("self.updateInputModeForCurrentField()\n            self.applyLayoutForCurrentInputField()"),
+                      "setupDatabase should re-apply current input mode/layout after activatedIMs refresh")
+        XCTAssertTrue(source.contains("first activation after Settings/cloud install"))
+    }
+
     func testLimeToastStateShowsTrimmedNonEmptyMessage() {
         var state = LimeToastState()
 

--- a/LimeIME-iOS/LimeTests/LIMEPreferenceManagerTest.swift
+++ b/LimeIME-iOS/LimeTests/LIMEPreferenceManagerTest.swift
@@ -27,6 +27,15 @@ final class LIMEPreferenceManagerTest: XCTestCase {
         super.tearDown()
     }
 
+    func testSyncIMActivatedStateKeepsKeyboardListCoherentWithEnabledIMs() throws {
+        let source = try String(contentsOf: projectFileURL("Shared/Preferences/LIMEPreferenceManager.swift"),
+                                encoding: .utf8)
+
+        XCTAssertTrue(source.contains("let enabledTableNicks = Set(enabledConfigs.map { $0.element.tableNick })"))
+        XCTAssertTrue(source.contains("current.isEmpty || !enabledTableNicks.contains(current)"))
+        XCTAssertTrue(source.contains("keyboardList = firstEnabled"))
+    }
+
     // MARK: - Default values
 
     func testDefaultKeyboardTheme() {
@@ -306,5 +315,12 @@ final class LIMEPreferenceManagerTest: XCTestCase {
         prefs.syncIMActivatedState(dbServer: DBServer(_testDatasource: db))
         let state = prefs.keyboardState
         XCTAssertNotNil(state)
+    }
+
+    private func projectFileURL(_ relativePath: String) -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // LimeTests
+            .deletingLastPathComponent() // LimeIME-iOS
+            .appendingPathComponent(relativePath)
     }
 }

--- a/LimeIME-iOS/Shared/Preferences/LIMEPreferenceManager.swift
+++ b/LimeIME-iOS/Shared/Preferences/LIMEPreferenceManager.swift
@@ -385,9 +385,21 @@ final class LIMEPreferenceManager {
     /// Mirrors Android's LIMEPreferenceManager.syncIMActivatedState().
     func syncIMActivatedState(dbServer: DBServer) {
         guard let configs = try? dbServer.getAllImConfigs() else { return }
-        let enabledIndices = configs.enumerated()
+        let enabledConfigs = configs.enumerated()
             .filter { $0.element.enabled }
+        keyboardState = enabledConfigs
             .map { "\($0.offset)" }
-        keyboardState = enabledIndices.joined(separator: ";")
+            .joined(separator: ";")
+
+        // Keep the current IM preference coherent with the newly synced enabled list.
+        // Cloud/download installs run from the Settings process; without this, the
+        // keyboard extension can warm-start with a stale/default keyboard_list value
+        // while setupDatabase() resolves a different active IM from keyboard_state (#121).
+        let enabledTableNicks = Set(enabledConfigs.map { $0.element.tableNick })
+        let current = keyboardList
+        if let firstEnabled = enabledConfigs.first?.element.tableNick,
+           (current.isEmpty || !enabledTableNicks.contains(current)) {
+            keyboardList = firstEnabled
+        }
     }
 }

--- a/docs/#121_ISSUE.md
+++ b/docs/#121_ISSUE.md
@@ -5,7 +5,7 @@
 - GitHub issue: https://github.com/lime-ime/limeime/issues/121
 - Reporter/source: `limeimetw` maintainer-created tracking issue
 - Classification: `bug`, `Type-Defect`, `Usability`
-- Current state: open and assigned to `jrywu`
+- Current state: open and assigned to `jrywu`; source fix prepared in PR workflow
 - Public acknowledgement: none needed because this is maintainer-created internal tracking
 
 ## Problem statement
@@ -128,6 +128,23 @@ If direct `KeyboardViewController` unit coverage is too coupled to UIKit extensi
 6. Switch Chinese ↔ English after the first activation and confirm both the visible layout and composing behavior stay synchronized.
 7. Reopen the keyboard after backgrounding Settings/host app to confirm warm-extension state does not reuse a stale layout.
 
+## Implemented source fix
+
+The focused fix keeps the iOS Settings-side preferences and keyboard-extension runtime snapshot coherent after a cloud/download install:
+
+1. `LIMEPreferenceManager.syncIMActivatedState(...)` still rebuilds `keyboard_state` from enabled `im` rows, and now also repairs `keyboard_list` when the saved/current IM is empty or no longer among the enabled IMs. This prevents a warm keyboard extension from restoring a stale/default active IM while the enabled list points elsewhere.
+2. `KeyboardViewController.initOnStartInput()` now shares its input-mode and layout-selection logic through `updateInputModeForCurrentField()` and `applyLayoutForCurrentInputField()`.
+3. After async `setupDatabase()` refreshes `SearchServer`, `activatedIMs`, settings, and IM keys, it re-reads the current field mode and re-applies the visible layout from the freshly resolved activated IM list. This closes the first-switch race where an earlier `viewWillAppear()` pass selected a layout from stale or empty `activatedIMs`.
+
+The fix is iOS-only and deliberately leaves #119 text-import layout mapping untouched.
+
+## Verification coverage
+
+- Added iOS regression coverage for the pure layout resolver, including English runtime with active IMs, Chinese runtime with active IMs, empty activated IMs, and numeric/phone field overrides.
+- Added iOS source-guard coverage that asserts async DB setup re-applies current input mode/layout after activated IM refresh.
+- Added iOS preference regression/source-guard coverage that asserts `syncIMActivatedState(...)` keeps `keyboard_list` coherent with enabled IMs.
+- Manual/device verification is still needed on iOS for warm-extension and cold-start first activation after cloud/download IM install.
+
 ## Follow-up / retest condition
 
-No public acknowledgement or community retest request is needed because #121 is maintainer-created. After a source fix lands, verify with iOS unit/simulator/device checks. Close the maintainer-created issue after maintainer/local verification or after a TestFlight/App Store build containing the targeted fix is verified; do not announce an Android APK for this iOS-only path.
+No public community retest request is needed because #121 is maintainer-created. After the source fix lands, verify with iOS unit/simulator/device checks. Close the maintainer-created issue directly after maintainer/local verification or after a TestFlight/App Store build containing the targeted fix is validated.


### PR DESCRIPTION
## Summary
- Fixes the iOS cloud/download IM first-switch race by reapplying field mode and visible layout after async keyboard DB setup refreshes `activatedIMs` / `activeIM`.
- Keeps Settings-side `keyboard_state` and `keyboard_list` coherent after cloud/download IM installs when the saved current IM is empty or no longer enabled.
- Documents #121 as iOS-only with no confirmed Android impact or Android APK retest requirement.

## Android impact check
- Audited Android startup/active-IM path separately from iOS.
- #121 is triggered by iOS `IMStoreView` + app-group `UserDefaults` + `KeyboardViewController.setupDatabase(...)` lifecycle ordering.
- No Android code is changed in this PR; if Android evidence appears later, triage separately against Android IME startup state.

## Verification
- `git diff --check`
- Lightweight Swift delimiter/source guard checks in WSL
- Security scan of added lines: no findings for hardcoded secrets, shell injection, eval/exec, pickle, or SQL formatting patterns
- Independent reviewer subagent: passed; no blocking security concerns or logic errors
- `xcodebuild` / iOS simulator tests: not available in WSL, so device/simulator verification is still needed on macOS

Closes #121
