### PR TITLE
fix(android): refresh related list after deletion

### DIFF
--- a/LimeStudio/app/src/androidTest/java/org/limeime/ManageRelatedDeletionRefreshTest.java
+++ b/LimeStudio/app/src/androidTest/java/org/limeime/ManageRelatedDeletionRefreshTest.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  *
+ *  **    Copyright 2026, The LimeIME Open Source Project
+ *  **
+ *  **    Project Url: http://github.com/lime-ime/limeime/
+ *  **
+ *  **    This program is free software: you can redistribute it and/or modify
+ *  **    it under the terms of the GNU General Public License as published by
+ *  **    the Free Software Foundation, either version 3 of the License, or
+ *  **    (at your option) any later version.
+ *  *
+ */
+
+package org.limeime;
+
+import static org.junit.Assert.assertEquals;
+
+import android.app.Activity;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.limeime.data.Related;
+import org.limeime.ui.controller.ManageImController;
+import org.limeime.ui.view.ManageRelatedAdapter;
+import org.limeime.ui.view.ManageRelatedFragment;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(AndroidJUnit4.class)
+public class ManageRelatedDeletionRefreshTest {
+
+    @Test
+    public void submittedListIsSnapshotWhenCallerMutatesSource() {
+        List<Related> source = new ArrayList<>();
+        source.add(related(1, "/084V9P2", "/084V9P2"));
+        source.add(related(2, "/084V9P2", "台中"));
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+            ManageRelatedAdapter adapter = new ManageRelatedAdapter(Mockito.mock(Activity.class));
+            adapter.submitList(source);
+            assertEquals(2, adapter.getItemCount());
+
+            source.remove(0);
+
+            assertEquals(
+                    "Mutating the fragment list must not silently change ListAdapter state",
+                    2,
+                    adapter.getItemCount());
+        });
+    }
+
+    @Test
+    public void removeRelatedKeepsSubmittedPageImmutableUntilRefresh() throws Exception {
+        List<Related> source = new ArrayList<>();
+        source.add(related(1, "/084V9P2", "/084V9P2"));
+        source.add(related(2, "/084V9P2", "台中"));
+
+        ManageRelatedFragment fragment = new ManageRelatedFragment();
+        ManageImController controller = Mockito.mock(ManageImController.class);
+        setField(fragment, "relatedlist", source);
+        setField(fragment, "manageImController", controller);
+
+        fragment.removeRelated(1);
+
+        assertEquals(
+                "The current page must remain unchanged until the controller supplies a new snapshot",
+                2,
+                source.size());
+        Mockito.verify(controller).deleteRelatedPhrase(1);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Related related(int id, String pword, String cword) {
+        Related related = new Related();
+        related.setId(id);
+        related.setPword(pword);
+        related.setCword(cword);
+        return related;
+    }
+}

--- a/LimeStudio/app/src/main/java/org/limeime/ui/view/ManageRelatedAdapter.java
+++ b/LimeStudio/app/src/main/java/org/limeime/ui/view/ManageRelatedAdapter.java
@@ -37,6 +37,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import org.limeime.R;
 import org.limeime.data.Related;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -65,6 +67,15 @@ public class ManageRelatedAdapter extends ListAdapter<Related, ManageRelatedAdap
     public ManageRelatedAdapter(Activity activity) {
         super(DIFF_CALLBACK);
         this.activity = activity;
+    }
+
+    @Override
+    public void submitList(List<Related> list) {
+        // ListAdapter requires submitted lists to remain immutable while DiffUtil
+        // compares them. The fragment also keeps its own mutable page list, so
+        // submit a snapshot to prevent a delete from silently changing adapter
+        // item positions before the refreshed database result arrives.
+        super.submitList(list == null ? null : new ArrayList<>(list));
     }
 
     private static final DiffUtil.ItemCallback<Related> DIFF_CALLBACK = new DiffUtil.ItemCallback<Related>() {

--- a/LimeStudio/app/src/main/java/org/limeime/ui/view/ManageRelatedFragment.java
+++ b/LimeStudio/app/src/main/java/org/limeime/ui/view/ManageRelatedFragment.java
@@ -312,17 +312,10 @@ public class ManageRelatedFragment extends Fragment implements ManageRelatedView
     }
 
     public void removeRelated(int id){
-        if (this.relatedlist != null) {
-            for (int i = 0; i < this.relatedlist.size(); i++) {
-                if (id == this.relatedlist.get(i).getIdAsInt()) {
-                    this.relatedlist.remove(i);
-                    break;
-                }
-            }
-        }
         if (manageImController != null) {
+            // Keep the currently submitted page immutable. The controller deletes
+            // the row and refreshes the view with a new database snapshot.
             manageImController.deleteRelatedPhrase(id);
-            searchRelated();
         }
     }
 

--- a/docs/#161_ISSUE.md
+++ b/docs/#161_ISSUE.md
@@ -5,7 +5,7 @@
 - GitHub issue: https://github.com/lime-ime/limeime/issues/161
 - Classification: `bug` + `Usability`
 - Platforms: Android and iOS
-- State: open pending reporter confirmation on Android GitHub APK v6.1.33; iOS binary delivery and corrected-source validation remain separate
+- State: open after the reporter confirmed the Android v6.1.33 search and immediate candidate-refresh fixes; the uploaded recording shows a separate Android management-list refresh defect after deletion, while iOS binary delivery and corrected-source validation remain separate
 
 ## Corrected scope
 
@@ -56,6 +56,10 @@ Management search is separate from runtime candidate lookup. A non-empty query p
 - iOS audit found the same gap in mirror form: `ManageRelatedController` mutations never set the `needsKeyboardCacheReset` App-Group flag that `ManageImController` uses, so a warm keyboard process whose table sync was applied by another process (settings probe / other host app) could keep serving its stale `relatedCache`. FIXED: all seven related mutation sites now call the shared (`nonisolated`) `ManageImController.markKeyboardCacheDirty()` after a successful write, matching the mapping-editor pattern; the keyboard clears all caches on next activation.
 - Do not request reporter retest from v6.1.32 or from any build that contains PR #167 without the cache-invalidation follow-ups.
 - Issue #161 was reopened for Android reporter confirmation. The retained v6.1.33 retest request is https://github.com/lime-ime/limeime/issues/161#issuecomment-5011747138 and asks the reporter to verify `pword`-prefix search/deletion plus immediate candidate refresh after manual add/update/delete.
+- Reporter `coral0819` confirmed both requested Android checks in https://github.com/lime-ime/limeime/issues/161#issuecomment-5012137623: previously unfindable related records can now be found and deleted, and keyboard related candidates update immediately after add/update/delete. The comment was then edited to add a public Google Drive recording. The downloaded 21.376-second MP4 is 15,818,451 bytes with SHA-256 `0bce29c2e256c53dd7251053b77b2a98cf6955fa3ad175d38111506c95e83497`.
+- The recording establishes a separate Android management-list synchronization defect. With search text `/`, the list initially shows three records with the same parent `/084V9P2` and children `/084V9P2`, `台中`, and `/`. After a delete is confirmed, the filtered list count changes but a visible row can retain the deleted record's text; tapping that stale-looking row opens a different surviving record. Clearing/re-entering the search refreshes the visible row contents. This does not invalidate the confirmed prefix-search or keyboard-candidate cache fixes, but it keeps #161 open for a focused list-refresh fix.
+- Root cause: `ManageRelatedFragment.removeRelated()` removed the row directly from the same mutable list previously submitted to `ListAdapter`, violating DiffUtil's immutable-list contract. The adapter's internal item count changed without a matching RecyclerView diff/rebind, so visible holder text and the refreshed database position could diverge. The fragment also requested a second redundant refresh after `ManageImController.deleteRelatedPhrase()` had already refreshed the view.
+- Focused Android fix branch `fix/161-android-related-delete-list` keeps the submitted page unchanged until the controller returns a fresh database result, removes the redundant delete refresh, and makes `ManageRelatedAdapter` snapshot each submitted list defensively. Instrumentation regression coverage first reproduced RED when caller mutation changed the adapter count from 2 to 1 without a new submission, then passed GREEN after the fix; a second RED/GREEN test verifies `removeRelated()` does not mutate the current page before controller refresh.
 - iOS delivery still requires corrected-source XCTest/Xcode Cloud validation and a verified newer TestFlight/App Store build. The Android APK does not verify iOS behavior.
 
 ## Acceptance criteria
@@ -70,4 +74,5 @@ Management search is separate from runtime candidate lookup. A non-empty query p
 - [x] Maintainer review/merge as PR #167 / `7f799370b0e3e6cdfc7114ea7af8ffb5b71a8262`
 - [x] Android manual related add/update/delete invalidates both initial and full runtime related-cache entries (whole-cache flush in the generic mutation wrappers + regression test)
 - [x] iOS manual related add/update/delete signals `needsKeyboardCacheReset` so the keyboard flushes `relatedCache` on next activation
-- [ ] Reporter verifies search/deletion in a released build
+- [x] Reporter verifies Android search/deletion and immediate candidate refresh in v6.1.33
+- [ ] Android filtered management list refreshes row contents after deletion so the visible row and the record opened by tapping it remain identical

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,10 +2,10 @@
 
 Public backlog for confirmed unresolved fixes and product work. Issue-specific investigation details stay in `docs/#NN_ISSUE.md`; completed, shipped, or closed scopes stay in their issue docs instead of here.
 
-Last reviewed: 2026-07-18
+Last reviewed: 2026-07-19
 
 ## Pending fixes
-- fix#161 iOS/reporter follow-up: Android GitHub APK v6.1.33 includes the escaped `pword` prefix management search, runtime parity, and manual add/update/delete cache invalidation follow-ups, and issue #161 is open pending reporter confirmation. iOS source includes the corresponding management/runtime/cache-reset changes but still needs corrected-source XCTest/Xcode Cloud validation and a verified newer TestFlight/App Store build. See `docs/#161_ISSUE.md`.
+- fix#161 Android+iOS follow-up: the reporter confirmed Android GitHub APK v6.1.33 fixes escaped `pword` prefix search and immediate related-candidate refresh after manual add/update/delete. The uploaded recording shows a separate Android defect where the filtered management list can retain deleted row text and open a different surviving record when that stale-looking row is tapped; clearing/re-entering the filter refreshes it. iOS source includes the corresponding management/runtime/cache-reset changes but still needs corrected-source XCTest/Xcode Cloud validation and a verified newer TestFlight/App Store build. See `docs/#161_ISSUE.md`.
 - fix#160 iOS: the shared-catalog keyboard option `limenumsym` (`LIME+數字符號鍵盤`) renders the ordinary number-row QWERTY layout instead of its dedicated number/symbol layout. Android is reporter-confirmed working. PR #162 merged the missing phone/iPad resources as `c56593f8e3fd76b4a800b66b12ab76b7a6b96f46`; follow-up PR #164 merged the source-independent semantic oracle and corrected full/narrow-iPad punctuation preservation as `66b1577f0c58eee1359d5e921ce57ebaeca9a68d`. Remaining work is phone/full-iPad/narrow-iPad device verification, a newer TestFlight/App Store build containing both merges, and reporter confirmation. Android is not in scope. See `docs/#160_ISSUE.md`.
 
 ## Product work


### PR DESCRIPTION
## Summary

- stop mutating the `ListAdapter` backing page in place before a related-record deletion refresh
- submit defensive page snapshots so `DiffUtil` always compares stable old/new lists
- add Android instrumentation regression coverage for source-list mutation and delete delegation
- record the reporter-confirmed v6.1.33 fixes and the separate deletion-list refresh defect in issue docs/backlog

## Root cause

`ManageRelatedFragment` submitted its mutable `relatedlist` directly to `ManageRelatedAdapter`, then removed the deleted row from that same list before the database refresh. `ListAdapter`/`DiffUtil` therefore lost a stable old-list snapshot. The RecyclerView could retain deleted row text while its current adapter data already pointed at another surviving record.

## Verification

- RED before production fix:
  - `ManageRelatedDeletionRefreshTest` failed because mutating the caller list silently changed adapter state and `removeRelated()` changed the submitted page before refresh
- GREEN after fix:
  - `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.limeime.ManageRelatedDeletionRefreshTest`
  - 2/2 tests passed on Pixel 9 Pro AVD, Android 16
- `./gradlew :app:compileDebugJavaWithJavac :app:compileDebugAndroidTestJavaWithJavac :app:testDebugUnitTest`
- `git diff --check`
- narrow Claude Code blocker review: `BLOCKERS: none`

## Platform impact

- Android: fixes the filtered `關聯字管理` list refresh shown in the reporter's recording.
- iOS: no corresponding RecyclerView/ListAdapter code path is changed. Existing iOS #161 delivery/validation remains separate.

Relates to #161. Keep the community issue open until a newer Android build contains this fix and the reporter confirms the deletion flow.
