### PR TITLE
Fix related-record parent validation

### DIFF
--- a/LimeIME-iOS/LimeSettings/Controllers/ManageRelatedController.swift
+++ b/LimeIME-iOS/LimeSettings/Controllers/ManageRelatedController.swift
@@ -35,6 +35,27 @@ import Foundation
 final class ManageRelatedController: BaseController {
 
     nonisolated static let pageSize = 100
+    nonisolated static let invalidParentMessage = "首字只能輸入一個中文字"
+
+    nonisolated static func isValidParentWord(_ input: String) -> Bool {
+        let value = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard value.count == 1,
+              value.unicodeScalars.count == 1,
+              let scalar = value.unicodeScalars.first else { return false }
+        let codePoint = scalar.value
+        return codePoint == 0x3007
+            || (0x3400...0x4DBF).contains(codePoint)
+            || (0x4E00...0x9FFF).contains(codePoint)
+            || (0xF900...0xFAFF).contains(codePoint)
+            || (0x20000...0x2A6DF).contains(codePoint)
+            || (0x2A700...0x2B73F).contains(codePoint)
+            || (0x2B740...0x2B81F).contains(codePoint)
+            || (0x2B820...0x2CEAF).contains(codePoint)
+            || (0x2CEB0...0x2EBEF).contains(codePoint)
+            || (0x2EBF0...0x2EE5F).contains(codePoint)
+            || (0x2F800...0x2FA1F).contains(codePoint)
+            || (0x30000...0x323AF).contains(codePoint)
+    }
 
     /// Incrementing this causes RelatedListView to reload its data.
     /// Call after seeding or any external data change.
@@ -63,13 +84,17 @@ final class ManageRelatedController: BaseController {
 
     func addRelated(parentWord: String, childWord: String,
                     score: Int = 0) async -> Result<Void, Error> {
-        guard !parentWord.isEmpty, !childWord.isEmpty else {
+        let normalizedParent = parentWord.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isValidParentWord(normalizedParent) else {
+            return .failure(ControllerError.validation(Self.invalidParentMessage))
+        }
+        guard !childWord.isEmpty else {
             return .failure(ControllerError.validation("詞彙和關聯字不能為空"))
         }
         let server = self.dbServer
         let result: Result<Void, Error> = await Task.detached(priority: .userInitiated) {
             let rowID = server.addRecord("related",
-                                         ["pword": parentWord, "cword": childWord,
+                                         ["pword": normalizedParent, "cword": childWord,
                                           "basescore": 0, "score": score])
             guard rowID > 0 else { return .failure(ControllerError.operation("新增失敗")) }
             do {
@@ -84,13 +109,17 @@ final class ManageRelatedController: BaseController {
 
     func updateRelated(id: Int64, parentWord: String,
                        childWord: String, score: Int = 0) async -> Result<Void, Error> {
-        guard !parentWord.isEmpty, !childWord.isEmpty else {
+        let normalizedParent = parentWord.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isValidParentWord(normalizedParent) else {
+            return .failure(ControllerError.validation(Self.invalidParentMessage))
+        }
+        guard !childWord.isEmpty else {
             return .failure(ControllerError.validation("詞彙和關聯字不能為空"))
         }
         let server = self.dbServer
         let result: Result<Void, Error> = await Task.detached(priority: .userInitiated) {
             let affected = server.updateRecord("related",
-                                               ["pword": parentWord, "cword": childWord, "score": score],
+                                               ["pword": normalizedParent, "cword": childWord, "score": score],
                                                "_id = ?", ["\(id)"])
             guard affected > 0 else { return .failure(ControllerError.operation("更新失敗")) }
             do {
@@ -150,13 +179,17 @@ final class ManageRelatedController: BaseController {
 
     func addRelated(parentWord: String, childWord: String, score: Int = 0,
                     view: (any ManageRelatedView)?) {
-        guard !parentWord.isEmpty, !childWord.isEmpty else {
+        let normalizedParent = parentWord.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isValidParentWord(normalizedParent) else {
+            view?.onError(Self.invalidParentMessage); return
+        }
+        guard !childWord.isEmpty else {
             view?.onError("詞彙和關聯字不能為空"); return
         }
         let server = self.dbServer
         Task.detached(priority: .userInitiated) {
             let rowID = server.addRecord("related",
-                                        ["pword": parentWord, "cword": childWord,
+                                        ["pword": normalizedParent, "cword": childWord,
                                          "basescore": 0, "score": score])
             if rowID > 0 {
                 try? server.markTableChangedAndPublish("related")
@@ -169,13 +202,17 @@ final class ManageRelatedController: BaseController {
 
     func updateRelated(id: Int64, parentWord: String, childWord: String,
                        score: Int = 0, view: (any ManageRelatedView)?) {
-        guard !parentWord.isEmpty, !childWord.isEmpty else {
+        let normalizedParent = parentWord.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isValidParentWord(normalizedParent) else {
+            view?.onError(Self.invalidParentMessage); return
+        }
+        guard !childWord.isEmpty else {
             view?.onError("詞彙和關聯字不能為空"); return
         }
         let server = self.dbServer
         Task.detached(priority: .userInitiated) {
             let affected = server.updateRecord("related",
-                                               ["pword": parentWord, "cword": childWord, "score": score],
+                                               ["pword": normalizedParent, "cword": childWord, "score": score],
                                                "_id = ?", ["\(id)"])
             if affected > 0 {
                 try? server.markTableChangedAndPublish("related")

--- a/LimeIME-iOS/LimeSettings/Views/AddRelatedView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/AddRelatedView.swift
@@ -44,7 +44,7 @@ struct AddRelatedView: View {
         NavigationView {
             Form {
                 Section(header: Text("新增資料列")) {
-                    TextField("詞彙 (word)", text: $parentWord)
+                    TextField("首字（一個中文字）", text: $parentWord)
                         .disableAutocorrection(true)
                     TextField("關聯字 (related)", text: $childWord)
                         .disableAutocorrection(true)

--- a/LimeIME-iOS/LimeSettings/Views/EditRelatedView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/EditRelatedView.swift
@@ -54,7 +54,7 @@ struct EditRelatedView: View {
         NavigationView {
             Form {
                 Section(header: Text("編輯資料列")) {
-                    TextField("詞彙", text: $parentWord)
+                    TextField("首字（一個中文字）", text: $parentWord)
                         .disableAutocorrection(true)
                     TextField("關聯字", text: $childWord)
                         .disableAutocorrection(true)

--- a/LimeIME-iOS/LimeTests/ManageRelatedControllerTest.swift
+++ b/LimeIME-iOS/LimeTests/ManageRelatedControllerTest.swift
@@ -96,13 +96,65 @@ final class ManageRelatedControllerTest: XCTestCase {
 
     // MARK: - addRelated
 
+    func testRelatedParentRequiresExactlyOneHanCharacter() {
+        XCTAssertTrue(LimeIME.ManageRelatedController.isValidParentWord("中"))
+        XCTAssertTrue(LimeIME.ManageRelatedController.isValidParentWord("〇"))
+        XCTAssertTrue(LimeIME.ManageRelatedController.isValidParentWord("𠀀"))
+        XCTAssertTrue(LimeIME.ManageRelatedController.isValidParentWord(" 中 "))
+        XCTAssertFalse(LimeIME.ManageRelatedController.isValidParentWord("台中"))
+        XCTAssertFalse(LimeIME.ManageRelatedController.isValidParentWord("add"))
+        XCTAssertFalse(LimeIME.ManageRelatedController.isValidParentWord("Ａ"))
+        XCTAssertFalse(LimeIME.ManageRelatedController.isValidParentWord("１"))
+        XCTAssertFalse(LimeIME.ManageRelatedController.isValidParentWord("，"))
+    }
+
+    func testAddRelatedRejectsMultiCharacterParent() async throws {
+        let (url, db) = try makeDB()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let controller = await LimeIME.ManageRelatedController(
+            dbServer: LimeIME.DBServer(_testDatasource: db))
+
+        let result = await controller.addRelated(parentWord: "台中", childWord: "市")
+
+        guard case .failure(let error) = result else {
+            XCTFail("Expected multi-character parent to be rejected")
+            return
+        }
+        XCTAssertEqual(error.localizedDescription,
+                       LimeIME.ManageRelatedController.invalidParentMessage)
+        XCTAssertTrue(db.getRelated(nil, 10, 0).isEmpty)
+    }
+
+    func testUpdateRelatedRejectsNonHanParent() async throws {
+        let (url, db) = try makeDB()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let controller = await LimeIME.ManageRelatedController(
+            dbServer: LimeIME.DBServer(_testDatasource: db))
+        _ = await controller.addRelated(parentWord: "台", childWord: "中市")
+        guard let existing = db.getRelated(nil, 10, 0).first else {
+            XCTFail("Expected seeded relation")
+            return
+        }
+
+        let result = await controller.updateRelated(
+            id: existing.id, parentWord: "add", childWord: "中市")
+
+        guard case .failure(let error) = result else {
+            XCTFail("Expected non-Han parent to be rejected")
+            return
+        }
+        XCTAssertEqual(error.localizedDescription,
+                       LimeIME.ManageRelatedController.invalidParentMessage)
+        XCTAssertEqual(db.getRelated(nil, 10, 0).first?.parentWord, "台")
+    }
+
     func testAddRelatedSuccess() async throws {
         let (url, db) = try makeDB()
         defer { try? FileManager.default.removeItem(at: url) }
         let mock = await MockManageRelatedView()
         let controller = await LimeIME.ManageRelatedController(dbServer: LimeIME.DBServer(_testDatasource: db))
 
-        await MainActor.run { controller.addRelated(parentWord: "你好", childWord: "世界", view: mock) }
+        await MainActor.run { controller.addRelated(parentWord: "你", childWord: "好世界", view: mock) }
         await waitUntil { mock.refreshCount == 1 }
 
         await MainActor.run {
@@ -116,7 +168,7 @@ final class ManageRelatedControllerTest: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
         let controller = await LimeIME.ManageRelatedController(dbServer: LimeIME.DBServer(_testDatasource: db))
 
-        let result = await controller.addRelated(parentWord: "分數", childWord: "新增", score: 42)
+        let result = await controller.addRelated(parentWord: "分", childWord: "數新增", score: 42)
 
         guard case .success = result else {
             XCTFail("Expected addRelated to succeed")
@@ -124,7 +176,7 @@ final class ManageRelatedControllerTest: XCTestCase {
         }
         let phrases = db.getRelated(nil, 10, 0)
         XCTAssertTrue(phrases.contains {
-            $0.parentWord == "分數" && $0.childWord == "新增" && $0.score == 42
+            $0.parentWord == "分" && $0.childWord == "數新增" && $0.score == 42
         })
     }
 
@@ -134,9 +186,9 @@ final class ManageRelatedControllerTest: XCTestCase {
         let controller = await LimeIME.ManageRelatedController(dbServer: LimeIME.DBServer(_testDatasource: db))
         let meta = try syncMeta(for: url)
 
-        let add = await controller.addRelated(parentWord: "i3", childWord: "新增", score: 1)
+        let add = await controller.addRelated(parentWord: "同", childWord: "步新增", score: 1)
         guard case .success = add,
-              let first = db.getRelated(nil, 10, 0).first(where: { $0.parentWord == "i3" }) else {
+              let first = db.getRelated(nil, 10, 0).first(where: { $0.parentWord == "同" }) else {
             XCTFail("Expected addRelated to succeed")
             return
         }
@@ -144,7 +196,7 @@ final class ManageRelatedControllerTest: XCTestCase {
         XCTAssertEqual(try meta.generation(), 1)
 
         let update = await controller.updateRelated(id: first.id,
-                                                    parentWord: "i3",
+                                                    parentWord: "同",
                                                     childWord: "更新",
                                                     score: 2)
         guard case .success = update else {
@@ -182,7 +234,7 @@ final class ManageRelatedControllerTest: XCTestCase {
         let controller = await LimeIME.ManageRelatedController(dbServer: LimeIME.DBServer(_testDatasource: db))
 
         await MainActor.run {
-            controller.addRelated(parentWord: "hello", childWord: "", view: mock)
+            controller.addRelated(parentWord: "哈", childWord: "", view: mock)
             XCTAssertFalse(mock.errors.isEmpty)
         }
     }
@@ -223,18 +275,18 @@ final class ManageRelatedControllerTest: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
         let controller = await LimeIME.ManageRelatedController(dbServer: LimeIME.DBServer(_testDatasource: db))
 
-        let addResult = await controller.addRelated(parentWord: "分數", childWord: "編輯", score: 7)
+        let addResult = await controller.addRelated(parentWord: "分", childWord: "數編輯", score: 7)
         guard case .success = addResult,
               let first = db.getRelated(nil, 10, 0).first(where: {
-                  $0.parentWord == "分數" && $0.childWord == "編輯"
+                  $0.parentWord == "分" && $0.childWord == "數編輯"
               }) else {
             XCTFail("Expected seeded related phrase")
             return
         }
 
         let updateResult = await controller.updateRelated(id: first.id,
-                                                          parentWord: "分數",
-                                                          childWord: "更新",
+                                                          parentWord: "分",
+                                                          childWord: "數更新",
                                                           score: 88)
 
         guard case .success = updateResult else {
@@ -243,7 +295,7 @@ final class ManageRelatedControllerTest: XCTestCase {
         }
         let updated = db.getRelated(nil, 10, 0)
         XCTAssertTrue(updated.contains {
-            $0.parentWord == "分數" && $0.childWord == "更新" && $0.score == 88
+            $0.parentWord == "分" && $0.childWord == "數更新" && $0.score == 88
         })
     }
 
@@ -295,8 +347,8 @@ final class ManageRelatedControllerTest: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
         let controller = await LimeIME.ManageRelatedController(dbServer: LimeIME.DBServer(_testDatasource: db))
 
-        _ = await controller.addRelated(parentWord: "A", childWord: "B")
-        _ = await controller.addRelated(parentWord: "C", childWord: "D")
+        _ = await controller.addRelated(parentWord: "甲", childWord: "乙")
+        _ = await controller.addRelated(parentWord: "丙", childWord: "丁")
 
         let mock = await MockManageRelatedView()
         await MainActor.run { controller.loadRelated(query: nil, page: 0, view: mock) }
@@ -312,14 +364,12 @@ final class ManageRelatedControllerTest: XCTestCase {
         defer { try? FileManager.default.removeItem(at: url) }
         let controller = await LimeIME.ManageRelatedController(dbServer: LimeIME.DBServer(_testDatasource: db))
 
-        _ = await controller.addRelated(parentWord: "搜尋", childWord: "結果")
-        _ = await controller.addRelated(parentWord: "其他", childWord: "詞彙")
+        _ = await controller.addRelated(parentWord: "搜", childWord: "尋結果")
+        _ = await controller.addRelated(parentWord: "其", childWord: "他詞彙")
 
         let mock = await MockManageRelatedView()
         await MainActor.run { controller.loadRelated(query: "搜", page: 0, view: mock) }
-        // Pure absence assertion: query "搜" matches pword exactly (not "搜尋"), so the load
-        // yields displayRelatedPhrases([]) — no positive signal to poll. Widened fixed wait.
-        try await Task.sleep(nanoseconds: 1_500_000_000)
+        await waitUntil { !mock.displayedPhrases.isEmpty }
 
         await MainActor.run {
             XCTAssertTrue(mock.errors.isEmpty)
@@ -343,7 +393,7 @@ final class ManageRelatedControllerTest: XCTestCase {
         let threadMock = await ThreadCaptureMock()
         let controller = await LimeIME.ManageRelatedController(dbServer: LimeIME.DBServer(_testDatasource: db))
 
-        await MainActor.run { controller.addRelated(parentWord: "主線", childWord: "回呼", view: threadMock) }
+        await MainActor.run { controller.addRelated(parentWord: "主", childWord: "線回呼", view: threadMock) }
         await waitUntil { threadMock.capturedThread != nil }
 
         await MainActor.run {

--- a/LimeStudio/app/src/androidTest/java/org/limeime/ManageImControllerTest.java
+++ b/LimeStudio/app/src/androidTest/java/org/limeime/ManageImControllerTest.java
@@ -2,11 +2,14 @@ package org.limeime;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.limeime.SearchServer;
 import org.limeime.data.Record;
+import org.limeime.data.Related;
 import org.limeime.ui.controller.ManageImController;
 import org.limeime.ui.view.ManageImView;
+import org.limeime.ui.view.ManageRelatedView;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,6 +59,36 @@ public class ManageImControllerTest {
         }
 
 
+    }
+
+    private static class StubManageRelatedView implements ManageRelatedView {
+        private final AtomicReference<String> errorRef;
+        private boolean refreshed;
+
+        StubManageRelatedView(AtomicReference<String> errorRef) {
+            this.errorRef = errorRef;
+        }
+
+        @Override
+        public void displayRelatedPhrases(List<Related> related) { /* no-op */ }
+
+        @Override
+        public void updatePhraseCount(int count) { /* no-op */ }
+
+        @Override
+        public void refreshPhraseList() { refreshed = true; }
+
+        @Override
+        public void showEditPhraseDialog(Related related) { /* no-op */ }
+
+        @Override
+        public void showAddPhraseDialog() { /* no-op */ }
+
+        @Override
+        public void showDeleteConfirmDialog(long id) { /* no-op */ }
+
+        @Override
+        public void onError(String message) { errorRef.set(message); }
     }
 
     @Test
@@ -122,5 +155,35 @@ public class ManageImControllerTest {
 
         assertTrue(controller.updateIMMetadataField("custom", "limeendkey", " "));
         assertEquals("", dbServer.getImConfig("custom", "limeendkey"));
+    }
+
+    @Test
+    public void addRelatedPhrase_rejectsInvalidParentBeforeDatabaseWrite() {
+        SearchServer searchServer = new SearchServer(ApplicationProvider.getApplicationContext());
+        ManageImController controller = new ManageImController(searchServer);
+        AtomicReference<String> errorRef = new AtomicReference<>();
+        StubManageRelatedView view = new StubManageRelatedView(errorRef);
+        controller.setManageRelatedView(view);
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(
+                () -> controller.addRelatedPhrase("台中", "市", 0));
+
+        assertNotNull("Multi-character parent should report a validation error", errorRef.get());
+        assertFalse("Invalid parent must not refresh after a database write", view.refreshed);
+    }
+
+    @Test
+    public void updateRelatedPhrase_rejectsNonHanParentBeforeDatabaseWrite() {
+        SearchServer searchServer = new SearchServer(ApplicationProvider.getApplicationContext());
+        ManageImController controller = new ManageImController(searchServer);
+        AtomicReference<String> errorRef = new AtomicReference<>();
+        StubManageRelatedView view = new StubManageRelatedView(errorRef);
+        controller.setManageRelatedView(view);
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(
+                () -> controller.updateRelatedPhrase(1, "add", "市", 0));
+
+        assertNotNull("Non-Han parent should report a validation error", errorRef.get());
+        assertFalse("Invalid parent must not refresh after a database write", view.refreshed);
     }
 }

--- a/LimeStudio/app/src/androidTest/java/org/limeime/ManageRelatedAddDialogTest.java
+++ b/LimeStudio/app/src/androidTest/java/org/limeime/ManageRelatedAddDialogTest.java
@@ -51,6 +51,30 @@ public class ManageRelatedAddDialogTest {
     }
 
     @Test
+    public void testRelatedParentRequiresExactlyOneHanCharacter() throws Exception {
+        assertRelatedInputValidity("org.limeime.ui.dialog.ManageRelatedAddSheet", "中", true);
+        assertRelatedInputValidity("org.limeime.ui.dialog.ManageRelatedAddSheet", "𠀀", true);
+        assertRelatedInputValidity("org.limeime.ui.dialog.ManageRelatedAddSheet", "台中", false);
+        assertRelatedInputValidity("org.limeime.ui.dialog.ManageRelatedAddSheet", "add", false);
+        assertRelatedInputValidity("org.limeime.ui.dialog.ManageRelatedAddSheet", "Ａ", false);
+
+        assertRelatedInputValidity("org.limeime.ui.dialog.ManageRelatedEditSheet", "中", true);
+        assertRelatedInputValidity("org.limeime.ui.dialog.ManageRelatedEditSheet", "台中", false);
+        assertRelatedInputValidity("org.limeime.ui.dialog.ManageRelatedEditSheet", "add", false);
+    }
+
+    private void assertRelatedInputValidity(String className, String parentWord,
+                                            boolean expected) throws Exception {
+        Class<?> dialog = Class.forName(className);
+        Object instance = dialog.getDeclaredConstructor().newInstance();
+        java.lang.reflect.Method validate = dialog.getDeclaredMethod(
+                "validateInput", String.class, String.class);
+        validate.setAccessible(true);
+        assertEquals(className + " parentWord=" + parentWord,
+                expected, validate.invoke(instance, parentWord, "關聯"));
+    }
+
+    @Test
     public void testSheetLayoutScrollsWhenImeIsVisible() {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         assertEquals("ManageRelatedAddSheet root should scroll above the soft keyboard",

--- a/LimeStudio/app/src/main/java/org/limeime/global/RelatedParentValidator.java
+++ b/LimeStudio/app/src/main/java/org/limeime/global/RelatedParentValidator.java
@@ -1,0 +1,33 @@
+package org.limeime.global;
+
+/** Validation rules for the parent key used by related-word records. */
+public final class RelatedParentValidator {
+    public static final String ERROR_MESSAGE = "首字只能輸入一個中文字";
+
+    private RelatedParentValidator() {}
+
+    public static String normalize(String parentWord) {
+        return parentWord == null ? "" : parentWord.trim();
+    }
+
+    public static boolean isValid(String parentWord) {
+        String value = normalize(parentWord);
+        if (value.codePointCount(0, value.length()) != 1) return false;
+        return isHanCodePoint(value.codePointAt(0));
+    }
+
+    private static boolean isHanCodePoint(int codePoint) {
+        return codePoint == 0x3007
+                || (codePoint >= 0x3400 && codePoint <= 0x4DBF)
+                || (codePoint >= 0x4E00 && codePoint <= 0x9FFF)
+                || (codePoint >= 0xF900 && codePoint <= 0xFAFF)
+                || (codePoint >= 0x20000 && codePoint <= 0x2A6DF)
+                || (codePoint >= 0x2A700 && codePoint <= 0x2B73F)
+                || (codePoint >= 0x2B740 && codePoint <= 0x2B81F)
+                || (codePoint >= 0x2B820 && codePoint <= 0x2CEAF)
+                || (codePoint >= 0x2CEB0 && codePoint <= 0x2EBEF)
+                || (codePoint >= 0x2EBF0 && codePoint <= 0x2EE5F)
+                || (codePoint >= 0x2F800 && codePoint <= 0x2FA1F)
+                || (codePoint >= 0x30000 && codePoint <= 0x323AF);
+    }
+}

--- a/LimeStudio/app/src/main/java/org/limeime/ui/controller/ManageImController.java
+++ b/LimeStudio/app/src/main/java/org/limeime/ui/controller/ManageImController.java
@@ -11,6 +11,7 @@ import org.limeime.SearchServer;
 import org.limeime.data.Record;
 import org.limeime.data.Related;
 import org.limeime.global.LIME;
+import org.limeime.global.RelatedParentValidator;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -238,13 +239,18 @@ public class ManageImController extends BaseController {
      * @param score The score
      */
     public void addRelatedPhrase(String pWord, String cWord, int score) {
+        String normalizedPWord = RelatedParentValidator.normalize(pWord);
+        if (!RelatedParentValidator.isValid(normalizedPWord)) {
+            handleError(manageRelatedView, RelatedParentValidator.ERROR_MESSAGE, null);
+            return;
+        }
         try {
             android.content.ContentValues cv = new android.content.ContentValues();
-            cv.put(LIME.DB_RELATED_COLUMN_PWORD, pWord);
+            cv.put(LIME.DB_RELATED_COLUMN_PWORD, normalizedPWord);
             cv.put(LIME.DB_RELATED_COLUMN_CWORD, cWord);
             cv.put(LIME.DB_RELATED_COLUMN_USERSCORE, score);
-            if (searchServer.hasRelated(pWord, cWord)) {
-                searchServer.updateRecord(LIME.DB_TABLE_RELATED, cv, LIME.DB_RELATED_COLUMN_PWORD + " = ? AND " + LIME.DB_RELATED_COLUMN_CWORD + " = ?", new String[]{pWord, cWord});
+            if (searchServer.hasRelated(normalizedPWord, cWord)) {
+                searchServer.updateRecord(LIME.DB_TABLE_RELATED, cv, LIME.DB_RELATED_COLUMN_PWORD + " = ? AND " + LIME.DB_RELATED_COLUMN_CWORD + " = ?", new String[]{normalizedPWord, cWord});
             } else {
                 searchServer.addRecord(LIME.DB_TABLE_RELATED, cv);
             }
@@ -266,9 +272,14 @@ public class ManageImController extends BaseController {
      * @param score The new score
      */
     public void updateRelatedPhrase(long id, String pWord, String cWord, int score) {
+        String normalizedPWord = RelatedParentValidator.normalize(pWord);
+        if (!RelatedParentValidator.isValid(normalizedPWord)) {
+            handleError(manageRelatedView, RelatedParentValidator.ERROR_MESSAGE, null);
+            return;
+        }
         try {
             android.content.ContentValues cv = new android.content.ContentValues();
-            cv.put(LIME.DB_RELATED_COLUMN_PWORD, pWord);
+            cv.put(LIME.DB_RELATED_COLUMN_PWORD, normalizedPWord);
             cv.put(LIME.DB_RELATED_COLUMN_CWORD, cWord);
             cv.put(LIME.DB_RELATED_COLUMN_BASESCORE, score);
             searchServer.updateRecord(LIME.DB_TABLE_RELATED, cv, LIME.DB_COLUMN_ID + " = ?", new String[]{String.valueOf(id)});

--- a/LimeStudio/app/src/main/java/org/limeime/ui/dialog/ManageRelatedAddSheet.java
+++ b/LimeStudio/app/src/main/java/org/limeime/ui/dialog/ManageRelatedAddSheet.java
@@ -36,6 +36,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.textfield.TextInputEditText;
 
 import org.limeime.R;
+import org.limeime.global.RelatedParentValidator;
 import org.limeime.ui.view.ManageRelatedFragment;
 
 /**
@@ -88,7 +89,10 @@ public class ManageRelatedAddSheet extends BottomSheetDialogFragment {
             String pword = edtWord.getText() != null ? edtWord.getText().toString().trim() : "";
             String cword = edtRelated.getText() != null ? edtRelated.getText().toString().trim() : "";
             if (!validateInput(pword, cword)) {
-                Toast.makeText(requireContext(), R.string.insert_error, Toast.LENGTH_SHORT).show();
+                int message = !RelatedParentValidator.isValid(pword)
+                        ? R.string.manage_related_invalid_parent
+                        : R.string.insert_error;
+                Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show();
                 return;
             }
             score = ManageSheetScoreInput.readScore(edtScore, score);
@@ -106,7 +110,7 @@ public class ManageRelatedAddSheet extends BottomSheetDialogFragment {
     }
 
     private boolean validateInput(String pword, String cword) {
-        return !pword.isEmpty() && !cword.isEmpty();
+        return RelatedParentValidator.isValid(pword) && !cword.isEmpty();
     }
 
     @Override

--- a/LimeStudio/app/src/main/java/org/limeime/ui/dialog/ManageRelatedEditSheet.java
+++ b/LimeStudio/app/src/main/java/org/limeime/ui/dialog/ManageRelatedEditSheet.java
@@ -37,6 +37,7 @@ import com.google.android.material.textfield.TextInputEditText;
 
 import org.limeime.R;
 import org.limeime.data.Related;
+import org.limeime.global.RelatedParentValidator;
 import org.limeime.ui.view.ManageRelatedFragment;
 
 /**
@@ -111,7 +112,10 @@ public class ManageRelatedEditSheet extends BottomSheetDialogFragment {
             String pword = edtWord.getText() != null ? edtWord.getText().toString().trim() : "";
             String cword = edtRelated.getText() != null ? edtRelated.getText().toString().trim() : "";
             if (!validateInput(pword, cword)) {
-                Toast.makeText(requireContext(), R.string.update_error, Toast.LENGTH_SHORT).show();
+                int message = !RelatedParentValidator.isValid(pword)
+                        ? R.string.manage_related_invalid_parent
+                        : R.string.update_error;
+                Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show();
                 return;
             }
             score = ManageSheetScoreInput.readScore(edtScore, score);
@@ -136,7 +140,7 @@ public class ManageRelatedEditSheet extends BottomSheetDialogFragment {
     }
 
     private boolean validateInput(String pword, String cword) {
-        return !pword.isEmpty() && !cword.isEmpty();
+        return RelatedParentValidator.isValid(pword) && !cword.isEmpty();
     }
 
     @Override

--- a/LimeStudio/app/src/main/res/values/strings.xml
+++ b/LimeStudio/app/src/main/res/values/strings.xml
@@ -210,6 +210,7 @@
     <string name="manage_related_loading">讀取中 ...</string>
     <string name="manage_related_reset">重置</string>
     <string name="manage_related_duplicated_error">關聯字重覆或建立錯誤，無法儲存</string>
+    <string name="manage_related_invalid_parent">首字只能輸入一個中文字</string>
     <string name="manage_related_word_hint">合併詞（第一字為索引詞）</string>
 
 
@@ -314,6 +315,6 @@
     <string name="dialog_update_message">儲存變更？</string>
 
     <!-- Batch 6: related sheet field hints -->
-    <string name="manage_related_hint_word">詞彙</string>
+    <string name="manage_related_hint_word">首字（一個中文字）</string>
     <string name="manage_related_hint_related">關聯字</string>
 </resources>

--- a/LimeStudio/app/src/test/java/org/limeime/global/RelatedParentValidatorTest.java
+++ b/LimeStudio/app/src/test/java/org/limeime/global/RelatedParentValidatorTest.java
@@ -1,0 +1,35 @@
+package org.limeime.global;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RelatedParentValidatorTest {
+
+    @Test
+    public void acceptsExactlyOneHanCodePoint() {
+        assertTrue(RelatedParentValidator.isValid("中"));
+        assertTrue(RelatedParentValidator.isValid("〇"));
+        assertTrue(RelatedParentValidator.isValid("𠀀"));
+        assertTrue(RelatedParentValidator.isValid(" 中 "));
+    }
+
+    @Test
+    public void rejectsMultipleHanAndNonHanInput() {
+        assertFalse(RelatedParentValidator.isValid("台中"));
+        assertFalse(RelatedParentValidator.isValid("add"));
+        assertFalse(RelatedParentValidator.isValid("Ａ"));
+        assertFalse(RelatedParentValidator.isValid("１"));
+        assertFalse(RelatedParentValidator.isValid("，"));
+        assertFalse(RelatedParentValidator.isValid(""));
+        assertFalse(RelatedParentValidator.isValid(null));
+    }
+
+    @Test
+    public void normalizesBeforeValidationAndStorage() {
+        assertEquals("中", RelatedParentValidator.normalize(" 中 "));
+        assertEquals("", RelatedParentValidator.normalize(null));
+    }
+}

--- a/docs/#161_ISSUE.md
+++ b/docs/#161_ISSUE.md
@@ -1,0 +1,62 @@
+# Issue #161: Validate Related-Word Parent Input
+
+## Classification
+
+- GitHub issue: https://github.com/lime-ime/limeime/issues/161
+- Type: `bug` + `Usability`
+- Reporter platform: Android, based on the attached Settings screenshots
+- Cross-platform scope: Android and iOS have equivalent related-record add/update paths
+- Product invariant: related-table `pword` is exactly one Chinese Han character
+
+## Problem
+
+The original question asked for an iOS text-replacement / Samsung text-shortcut equivalent. LIME already supports that workflow through each input method's `瀏覽 / 編輯資料表`, and the reporter confirmed that path works.
+
+The follow-up exposed a separate validation bug in `關聯字管理`: add/edit accepted parent values that violate the related-table model. For example, a record with `pword = add` could be saved successfully but could not be found through the designed related-word lookup. Multi-character parent input has the same model mismatch.
+
+## Root cause
+
+The Android and iOS related-record editors checked only that `pword` and `cword` were non-empty. Their controller/database boundaries did not enforce the existing one-Han-character `pword` invariant.
+
+Runtime related-candidate lookup intentionally treats one Chinese character as `pword` and the continuation as `cword`. The defect is missing write-time validation, not the runtime lookup contract. PR #163 was closed unmerged because its broad management substring-search approach assumed multi-character `pword` records should be supported.
+
+## Fix
+
+For both add and update:
+
+- accept exactly one Unicode Han code point as `pword`
+- accept supplementary-plane Han characters
+- trim surrounding whitespace before validation and storage
+- reject two or more Chinese characters
+- reject ASCII letters, digits, punctuation, and full-width non-Han characters
+- display `首字只能輸入一個中文字`
+- keep runtime related-candidate lookup unchanged
+- keep deletion available for existing malformed rows
+- do not migrate or delete existing records automatically
+
+## Platform impact
+
+### Android
+
+Confirmed affected by the reporter's screenshots and source inspection. Validation is added to both add/edit sheets and `ManageImController`, so bypassing the UI cannot write a malformed parent. Focused unit and instrumentation tests cover Unicode validation, add/edit UI validation, and controller rejection before refresh/database success behavior.
+
+### iOS
+
+Source inspection found the same non-empty-only checks in both async and callback add/update APIs. Matching validation and tests are included. iOS behavior is source-audited but not reporter-confirmed, and XCTest still requires macOS/Xcode execution.
+
+## TDD evidence
+
+Before production changes, focused tests demonstrated that Android accepted `台中` and non-Han parent text at the editor/controller boundary. The corrected tests require exactly one Han code point and verify that rejected writes do not report successful refresh.
+
+## Acceptance criteria
+
+- [x] Exactly one BMP Han character is accepted.
+- [x] Exactly one supplementary-plane Han character is accepted.
+- [x] Multiple Chinese characters are rejected.
+- [x] ASCII and full-width non-Han input are rejected.
+- [x] Android add/edit UI and controller boundaries validate input.
+- [x] iOS async and callback add/update boundaries validate input.
+- [x] Existing malformed rows can still be deleted.
+- [ ] iOS XCTest passes under Xcode.
+- [ ] Maintainer review/merge.
+- [ ] Reporter confirms the fix in a newer Android build.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,7 @@ Last reviewed: 2026-07-18
 
 ## Pending fixes
 - fix#160 iOS: the shared-catalog keyboard option `limenumsym` (`LIME+數字符號鍵盤`) renders the ordinary number-row QWERTY layout instead of its dedicated number/symbol layout. Android is reporter-confirmed working. PR #162 merged the missing phone/iPad resources as `c56593f8e3fd76b4a800b66b12ab76b7a6b96f46`; follow-up PR #164 merged the source-independent semantic oracle and corrected full/narrow-iPad punctuation preservation as `66b1577f0c58eee1359d5e921ce57ebaeca9a68d`. Remaining work is phone/full-iPad/narrow-iPad device verification, a newer TestFlight/App Store build containing both merges, and reporter confirmation. Android is not in scope. See `docs/#160_ISSUE.md`.
+- fix#161 Android/iOS: enforce the existing related-table invariant at every add/update boundary. `pword` must be exactly one Unicode Han character; reject multi-character and non-Han input before database writes, preserve deletion of existing malformed rows, and leave runtime related-candidate lookup semantics unchanged. Android reporter retest waits for a newer APK; iOS XCTest/build verification remains pending. See `docs/#161_ISSUE.md`.
 
 ## Product work
 


### PR DESCRIPTION
## Summary

- enforce the existing one-Han-character `pword` invariant at Android and iOS related-record add/update boundaries
- reject multi-character and non-Han parent input before database writes
- normalize surrounding whitespace and provide clearer field guidance/error text
- keep runtime related-candidate lookup and deletion of existing malformed rows unchanged
- add Android unit/instrumentation coverage and matching iOS XCTest coverage

## Root cause

The related-record editors and controller boundaries checked only that parent/child values were non-empty. They could therefore save malformed parent values such as `add` or multi-character `台中`, even though related lookup treats `pword` as one Chinese Han character. Those malformed records could then be difficult or impossible to find through the designed lookup.

PR #163 and superseded PR #165 pursued broad management substring search and multi-character parent support. That premise conflicts with the confirmed data-model invariant, so this PR keeps runtime lookup unchanged and fixes the write boundary instead.

## Verification

- `:app:testDebugUnitTest`: passed
- `:app:compileDebugJavaWithJavac`: passed
- `:app:compileDebugAndroidTestJavaWithJavac`: passed
- focused Android instrumentation (`ManageRelatedAddDialogTest`, `ManageImControllerTest`): 12/12 passed on Pixel 9 Pro / Android 16 emulator
- `git diff --check`: passed
- Claude Code Superpowers review: `BLOCKERS: none`
- iOS XCTest: included but not run on this Linux host

## Platform scope

- Android: reporter path, compile/unit/instrumentation verified
- iOS: analogous source path updated with matching tests, pending Xcode execution

Addresses #161. Keep the issue open until a newer Android build is available and the reporter confirms the corrected add/search/delete workflow.