### PR TITLE
Fix related-record management search and iOS lookup parity

### DIFF
--- a/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
@@ -3068,16 +3068,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             }
             return
         }
-        let wasComposingCodeCommit = candidate.isComposingCodeRecord
         selectedCandidate = candidate
         commitTyped()
-        if wasComposingCodeCommit {
-            // Mixed-mode raw-English commit: no related phrases; clear the bar
-            // (updateRelatedPhrase bails for composing-code records without clearing).
-            clearSuggestions()
-        } else {
-            updateRelatedPhrase()
-        }
+        updateRelatedPhrase()
     }
 
     private func appendPickedCandidateToEmojiSearch(_ candidate: Mapping) -> Bool {
@@ -3201,7 +3194,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
               !committed.word.isEmpty,
               !committed.isEmojiRecord,
               !committed.isChinesePunctuationRecord,
-              !committed.isComposingCodeRecord,   // mixed-mode raw-code commit has no related phrases
               let ss = searchServer else { return }
 
         // Clear stale composing candidates immediately so the bar doesn't linger.

--- a/LimeIME-iOS/LimeSettings/Controllers/ManageRelatedController.swift
+++ b/LimeIME-iOS/LimeSettings/Controllers/ManageRelatedController.swift
@@ -55,8 +55,8 @@ final class ManageRelatedController: BaseController {
         let server = self.dbServer
         let q: String? = (query?.isEmpty == false) ? query : nil
         return await Task.detached(priority: .userInitiated) {
-            let phrases = server.getRelated(q, ManageRelatedController.pageSize, offset)
-            let total = server.countRecords("related", nil, nil)
+            let phrases = server.searchRelatedForManagement(q, ManageRelatedController.pageSize, offset)
+            let total = server.countRelatedForManagement(q)
             return (phrases, total)
         }.value
     }
@@ -143,7 +143,7 @@ final class ManageRelatedController: BaseController {
         let server = self.dbServer
         let q: String? = (query?.isEmpty == false) ? query : nil
         Task.detached(priority: .userInitiated) {
-            let phrases = server.getRelated(q, ManageRelatedController.pageSize, offset)
+            let phrases = server.searchRelatedForManagement(q, ManageRelatedController.pageSize, offset)
             await MainActor.run { view?.displayRelatedPhrases(phrases) }
         }
     }

--- a/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
+++ b/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
@@ -1081,6 +1081,27 @@ final class KeyboardViewControllerTest: XCTestCase {
                           "case (b): hasCandidatesShown must be restored before clearSuggestions()")
     }
 
+    func testRawCodeCommitRequestsRelatedPhrasesLikeAndroid() throws {
+        let sourceURL = projectFileURL("LimeKeyboard/KeyboardViewController.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        let selectionPattern = #"func pickCandidateManually[\s\S]*?\n    \}"#
+        let selectionRegex = try NSRegularExpression(pattern: selectionPattern)
+        let sourceRange = NSRange(source.startIndex..<source.endIndex, in: source)
+        let selectionMatch = try XCTUnwrap(selectionRegex.firstMatch(in: source, range: sourceRange))
+        let selection = String(source[Range(selectionMatch.range, in: source)!])
+        XCTAssertFalse(selection.contains("wasComposingCodeCommit"))
+        XCTAssertTrue(selection.contains("commitTyped()"))
+        XCTAssertTrue(selection.contains("updateRelatedPhrase()"))
+
+        let relatedPattern = #"func updateRelatedPhrase[\s\S]*?\n    \}"#
+        let relatedRegex = try NSRegularExpression(pattern: relatedPattern)
+        let relatedMatch = try XCTUnwrap(relatedRegex.firstMatch(in: source, range: sourceRange))
+        let related = String(source[Range(relatedMatch.range, in: source)!])
+        XCTAssertFalse(related.contains("!committed.isComposingCodeRecord"))
+        XCTAssertTrue(related.contains("ss.getRelatedByWord(word, getAllRecords: true)"))
+    }
+
     // docs/AUTO_CHINESE_PUNC.md §10.3 (T-iOS-3): clearSuggestions() is the single
     // strip builder. It must carry the full gate
     // (autoChineseSymbol && !mEnglishOnly && hasCandidatesShown && !hasChineseSymbolCandidatesShown)

--- a/LimeIME-iOS/LimeTests/LimeDBTest.swift
+++ b/LimeIME-iOS/LimeTests/LimeDBTest.swift
@@ -1354,6 +1354,51 @@ final class LimeDBTest: XCTestCase {
         XCTAssertNotNil(list)
     }
 
+    func testRelatedManagementSearchUsesParentPrefixOnly() throws {
+        let db = try makeLimeDB()
+        let parent = "台中𠀀𠀁𠀂"
+        let child = "市"
+        let id = db.addRecord(LIME.DB_TABLE_RELATED, [
+            "pword": parent, "cword": child, "score": 0, "basescore": 0
+        ])
+        XCTAssertGreaterThan(id, 0)
+
+        defer { _ = db.deleteRecord(LIME.DB_TABLE_RELATED, "_id = ?", ["\(id)"]) }
+
+        XCTAssertTrue(db.searchRelatedForManagement("台中𠀀", 100, 0).contains { $0.id == id })
+        XCTAssertFalse(db.searchRelatedForManagement(child, 100, 0).contains { $0.id == id })
+        XCTAssertFalse(db.searchRelatedForManagement(parent + child, 100, 0).contains { $0.id == id })
+        XCTAssertFalse(db.searchRelatedForManagement("不存在𠀃", 100, 0).contains { $0.id == id })
+        XCTAssertEqual(db.countRelatedForManagement("台中𠀀"), 1)
+    }
+
+    func testRuntimeRelatedLookupMatchesFullCommittedWordThenLastCharacter() throws {
+        let db = try makeLimeDB()
+        let fullID = db.addRecord(LIME.DB_TABLE_RELATED, [
+            "pword": "台中", "cword": "市", "score": 1, "basescore": 0
+        ])
+        let fallbackID = db.addRecord(LIME.DB_TABLE_RELATED, [
+            "pword": "中", "cword": "心", "score": 99, "basescore": 0
+        ])
+        let unrelatedID = db.addRecord(LIME.DB_TABLE_RELATED, [
+            "pword": "台", "cword": "灣", "score": 99, "basescore": 0
+        ])
+        defer {
+            for id in [fullID, fallbackID, unrelatedID] where id > 0 {
+                _ = db.deleteRecord(LIME.DB_TABLE_RELATED, "_id = ?", ["\(id)"])
+            }
+        }
+
+        let results = try db.getRelatedMappings(parentWord: "台中", limit: 10)
+        let words = results.map(\.word)
+
+        XCTAssertTrue(words.contains("市"), "full committed-word relation must be returned")
+        XCTAssertTrue(words.contains("心"), "last-character fallback must match Android")
+        XCTAssertFalse(words.contains("灣"), "first-character records must not be queried")
+        XCTAssertLessThan(words.firstIndex(of: "市")!, words.firstIndex(of: "心")!,
+                          "full-word relation must sort before fallback regardless of score")
+    }
+
     func testLimeDBLoadRelatedEdgeCases() throws {
         let db = try makeLimeDB()
         XCTAssertNotNil(db.getRelated(nil, 10, 0))

--- a/LimeIME-iOS/Shared/Database/DBServer.swift
+++ b/LimeIME-iOS/Shared/Database/DBServer.swift
@@ -1330,6 +1330,14 @@ final class DBServer {
         datasource?.getRelated(pword, maximum, offset) ?? []
     }
 
+    func searchRelatedForManagement(_ query: String?, _ maximum: Int, _ offset: Int) -> [Related] {
+        datasource?.searchRelatedForManagement(query, maximum, offset) ?? []
+    }
+
+    func countRelatedForManagement(_ query: String?) -> Int {
+        datasource?.countRelatedForManagement(query) ?? 0
+    }
+
     // MARK: - Validation Proxy
 
     func isValidTableName(_ name: String?) -> Bool {

--- a/LimeIME-iOS/Shared/Database/LimeDB.swift
+++ b/LimeIME-iOS/Shared/Database/LimeDB.swift
@@ -850,16 +850,26 @@ final class LimeDB {
     /// Returns related Mapping objects (for SearchServer). Throws version.
     func getRelatedMappings(parentWord: String, limit: Int = 10) throws -> [Mapping] {
         try dbQueue.read { db in
+            let hasMultipleCharacters = parentWord.count > 1
+            let predicate = hasMultipleCharacters ? "(pword = ? OR pword = ?)" : "pword = ?"
             let sql = """
-                SELECT cword, (COALESCE(basescore,0) + COALESCE(score,0)) AS total
-                FROM related WHERE pword = ?
-                ORDER BY total DESC LIMIT ?
+                SELECT pword, cword, (COALESCE(basescore,0) + COALESCE(score,0)) AS total,
+                       length(pword) AS parent_length
+                FROM related WHERE \(predicate) AND cword IS NOT NULL
+                ORDER BY parent_length DESC, total DESC LIMIT ?
             """
-            return try Row.fetchAll(db, sql: sql, arguments: [parentWord, limit]).map { row in
+            let rows: [Row]
+            if hasMultipleCharacters {
+                rows = try Row.fetchAll(db, sql: sql,
+                                        arguments: [parentWord, String(parentWord.suffix(1)), limit])
+            } else {
+                rows = try Row.fetchAll(db, sql: sql, arguments: [parentWord, limit])
+            }
+            return rows.map { row in
                 Mapping(id: 0, code: "", word: (row.optString("cword") ?? ""),
                         score: (row.optInt("total") ?? 0), baseScore: 0,
                         recordType: Mapping.RecordType.relatedPhrase,
-                        pword: parentWord)   // spec §14: populate pword
+                        pword: (row.optString("pword") ?? parentWord))
             }
         }
     }
@@ -1524,6 +1534,40 @@ final class LimeDB {
                         baseScore:  (row.optInt("basescore") ?? 0))
             }
         }) ?? []
+    }
+
+    func searchRelatedForManagement(_ query: String?, _ maximum: Int, _ offset: Int) -> [Related] {
+        guard !checkDBConnection() else { return [] }
+        let filter = relatedManagementFilter(query)
+        let limit = maximum > 0 ? " LIMIT \(maximum) OFFSET \(offset)" : ""
+        let sql = "SELECT _id, pword, cword, basescore, score FROM related WHERE \(filter.whereClause) ORDER BY score DESC, basescore DESC\(limit)"
+        return (try? dbQueue.read { db in
+            try Row.fetchAll(db, sql: sql, arguments: StatementArguments(filter.args)).map { row in
+                Related(id:         (row.optInt64("_id") ?? 0),
+                        parentWord: (row.optString("pword") ?? ""),
+                        childWord:  (row.optString("cword") ?? ""),
+                        score:      (row.optInt("score") ?? 0),
+                        baseScore:  (row.optInt("basescore") ?? 0))
+            }
+        }) ?? []
+    }
+
+    func countRelatedForManagement(_ query: String?) -> Int {
+        let filter = relatedManagementFilter(query)
+        return countRecords(LIME.DB_TABLE_RELATED, filter.whereClause,
+                            filter.args.isEmpty ? nil : filter.args)
+    }
+
+    private func relatedManagementFilter(_ query: String?) -> (whereClause: String, args: [String]) {
+        let base = "ifnull(cword, '') <> ''"
+        guard let trimmed = query?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return (base, []) }
+        let escaped = trimmed
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
+        let whereClause = base + " AND pword LIKE ? ESCAPE '\\'"
+        return (whereClause, [escaped + "%"])
     }
 
     // MARK: - Backup / Restore

--- a/LimeStudio/app/src/androidTest/java/org/limeime/LimeDBTest.java
+++ b/LimeStudio/app/src/androidTest/java/org/limeime/LimeDBTest.java
@@ -1378,6 +1378,40 @@ public class LimeDBTest {
         assertTrue("getAllRelated operation should complete", true);
     }
 
+    @Test(timeout = 5000)
+    public void testRelatedManagementSearchUsesParentPrefixOnly() {
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        LimeDB limeDB = new LimeDB(appContext);
+        if (!initializeDatabase(limeDB)) {
+            fail("ERROR: Cannot initialize database connection.");
+        }
+
+        String parent = "台中𠀀𠀁𠀂";
+        String child = "市";
+        android.content.ContentValues values = new android.content.ContentValues();
+        values.put(LIME.DB_RELATED_COLUMN_PWORD, parent);
+        values.put(LIME.DB_RELATED_COLUMN_CWORD, child);
+        values.put(LIME.DB_RELATED_COLUMN_USERSCORE, 0);
+        long id = limeDB.addRecord(LIME.DB_TABLE_RELATED, values);
+        assertTrue("fixture insert should succeed", id > 0);
+
+        try {
+            List<Related> byParent = limeDB.searchRelatedForManagement("台中𠀀", 100, 0);
+            List<Related> byChild = limeDB.searchRelatedForManagement(child, 100, 0);
+            List<Related> byCombined = limeDB.searchRelatedForManagement(parent + child, 100, 0);
+            List<Related> unrelated = limeDB.searchRelatedForManagement("不存在𠀃", 100, 0);
+
+            String idString = String.valueOf(id);
+            assertTrue(byParent.stream().anyMatch(r -> idString.equals(r.getId())));
+            assertFalse(byChild.stream().anyMatch(r -> idString.equals(r.getId())));
+            assertFalse(byCombined.stream().anyMatch(r -> idString.equals(r.getId())));
+            assertFalse(unrelated.stream().anyMatch(r -> idString.equals(r.getId())));
+            assertEquals(1, limeDB.countRelatedForManagement("台中𠀀"));
+        } finally {
+            limeDB.deleteRecord(LIME.DB_TABLE_RELATED, "_id = ?", new String[]{String.valueOf(id)});
+        }
+    }
+
     @Test(timeout = 5000) // 5 second timeout to prevent infinite hang
     public void testLimeDBInsertOperation() {
         // Test addRecord operation with ContentValues

--- a/LimeStudio/app/src/main/java/org/limeime/SearchServer.java
+++ b/LimeStudio/app/src/main/java/org/limeime/SearchServer.java
@@ -2798,6 +2798,16 @@ List<Mapping> scorelistSnapshot = null;
         return dbadapter.getRelated(pword, maximum, offset);
     }
 
+    public List<Related> searchRelatedForManagement(String query, int maximum, int offset) {
+        if (dbadapter == null) return new ArrayList<>();
+        return dbadapter.searchRelatedForManagement(query, maximum, offset);
+    }
+
+    public int countRelatedForManagement(String query) {
+        if (dbadapter == null) return 0;
+        return dbadapter.countRelatedForManagement(query);
+    }
+
     /**
      * Gets a list of IM information records for a specific IM code.
      * 

--- a/LimeStudio/app/src/main/java/org/limeime/limedb/LimeDB.java
+++ b/LimeStudio/app/src/main/java/org/limeime/limedb/LimeDB.java
@@ -6824,6 +6824,51 @@ public class LimeDB extends LimeSQLiteOpenHelper {
         return result;
     }
 
+    /** Searches related records for the management UI without changing runtime lookup semantics. */
+    public List<Related> searchRelatedForManagement(String query, int maximum, int offset) {
+        List<Related> result = new ArrayList<>();
+        if (checkDBConnection()) return result;
+
+        String order = LIME.DB_RELATED_COLUMN_USERSCORE + " desc," +
+                LIME.DB_RELATED_COLUMN_BASESCORE + " desc";
+        if (maximum > 0) order += " LIMIT " + maximum + " OFFSET " + offset;
+
+        try (Cursor cursor = db.query(LIME.DB_TABLE_RELATED, null,
+                relatedManagementWhere(query), relatedManagementArgs(query),
+                null, null, order)) {
+            while (cursor.moveToNext()) {
+                Related record = new Related();
+                record.setId(getCursorInt(cursor, LIME.DB_RELATED_COLUMN_ID));
+                record.setPword(getCursorString(cursor, LIME.DB_RELATED_COLUMN_PWORD));
+                record.setCword(getCursorString(cursor, LIME.DB_RELATED_COLUMN_CWORD));
+                record.setUserscore(getCursorInt(cursor, LIME.DB_RELATED_COLUMN_USERSCORE));
+                record.setBasescore(getCursorInt(cursor, LIME.DB_RELATED_COLUMN_BASESCORE));
+                result.add(record);
+            }
+        }
+        return result;
+    }
+
+    public int countRelatedForManagement(String query) {
+        if (checkDBConnection()) return 0;
+        return countRecords(LIME.DB_TABLE_RELATED, relatedManagementWhere(query),
+                relatedManagementArgs(query));
+    }
+
+    private String relatedManagementWhere(String query) {
+        String base = "ifnull(" + LIME.DB_RELATED_COLUMN_CWORD + ", '') <> ''";
+        if (query == null || query.trim().isEmpty()) return base;
+        return base + " AND " + LIME.DB_RELATED_COLUMN_PWORD + " LIKE ? ESCAPE '\\'";
+    }
+
+    private String[] relatedManagementArgs(String query) {
+        if (query == null || query.trim().isEmpty()) return null;
+        String escaped = query.trim().replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+        return new String[]{escaped + "%"};
+    }
+
 //    /**
 //     * Gets a single related phrase record by ID.
 //     *

--- a/LimeStudio/app/src/main/java/org/limeime/ui/controller/ManageImController.java
+++ b/LimeStudio/app/src/main/java/org/limeime/ui/controller/ManageImController.java
@@ -218,8 +218,8 @@ public class ManageImController extends BaseController {
     public void loadRelatedPhrases(String pWord, int offset, int limit) {
         try {
 
-            List<Related> phrases = searchServer.getRelatedByWord(pWord, limit, offset);
-            int count = searchServer.countRecordsRelated(pWord);
+            List<Related> phrases = searchServer.searchRelatedForManagement(pWord, limit, offset);
+            int count = searchServer.countRelatedForManagement(pWord);
             
             if (manageRelatedView != null) {
                 manageRelatedView.updatePhraseCount(count);

--- a/docs/#161_ISSUE.md
+++ b/docs/#161_ISSUE.md
@@ -1,0 +1,60 @@
+# Issue #161: Related-record management search and iOS runtime parity
+
+## Status
+
+- GitHub issue: https://github.com/lime-ime/limeime/issues/161
+- Classification: `bug` + `Usability`
+- Platforms: Android and iOS
+- State: implementation in PR #165; keep open until review, merge, release, and reporter retest
+
+## Corrected scope
+
+The original text-shortcut question is answered: shortcut-like entries belong in each input method's `瀏覽 / 編輯資料表`, not `關聯字管理`.
+
+The remaining confirmed defect is in related-record management. Valid records can use a multi-character `pword`, and management search must return records whose `pword` starts with the entered text so users can edit/delete them without paging through the entire table. For example, entering `萊` matches every record with `pword LIKE '萊%'`.
+
+Do not restrict `pword` to one character or to Han-only text:
+
+- related learning stores the full preceding committed candidate word as `pword`
+- LD and ordinary mappings can commit multi-character words
+- Android allows a raw item-0 code commit to query related records using that English/mixed-mode committed word
+- exact/partial mappings may also have non-Han output
+
+## Runtime lookup contract
+
+Android is the reference behavior:
+
+1. Pass the complete committed candidate word to related lookup.
+2. For a one-character word, query that exact `pword`.
+3. For a multi-character word, query both the full word and its final character.
+4. Sort full-word matches before final-character fallback matches, then by score.
+5. Item-0 composing-code commits participate in lookup but remain excluded from automatic related-word learning by record-type filters.
+
+The iOS path previously diverged in two ways:
+
+- `pickCandidateManually` cleared suggestions after an item-0 composing-code commit instead of calling `updateRelatedPhrase()`.
+- `getRelatedMappings` queried only the complete word and omitted Android's final-character fallback.
+
+PR #165 aligns these iOS paths with Android while leaving automatic-learning filters unchanged.
+
+## Management search contract
+
+Management search is separate from runtime candidate lookup. A non-empty query performs only an escaped `pword LIKE 'query%'` prefix match. It does not search `cword` or the displayed `pword + cword` combination. Filtered counts use exactly the same predicate as paged results. SQL wildcard characters in user text are treated literally.
+
+## TDD evidence
+
+- Existing code reproduced RED for iOS item-0 parity: the selection path contained `wasComposingCodeCommit` and bypassed `updateRelatedPhrase`; the lookup guard rejected composing-code records.
+- Added iOS tests for item-0 routing and full-word/final-character query behavior.
+- Existing Android/iOS management-search tests cover multi-character parent and combined-phrase lookup.
+
+## Acceptance criteria
+
+- [x] No Han-only or one-character validation is introduced
+- [x] Android management search uses `pword` prefix matching only
+- [x] iOS management search uses the same `pword` prefix semantics and filtered count
+- [x] iOS item-0 raw-code commit requests related candidates like Android
+- [x] iOS multi-character runtime lookup uses full word plus final-character fallback
+- [x] Android regression tests pass on the final branch
+- [ ] iOS XCTest/Xcode Cloud passes on the final branch
+- [ ] Maintainer review/merge
+- [ ] Reporter verifies search/deletion in a released build

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5,6 +5,7 @@ Public backlog for confirmed unresolved fixes and product work. Issue-specific i
 Last reviewed: 2026-07-18
 
 ## Pending fixes
+- fix#161 Android/iOS: make `關聯字管理` use an escaped `pword` prefix query (`萊` → `pword LIKE '萊%'`) with filtered count/pagination parity; do not search `cword` or combined display text. Align iOS runtime lookup to Android so item-0 raw-code commits request related candidates and multi-character committed words query both the full word and final-character fallback. Do not add Han-only validation; automatic-learning record-type filters remain unchanged. See `docs/#161_ISSUE.md`.
 - fix#160 iOS: the shared-catalog keyboard option `limenumsym` (`LIME+數字符號鍵盤`) renders the ordinary number-row QWERTY layout instead of its dedicated number/symbol layout. Android is reporter-confirmed working. PR #162 merged the missing phone/iPad resources as `c56593f8e3fd76b4a800b66b12ab76b7a6b96f46`; follow-up PR #164 merged the source-independent semantic oracle and corrected full/narrow-iPad punctuation preservation as `66b1577f0c58eee1359d5e921ce57ebaeca9a68d`. Remaining work is phone/full-iPad/narrow-iPad device verification, a newer TestFlight/App Store build containing both merges, and reporter confirmation. Android is not in scope. See `docs/#160_ISSUE.md`.
 
 ## Product work


### PR DESCRIPTION
## Summary

- make Android and iOS `關聯字管理` search use only an escaped `pword` prefix query (`萊` → `pword LIKE '萊%'`)
- keep filtered count and pagination predicates aligned
- align iOS runtime related lookup with Android: item-0 raw-code commits request related candidates, and multi-character committed words query the full word plus final-character fallback
- preserve valid multi-character and non-Han `pword` values; this PR intentionally adds no Han-only or single-character gate
- add Android instrumentation, iOS XCTest/source-contract coverage, and corrected #161 documentation

## Corrected data model

`pword` is not restricted to one Chinese character and is not Han-only:

- LD and normal mappings can commit multi-character words, which become valid related-parent keys.
- Android item 0 can commit raw code and request related candidates using that code as `pword`.
- Automatic learning still excludes composing-code records through its existing record-type filter, but exact/partial mapped English output can participate.

The previous two commits on this PR incorrectly introduced a Han-only gate. They have been removed from the branch history and replaced by the corrected implementation.

## Management-search contract

For a non-empty editor query, both platforms now use:

```sql
pword LIKE 'escaped-query%'
```

The editor does not search `cword` or concatenated `pword + cword`. `%`, `_`, and `\` in user input are escaped and treated literally.

## Runtime parity

After committing `台中`:

- Android: query `pword = '台中' OR pword = '中'`
- iOS after this fix: same behavior, with full-word matches ordered before final-character fallback

After committing item-0 raw code `add`:

- Android: requests related candidates for `add`
- iOS after this fix: same behavior

## Verification

- RED: Android management test proved the previous broad substring/combined search returned child/combined-only matches
- GREEN: focused Android prefix-only management test passed
- full Android `LimeDBTest`: 215/215 passed on Pixel 9 Pro / Android 16
- Android `:app:testDebugUnitTest`: passed
- Android Java and instrumentation-test compilation: passed
- raw-code iOS source contract: passed
- `git diff --check`: passed
- iOS XCTest/Xcode Cloud: pending for corrected head

Fixes #161. Keep the issue open until a newer build is available and the reporter confirms the management search behavior.
