### PR TITLE
fix(android): restore portrait split keyboard

### DIFF
--- a/LimeStudio/app/src/main/java/org/limeime/LIMEKeyboardSwitcher.java
+++ b/LimeStudio/app/src/main/java/org/limeime/LIMEKeyboardSwitcher.java
@@ -339,9 +339,11 @@ public class LIMEKeyboardSwitcher {
 	                    keyboard.applyHorizontalAnchor(
 	                            ReachGeometry.numpadWidth(keyboard.getDisplayWidth(), 5, dm.xdpi),
 	                            anchor, false);
-	            } else if (!isTablet && portrait) {
-	                // Phone split renders landscape-only (LIMEBaseKeyboard gate), so
-	                // portrait always belongs to one-hand mode regardless of split pref.
+	            } else if (!isTablet && portrait
+	                    // Issue #169 precedence: an active portrait split (eligible layout
+	                    // under SPLIT_KEYBOARD_ALWAYS) wins over one-hand anchoring, so it
+	                    // must not be overridden here.
+	                    && !LIMEBaseKeyboard.portraitSplitActive(!numpadXml, mLIMEPref.getSplitKeyboard())) {
 	                int mode = mLIMEPref.getOneHandMode();
 	                if (mode != 0 && ReachGeometry.oneHandAvailable(dm.widthPixels, dm.xdpi))
 	                    keyboard.applyHorizontalAnchor(

--- a/LimeStudio/app/src/main/java/org/limeime/keyboard/LIMEBaseKeyboard.java
+++ b/LimeStudio/app/src/main/java/org/limeime/keyboard/LIMEBaseKeyboard.java
@@ -817,16 +817,45 @@ public class LIMEBaseKeyboard {
         //Jeremy '12,5,26 reserve  columns in the middle for arrow keys in landscape mode.
         //Jeremy '12,5,27 read splitkeyboard setting from preference.
         //Jeremy '12,6,19  add orientation consideration on split keyboard
-        // SPLIT_ONE_HAND_KB: on phones split renders in landscape only, whatever the
-        // stored value — portrait phone split keys fall below SPLIT_KEY_MIN_MM and
-        // portrait geometry belongs to one-hand mode (spec eligibility matrix).
         boolean tablet = context.getResources().getConfiguration().smallestScreenWidthDp >= 600;
-        mSplitKeyboard = splitEligible
-                && ((mLandScape && mShowArrowKeys != 0)
-                || (mLandScape && splitKeyboard == SPLIT_KEYBOARD_LANDSCAPD_ONLY)
-                || (splitKeyboard == SPLIT_KEYBOARD_ALWAYS && (tablet || mLandScape)));
+        mSplitKeyboard = splitKeyboardEligible(
+                splitEligible, mLandScape, tablet, mShowArrowKeys, splitKeyboard);
 
         loadKeyboard(context, context.getResources().getXml(xmlLayoutResId));
+    }
+
+    /**
+     * SPLIT_ONE_HAND_KB: split-keyboard eligibility contract, extracted as a pure
+     * function so the legacy split_keyboard_mode matrix is unit-testable.
+     *
+     * @param splitEligible false for numpad / T9 layouts, which never split
+     * @param landscape     current orientation is landscape
+     * @param tablet        smallestScreenWidthDp >= 600
+     * @param showArrowKeys landscape arrow-key split trigger (0 = off)
+     * @param splitMode     stored split_keyboard_mode (NEVER / ALWAYS / LANDSCAPE_ONLY)
+     */
+    public static boolean splitKeyboardEligible(boolean splitEligible, boolean landscape,
+                                         boolean tablet, int showArrowKeys, int splitMode) {
+        // Legacy contract (through v6.1.32, issue #169): ALWAYS renders split in
+        // BOTH orientations on phones and tablets. LANDSCAPE_ONLY and the arrow-key
+        // trigger stay landscape-only. `tablet` is retained for callers/tests but no
+        // longer gates ALWAYS.
+        return splitEligible
+                && ((landscape && showArrowKeys != 0)
+                || (landscape && splitMode == SPLIT_KEYBOARD_LANDSCAPD_ONLY)
+                || splitMode == SPLIT_KEYBOARD_ALWAYS);
+    }
+
+    /**
+     * SPLIT_ONE_HAND_KB (issue #169): whether a split keyboard renders in portrait,
+     * which only happens for a split-eligible layout under SPLIT_KEYBOARD_ALWAYS.
+     * An active portrait split takes precedence over one-hand anchoring, so the
+     * switcher uses this to suppress the one-hand anchor. Delegates to
+     * {@link #splitKeyboardEligible} (portrait: not landscape, no arrow trigger) so
+     * the precedence gate can never drift from the rendering gate.
+     */
+    public static boolean portraitSplitActive(boolean splitEligible, int splitMode) {
+        return splitKeyboardEligible(splitEligible, false, false, 0, splitMode);
     }
 
     /**

--- a/LimeStudio/app/src/test/java/org/limeime/SplitKeyboardModeTest.java
+++ b/LimeStudio/app/src/test/java/org/limeime/SplitKeyboardModeTest.java
@@ -1,0 +1,92 @@
+package org.limeime;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.limeime.keyboard.LIMEBaseKeyboard;
+
+/**
+ * Issue #169 regression: the legacy split_keyboard_mode contract. Through
+ * v6.1.32 SPLIT_KEYBOARD_ALWAYS rendered split in BOTH orientations, phones
+ * included; v6.1.33 gated it behind (tablet || landscape) so portrait phone
+ * split stopped rendering. These assertions pin the v6.1.32 contract.
+ */
+public class SplitKeyboardModeTest {
+
+    private static final int NEVER = LIMEBaseKeyboard.SPLIT_KEYBOARD_NEVER;          // 0
+    private static final int ALWAYS = LIMEBaseKeyboard.SPLIT_KEYBOARD_ALWAYS;        // 1
+    private static final int LANDSCAPE_ONLY = LIMEBaseKeyboard.SPLIT_KEYBOARD_LANDSCAPD_ONLY; // 2
+
+    private static final boolean PORTRAIT = false, LANDSCAPE = true;
+    private static final boolean PHONE = false, TABLET = true;
+    private static final boolean ELIGIBLE = true, NUMPAD = false;
+    private static final int NO_ARROWS = 0, ARROWS = 1;
+
+    // THE regression: ALWAYS must render split in portrait on a phone (v6.1.32 behavior).
+    @Test
+    public void alwaysSplitsInPortraitOnPhone() {
+        assertTrue(LIMEBaseKeyboard.splitKeyboardEligible(ELIGIBLE, PORTRAIT, PHONE, NO_ARROWS, ALWAYS));
+    }
+
+    @Test
+    public void alwaysSplitsInLandscapeOnPhone() {
+        assertTrue(LIMEBaseKeyboard.splitKeyboardEligible(ELIGIBLE, LANDSCAPE, PHONE, NO_ARROWS, ALWAYS));
+    }
+
+    @Test
+    public void alwaysSplitsInPortraitOnTablet() {
+        assertTrue(LIMEBaseKeyboard.splitKeyboardEligible(ELIGIBLE, PORTRAIT, TABLET, NO_ARROWS, ALWAYS));
+    }
+
+    // LANDSCAPE_ONLY stays landscape-only in both form factors.
+    @Test
+    public void landscapeOnlyDoesNotSplitInPortrait() {
+        assertFalse(LIMEBaseKeyboard.splitKeyboardEligible(ELIGIBLE, PORTRAIT, PHONE, NO_ARROWS, LANDSCAPE_ONLY));
+        assertFalse(LIMEBaseKeyboard.splitKeyboardEligible(ELIGIBLE, PORTRAIT, TABLET, NO_ARROWS, LANDSCAPE_ONLY));
+    }
+
+    @Test
+    public void landscapeOnlySplitsInLandscape() {
+        assertTrue(LIMEBaseKeyboard.splitKeyboardEligible(ELIGIBLE, LANDSCAPE, PHONE, NO_ARROWS, LANDSCAPE_ONLY));
+    }
+
+    // NEVER never splits, regardless of orientation / form factor.
+    @Test
+    public void neverDoesNotSplit() {
+        assertFalse(LIMEBaseKeyboard.splitKeyboardEligible(ELIGIBLE, PORTRAIT, PHONE, NO_ARROWS, NEVER));
+        assertFalse(LIMEBaseKeyboard.splitKeyboardEligible(ELIGIBLE, LANDSCAPE, TABLET, NO_ARROWS, NEVER));
+    }
+
+    // Numpad / T9 layouts are ineligible even under ALWAYS.
+    @Test
+    public void numpadNeverSplitsEvenWithAlways() {
+        assertFalse(LIMEBaseKeyboard.splitKeyboardEligible(NUMPAD, PORTRAIT, PHONE, NO_ARROWS, ALWAYS));
+        assertFalse(LIMEBaseKeyboard.splitKeyboardEligible(NUMPAD, LANDSCAPE, TABLET, ARROWS, ALWAYS));
+    }
+
+    // Landscape arrow-key split trigger is landscape-only (unchanged legacy behavior).
+    @Test
+    public void arrowKeysSplitOnlyInLandscape() {
+        assertTrue(LIMEBaseKeyboard.splitKeyboardEligible(ELIGIBLE, LANDSCAPE, PHONE, ARROWS, NEVER));
+        assertFalse(LIMEBaseKeyboard.splitKeyboardEligible(ELIGIBLE, PORTRAIT, PHONE, ARROWS, NEVER));
+    }
+
+    // Issue #169 precedence: an active portrait split (eligible + ALWAYS) wins over
+    // one-hand anchoring. This predicate gates the one-hand path in the switcher.
+    @Test
+    public void portraitSplitActiveWhenEligibleAndAlways() {
+        assertTrue(LIMEBaseKeyboard.portraitSplitActive(ELIGIBLE, ALWAYS));
+    }
+
+    @Test
+    public void portraitSplitInactiveForNumpadEvenWithAlways() {
+        assertFalse(LIMEBaseKeyboard.portraitSplitActive(NUMPAD, ALWAYS));
+    }
+
+    @Test
+    public void portraitSplitInactiveForLandscapeOnlyAndNever() {
+        assertFalse(LIMEBaseKeyboard.portraitSplitActive(ELIGIBLE, LANDSCAPE_ONLY));
+        assertFalse(LIMEBaseKeyboard.portraitSplitActive(ELIGIBLE, NEVER));
+    }
+}

--- a/docs/#169_ISSUE.md
+++ b/docs/#169_ISSUE.md
@@ -1,0 +1,81 @@
+# Issue #169: Android phone split keyboard no longer appears
+
+## Status
+
+Open community bug, labeled `bug` and `Usability`, assigned to `jrywu`.
+
+## Problem statement
+
+The reporter uses LIME 6.1.33 on Android 16 / Samsung One UI 8.5. Split keyboard worked before the 6.1.33 update. After updating, selecting `分離鍵盤` still renders the normal full-width keyboard. Turning the option off, restarting, and enabling it again does not restore the split layout.
+
+The report does not state the device orientation. The regression is nevertheless source-identifiable for portrait phones: v6.1.33 intentionally changed `split_keyboard_mode = 開啟` so phone split rendering is allowed only in landscape, even though older versions treated `開啟` as always enabled.
+
+## Current observations and likely root cause
+
+Commit `01aed41b57690cc54b1f39e248aba1643ca01543` (`fix(android): one-hand/split geometry — in-place rebuild, orientation gating, anchored expanded popup`) changed `LIMEBaseKeyboard` so `SPLIT_KEYBOARD_ALWAYS` now requires either a tablet or landscape orientation:
+
+```java
+splitKeyboard == SPLIT_KEYBOARD_ALWAYS && (tablet || mLandScape)
+```
+
+Before that commit, `SPLIT_KEYBOARD_ALWAYS` enabled split rendering in both orientations. The same commit changed the phone menu and one-hand precedence around the new landscape-only assumption. These changes are included in v6.1.33 and match the reported version boundary.
+
+The preference itself still persists correctly through `LIMEPreferenceManager.getSplitKeyboard()` / `setSplitKeyboard()`. Restarting therefore cannot restore the previous portrait behavior because the renderer now ignores `ALWAYS` on phones in portrait.
+
+This is a source-backed root-cause hypothesis for the portrait-phone path. The reporter has not yet confirmed whether the failed display is portrait-only, landscape-only, or both.
+
+## Proposed solution
+
+Restore the semantic distinction between the two existing split modes on Android phones:
+
+- `開啟` / `SPLIT_KEYBOARD_ALWAYS`: render split keyboard in portrait and landscape, as before v6.1.33.
+- `僅橫向` / `SPLIT_KEYBOARD_LANDSCAPD_ONLY`: render split keyboard only in landscape.
+- Keep numpad layouts excluded from split mode.
+- Ensure one-hand anchoring does not override an active portrait split keyboard.
+
+Extract the split-eligibility decision into a small deterministic helper and cover phone/tablet, portrait/landscape, preference mode, arrow-key, and split-ineligible layout cases with unit tests. Add a focused regression test that fails on current `master`: a split-eligible phone in portrait with `SPLIT_KEYBOARD_ALWAYS` must enable split rendering.
+
+## Follow-up questions
+
+If device verification is still needed after the source fix, ask the reporter to confirm:
+
+1. Whether the failed display occurs in portrait, landscape, or both.
+2. Which input method and keyboard layout were active.
+3. Whether `分離鍵盤` was set to `開啟` or `僅橫向`.
+4. Whether the active layout was a normal alphabetic/per-input-method layout or a numeric keypad layout.
+
+Do not request a retest until a newer Android build contains the targeted fix.
+
+## Verification plan
+
+### Automated Android checks
+
+1. Add a RED unit test proving `SPLIT_KEYBOARD_ALWAYS` enables a split-eligible phone keyboard in portrait.
+2. Verify GREEN after the smallest eligibility fix.
+3. Preserve coverage for:
+   - phone portrait `LANDSCAPE_ONLY` remains unsplit
+   - phone landscape `LANDSCAPE_ONLY` splits
+   - tablet `ALWAYS` splits
+   - split-ineligible/numpad layouts never split
+   - existing landscape arrow-key split behavior remains unchanged
+4. Run the focused unit tests, Android Java compile, Android test compile, and `git diff --check`.
+
+### Device checks
+
+On a phone-sized Android device or emulator:
+
+1. With an ordinary non-numpad layout in portrait, set `分離鍵盤` to `開啟` and verify that the split keyboard appears immediately.
+2. Rotate to landscape and verify split remains active.
+3. Set `分離鍵盤` to `僅橫向`, return to portrait, and verify the full-width keyboard appears.
+4. Verify one-hand mode does not replace an active portrait `開啟` split keyboard.
+5. Verify numeric keypad layouts remain unsplit.
+
+## Platform impact
+
+### Android
+
+Confirmed report platform and affected source path. The regression was introduced by Android-only changes in `LIMEBaseKeyboard` and `LIMEKeyboardSwitcher` included in v6.1.33. A newer Android APK or Google Play build containing the fix will be required for reporter confirmation. The reporter's distribution channel is not yet known, so no APK link or Play-specific retest instruction should be posted yet.
+
+### iOS
+
+The analogous iOS path was inspected. `KeyboardViewController` applies split mode only when `isOnPad` is true, and LimeSettings exposes `分離鍵盤` only on iPad. iPhone split rendering is not an existing iOS behavior, so the Android phone regression and proposed Android semantic restoration do not directly change iOS. Existing iPad split behavior should remain under normal release QA, but no iOS code change or TestFlight retest is required for the reported Android scope.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,9 +2,10 @@
 
 Public backlog for confirmed unresolved fixes and product work. Issue-specific investigation details stay in `docs/#NN_ISSUE.md`; completed, shipped, or closed scopes stay in their issue docs instead of here.
 
-Last reviewed: 2026-07-18
+Last reviewed: 2026-07-19
 
 ## Pending fixes
+- fix#169 Android: restore the pre-v6.1.33 phone behavior where `分離鍵盤 = 開啟` renders a split keyboard in portrait and landscape, while `僅橫向` remains landscape-only. Preserve numpad split exclusion and prevent one-hand anchoring from overriding an active portrait split. Retest only after a newer targeted Android build is available. See `docs/#169_ISSUE.md`.
 - fix#161 iOS/reporter follow-up: Android GitHub APK v6.1.33 includes the escaped `pword` prefix management search, runtime parity, and manual add/update/delete cache invalidation follow-ups, and issue #161 is open pending reporter confirmation. iOS source includes the corresponding management/runtime/cache-reset changes but still needs corrected-source XCTest/Xcode Cloud validation and a verified newer TestFlight/App Store build. See `docs/#161_ISSUE.md`.
 
 


### PR DESCRIPTION
## Summary
- restore the pre-v6.1.33 Android phone contract where `分離鍵盤 = 開啟` applies in portrait and landscape
- keep `僅橫向`, arrow-key, and numpad eligibility behavior unchanged
- prevent one-hand anchoring from overriding an active portrait split keyboard
- add focused RED/GREEN regression coverage and issue/backlog tracking

## Root cause
Commit `01aed41b` gated `SPLIT_KEYBOARD_ALWAYS` behind tablet-or-landscape geometry. That changed the legacy `開啟` behavior on portrait phones and matches the reporter's v6.1.33 boundary.

## Verification
- RED: `:app:testDebugUnitTest --tests org.limeime.SplitKeyboardModeTest` failed 2/11 assertions on the v6.1.33 gate
- GREEN: focused test passed after restoring the contract
- `:app:testDebugUnitTest`
- `:app:compileDebugJavaWithJavac`
- `:app:compileDebugAndroidTestJavaWithJavac`
- `git diff --check`
- narrow read-only Claude review: `BLOCKERS: none`, `DOC CORRECTIONS: none`

## Platform scope
Android only. The analogous iOS path remains iPad-only and is not changed here.

Refs #169
