### PR TITLE
Fix issue 124 Android popup placement

### DIFF
--- a/LimeStudio/app/src/androidTest/java/net/toload/main/hd/candidate/CandidateViewTest.java
+++ b/LimeStudio/app/src/androidTest/java/net/toload/main/hd/candidate/CandidateViewTest.java
@@ -55,6 +55,36 @@ public class CandidateViewTest {
     }
 
     @Test
+    public void clampPopupYKeepsToastFromRisingAboveCandidateRowIntoHostInput() {
+        // Issue #124: the reverse-lookup toast / composing popup naturally anchor at
+        // (candidateTop - popupHeight), i.e. above the candidate row. In bottom-composer apps
+        // (LINE/WeChat/Instagram) that area is the host message input field, so the popup must be
+        // clamped down to the candidate row top (start of the IME-owned area).
+        int candidateTopInWindow = 0;
+        int popupHeight = 80;
+        int desiredY = candidateTopInWindow - popupHeight; // -80, above the candidate row
+
+        assertEquals(candidateTopInWindow,
+                CandidateView.clampPopupYToImeArea(desiredY, candidateTopInWindow));
+    }
+
+    @Test
+    public void clampPopupYLeavesNaturalPositionWhenAlreadyInsideImeArea() {
+        // When the candidate row is not at the window top (e.g. floating candidate bar) and the
+        // popup already sits at/below the row top, the clamp must not push it down further.
+        int candidateTopInWindow = 40;
+        int desiredY = 120;
+
+        assertEquals(120, CandidateView.clampPopupYToImeArea(desiredY, candidateTopInWindow));
+    }
+
+    @Test
+    public void clampPopupYAtCandidateTopIsUnchanged() {
+        // Boundary: a popup already flush with the candidate row top stays put.
+        assertEquals(50, CandidateView.clampPopupYToImeArea(50, 50));
+    }
+
+    @Test
     public void setSuggestionsWithoutHighlightLeavesNoSelectedCandidate() {
         CandidateView candidateView = new CandidateView(
                 InstrumentationRegistry.getInstrumentation().getTargetContext(), null);

--- a/LimeStudio/app/src/main/java/net/toload/main/hd/candidate/CandidateView.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/candidate/CandidateView.java
@@ -863,6 +863,9 @@ public class CandidateView extends View implements View.OnClickListener {
         int mPopupComposingX = popupBaseXInWindow(offsetInWindow[0]);
 
         mPopupComposingY -= popupHeight;
+        // Issue #124: never let the composing/root-key popup rise above the candidate row into a
+        // host bottom-composer input field.
+        mPopupComposingY = clampPopupYToImeArea(mPopupComposingY, offsetInWindow[1]);
 
 
         if (DEBUG)
@@ -1026,13 +1029,19 @@ public class CandidateView extends View implements View.OnClickListener {
         int baseX = popupBaseXInWindow(offsetInWindow[0]);
         int x = baseX;
         int y = offsetInWindow[1] - toastHeight;
-        if (embeddedComposing != null && embeddedComposing.getVisibility() == VISIBLE) {
+        boolean embedded = embeddedComposing != null && embeddedComposing.getVisibility() == VISIBLE;
+        if (embedded) {
             int[] composingOffset = new int[2];
             embeddedComposing.getLocationInWindow(composingOffset);
             x = composingOffset[0] + embeddedComposing.getWidth() + dpToPx(8);
             y = composingOffset[1];
-        } else if (mComposingTextView != null && mComposingTextView.getVisibility() == VISIBLE) {
-            x = baseX + mComposingTextView.getWidth() + dpToPx(8);
+        } else {
+            if (mComposingTextView != null && mComposingTextView.getVisibility() == VISIBLE) {
+                x = baseX + mComposingTextView.getWidth() + dpToPx(8);
+            }
+            // Issue #124: the reverse-lookup toast anchors above the candidate row; clamp it down
+            // so it stays in the IME-owned area instead of covering a host bottom-composer input.
+            y = clampPopupYToImeArea(y, offsetInWindow[1]);
         }
 
         int rightEdge = offsetInWindow[0] + Math.max(getWidth(), 0);
@@ -1096,6 +1105,26 @@ public class CandidateView extends View implements View.OnClickListener {
 
     static int popupContentHeight(int popHeight) {
         return popHeight;
+    }
+
+    /**
+     * Issue #124: keep the in-keyboard floating popups (the composing/root-key hint and the
+     * reverse-lookup lime toast) from rising above the candidate row into a host app's
+     * bottom-composer input field.
+     *
+     * Both popups naturally anchor at {@code candidateTopInWindow - popupHeight}, i.e. above the
+     * candidate row, and disable clipping so they can draw outside the IME window. In
+     * bottom-composer apps (LINE/WeChat/Instagram) that area is the host message input field, so
+     * clamping the top down to the candidate row keeps the popup inside the IME-owned area
+     * (candidate row + keyboard) instead of covering the host input. The embedded composing view
+     * and the expanded candidate popup use separate paths and are unaffected.
+     *
+     * @param desiredY             the popup's natural top in window coordinates
+     * @param candidateTopInWindow the candidate row's top edge in window coordinates
+     * @return a top no higher (smaller) than the candidate row's top
+     */
+    static int clampPopupYToImeArea(int desiredY, int candidateTopInWindow) {
+        return Math.max(desiredY, candidateTopInWindow);
     }
 
     static int popupHeight(int availableSpace, int measuredContentHeight, boolean keyboardViewHidden) {

--- a/docs/#124_ISSUE.md
+++ b/docs/#124_ISSUE.md
@@ -8,7 +8,7 @@
 - Assignee: `jrywu`
 - Source: maintainer-created issue from a private email report. The public issue intentionally withholds the reporter email address.
 - Public acknowledgement: none needed for now because this tracking issue was created by the project account on behalf of the email reporter.
-- Implementation status: PR #126 (`fix/124-android-popup-placement`) constrains both Android popup paths to the IME-owned candidate area and is awaiting review/merge.
+- Implementation status: PR #126 (`fix/124-android-popup-placement`) clamps both Android fallback popup paths to start at the candidate row instead of drawing above it into bottom-composer host input fields. This is awaiting review/merge and still needs device UX verification because the fallback popups will overlap the candidate row rather than the host editor area.
 
 ## Problem statement
 
@@ -68,7 +68,8 @@ This is a geometry/placement bug in Android candidate-view popup handling, not a
 2. The composing/root-key popup path now clamps `mPopupComposingY` so it cannot rise above the candidate row and cover a host bottom-composer input field.
 3. The non-embedded reverse-lookup lime toast path now applies the same clamp, while the embedded composing path keeps its existing in-IME placement.
 4. Expanded candidate popup behavior is intentionally unchanged because it uses a separate bottom-anchored popup path and already hides the composing popup while expanded.
-5. Follow-up manual reproduction should still inspect runtime values for:
+5. This is a deliberate containment trade-off: in the affected fallback paths, the popup top will be clamped to the candidate-row top, so manual device testing must confirm the candidate-row overlap is acceptable and less disruptive than covering the host message field.
+6. Follow-up manual reproduction should still inspect runtime values for:
    - candidate view `getLocationInWindow(...)`
    - composing-popup and reverse-lookup toast measured heights
    - root-window visible display frame / IME visible area

--- a/docs/#124_ISSUE.md
+++ b/docs/#124_ISSUE.md
@@ -8,6 +8,7 @@
 - Assignee: `jrywu`
 - Source: maintainer-created issue from a private email report. The public issue intentionally withholds the reporter email address.
 - Public acknowledgement: none needed for now because this tracking issue was created by the project account on behalf of the email reporter.
+- Implementation status: branch `fix/124-android-popup-placement` constrains both Android popup paths to the IME-owned candidate area and is awaiting PR review/merge.
 
 ## Problem statement
 
@@ -61,19 +62,18 @@ Android has two relevant floating-popup paths anchored around the candidate row:
 
 This is a geometry/placement bug in Android candidate-view popup handling, not a LINE-specific text-processing bug based on current evidence.
 
-## Proposed fix / investigation direction
+## Implemented fix / investigation direction
 
-1. Reproduce on Android with LINE and Array IM, covering both the composing/root-key popup while typing and the reverse-lookup popup after committing a candidate.
-2. Inspect the runtime values for:
+1. Source fix in branch `fix/124-android-popup-placement` adds a shared Android `CandidateView.clampPopupYToImeArea(...)` helper.
+2. The composing/root-key popup path now clamps `mPopupComposingY` so it cannot rise above the candidate row and cover a host bottom-composer input field.
+3. The non-embedded reverse-lookup lime toast path now applies the same clamp, while the embedded composing path keeps its existing in-IME placement.
+4. Expanded candidate popup behavior is intentionally unchanged because it uses a separate bottom-anchored popup path and already hides the composing popup while expanded.
+5. Follow-up manual reproduction should still inspect runtime values for:
    - candidate view `getLocationInWindow(...)`
    - composing-popup and reverse-lookup toast measured heights
    - root-window visible display frame / IME visible area
    - whether LINE uses fullscreen/extract mode, insets, or adjusted resize/pan behavior on the affected device.
-3. Change the Android popup display strategy so both reverse lookup and composing/root-key hints avoid covering the host input field. Candidate approaches:
-   - Prefer rendering these short hints inside the existing candidate/input view area when possible, similar to the iOS candidate-bar path.
-   - If a `PopupWindow` remains necessary, use a shared helper to clamp or flip its Y position to stay within the IME-owned/candidate area instead of drawing into the host editor area.
-   - Add a small fallback for constrained layouts: use candidate-bar inline text or a short in-keyboard hint when there is not enough safe space above the candidate row.
-4. Add focused tests for the geometry helper(s), especially when the candidate row is adjacent to the visible host editor area and either popup would otherwise overlap it.
+6. If manual device testing shows the candidate-row overlay is still too intrusive, the next UI refinement should move these short hints fully inline inside the candidate/input view area, similar to the iOS candidate-bar path.
 
 ## Follow-up questions for the reporter
 
@@ -99,12 +99,14 @@ Because this was reported by email and the issue was created by `limeimetw`, avo
   - Reverse lookup still hides on the next LIME key press.
   - Candidate bar, expanded candidate popup, and clear-code/dismiss controls remain usable.
 - Automated checks:
-  - Add unit/helper coverage for popup Y-position selection and no-overlap fallback.
+  - `./gradlew :app:compileDebugJavaWithJavac`
+  - `./gradlew :app:compileDebugAndroidTestJavaWithJavac`
+  - Add helper coverage for popup Y-position clamping when a popup would otherwise rise above the candidate row.
   - Keep or update existing composing-popup and `reverseLookupUsesPersistentLimeToast()` / `nextKeyClearsPersistentLimeToast()` expectations according to the chosen UI path.
 
 ## Backlog / release follow-up
 
-- Track as an active Android usability bug until a source fix lands for bottom-composer placement of both composing/root-key and reverse-lookup floating popups.
+- Track as an active Android usability bug until the branch/PR source fix lands for bottom-composer placement of both composing/root-key and reverse-lookup floating popups.
 - No Android APK retest request applies yet because the observed `6.1.22-2026` report is on the current `LIMEHD2026-6.1.22.apk` line and no targeted popup-placement fix has landed after it.
 - No public reporter retest request should be posted until a newer Android APK contains the relevant popup-placement fix.
 - iOS/TestFlight retest is not required for the Android `PopupWindow` overlap path unless separate iOS reverse-lookup layout evidence appears.

--- a/docs/#124_ISSUE.md
+++ b/docs/#124_ISSUE.md
@@ -8,7 +8,7 @@
 - Assignee: `jrywu`
 - Source: maintainer-created issue from a private email report. The public issue intentionally withholds the reporter email address.
 - Public acknowledgement: none needed for now because this tracking issue was created by the project account on behalf of the email reporter.
-- Implementation status: branch `fix/124-android-popup-placement` constrains both Android popup paths to the IME-owned candidate area and is awaiting PR review/merge.
+- Implementation status: PR #126 (`fix/124-android-popup-placement`) constrains both Android popup paths to the IME-owned candidate area and is awaiting review/merge.
 
 ## Problem statement
 
@@ -64,7 +64,7 @@ This is a geometry/placement bug in Android candidate-view popup handling, not a
 
 ## Implemented fix / investigation direction
 
-1. Source fix in branch `fix/124-android-popup-placement` adds a shared Android `CandidateView.clampPopupYToImeArea(...)` helper.
+1. Source fix in PR #126 (`fix/124-android-popup-placement`) adds a shared Android `CandidateView.clampPopupYToImeArea(...)` helper.
 2. The composing/root-key popup path now clamps `mPopupComposingY` so it cannot rise above the candidate row and cover a host bottom-composer input field.
 3. The non-embedded reverse-lookup lime toast path now applies the same clamp, while the embedded composing path keeps its existing in-IME placement.
 4. Expanded candidate popup behavior is intentionally unchanged because it uses a separate bottom-anchored popup path and already hides the composing popup while expanded.
@@ -106,7 +106,7 @@ Because this was reported by email and the issue was created by `limeimetw`, avo
 
 ## Backlog / release follow-up
 
-- Track as an active Android usability bug until the branch/PR source fix lands for bottom-composer placement of both composing/root-key and reverse-lookup floating popups.
+- Track as an active Android usability bug until PR #126 lands for bottom-composer placement of both composing/root-key and reverse-lookup floating popups.
 - No Android APK retest request applies yet because the observed `6.1.22-2026` report is on the current `LIMEHD2026-6.1.22.apk` line and no targeted popup-placement fix has landed after it.
 - No public reporter retest request should be posted until a newer Android APK contains the relevant popup-placement fix.
 - iOS/TestFlight retest is not required for the Android `PopupWindow` overlap path unless separate iOS reverse-lookup layout evidence appears.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,7 +6,7 @@ Last reviewed: 2026-06-20
 
 ## Active issue follow-up
 
-- #124 Android: composing/root-key and reverse-lookup floating popups can cover bottom chat-app message input fields when using Array input. Branch `fix/124-android-popup-placement` constrains both popup paths to the IME-owned candidate area and awaits PR review/merge; no APK retest request applies until a newer Android build contains the targeted fix.
+- #124 Android: composing/root-key and reverse-lookup floating popups can cover bottom chat-app message input fields when using Array input. PR #126 (`fix/124-android-popup-placement`) constrains both popup paths to the IME-owned candidate area and awaits review/merge; no APK retest request applies until a newer Android build contains the targeted fix.
 
 ## Source fixed / awaiting build verification
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,7 +6,7 @@ Last reviewed: 2026-06-20
 
 ## Active issue follow-up
 
-- #124 Android: composing/root-key and reverse-lookup floating popups can cover bottom chat-app message input fields when using Array input. The original report was LINE, and follow-up screenshots/comments now mention WeChat and Instagram too. Track as an active Android usability bug until both popup paths are constrained to the IME/candidate area or moved inline; no APK retest request applies until a newer Android build contains the targeted fix.
+- #124 Android: composing/root-key and reverse-lookup floating popups can cover bottom chat-app message input fields when using Array input. Branch `fix/124-android-popup-placement` constrains both popup paths to the IME-owned candidate area and awaits PR review/merge; no APK retest request applies until a newer Android build contains the targeted fix.
 
 ## Source fixed / awaiting build verification
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,7 +6,7 @@ Last reviewed: 2026-06-20
 
 ## Active issue follow-up
 
-- #124 Android: composing/root-key and reverse-lookup floating popups can cover bottom chat-app message input fields when using Array input. PR #126 (`fix/124-android-popup-placement`) constrains both popup paths to the IME-owned candidate area and awaits review/merge; no APK retest request applies until a newer Android build contains the targeted fix.
+- #124 Android: composing/root-key and reverse-lookup floating popups can cover bottom chat-app message input fields when using Array input. PR #126 (`fix/124-android-popup-placement`) clamps both fallback popup paths to start at the candidate row instead of covering the host input field and awaits review/merge; manual device testing should confirm the candidate-row overlap trade-off is acceptable. No APK retest request applies until a newer Android build contains the targeted fix.
 
 ## Source fixed / awaiting build verification
 


### PR DESCRIPTION
## Summary

- constrain Android composing/root-key popup placement so it cannot rise above the candidate row into bottom-composer host input fields
- apply the same IME-area clamp to the non-embedded reverse-lookup lime toast path while preserving embedded composing placement
- document the #124 implementation state and add focused helper coverage

Fixes #124.

## Root cause

The normal Android candidate row does not use the embedded composing view, so both the composing/root-key hint and reverse-lookup lime toast can use `PopupWindow` paths anchored at `candidateTop - popupHeight`. In bottom-composer apps such as LINE, WeChat, and Instagram, that area is the host message input field, so the grey popup can cover the field.

## Android verification

- `./gradlew :app:compileDebugJavaWithJavac`
- `./gradlew :app:compileDebugAndroidTestJavaWithJavac`
- `git diff --check`

No connected Android device/emulator was available in this WSL environment, so `connectedDebugAndroidTest` and manual LINE/WeChat/Instagram visual verification still need a device build.

## Platform impact

- Android: source fix constrains the normal in-keyboard composing/root-key popup and non-embedded reverse-lookup toast to the IME-owned candidate area.
- iOS: no code change. The analogous iOS reverse-lookup display writes into keyboard-extension UI labels instead of using Android `PopupWindow` placement, so this specific host-window overlap path does not apply.

## Manual checks still recommended

- Array IM in LINE, WeChat, Instagram, or another bottom-composer app with composing/root-key display enabled
- reverse lookup after committing a candidate
- normal notes/editor app to confirm the hints remain readable
- expanded candidate popup and clear-code/dismiss controls
