### PR TITLE
fix(keyboard): unify phone split and one-hand modes

### DIFF
--- a/LimeIME-iOS/LimeIME.xcodeproj/project.pbxproj
+++ b/LimeIME-iOS/LimeIME.xcodeproj/project.pbxproj
@@ -162,6 +162,9 @@
 		B0B1C2D3E4F5061728394B51 /* KeyboardTypePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B1C2D3E4F5061728394B50 /* KeyboardTypePolicy.swift */; };
 		B0B1C2D3E4F5061728394B52 /* KeyboardTypePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B1C2D3E4F5061728394B50 /* KeyboardTypePolicy.swift */; };
 		B0B1C2D3E4F5061728394B53 /* KeyboardTypePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B1C2D3E4F5061728394B50 /* KeyboardTypePolicy.swift */; };
+		B0B1C2D3E4F5061728394BA1 /* PhoneKeyboardModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B1C2D3E4F5061728394BA0 /* PhoneKeyboardModePolicy.swift */; };
+		B0B1C2D3E4F5061728394BA2 /* PhoneKeyboardModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B1C2D3E4F5061728394BA0 /* PhoneKeyboardModePolicy.swift */; };
+		B0B1C2D3E4F5061728394BA3 /* PhoneKeyboardModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B1C2D3E4F5061728394BA0 /* PhoneKeyboardModePolicy.swift */; };
 		B125606CAD030A4BD9D6859C /* KeyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1C7A1DEDC91A7AF8E2B3C4 /* KeyLayout.swift */; };
 		B174D69873CFB28046FD2166 /* SearchServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AD7B903A3658D6EBB77E60 /* SearchServer.swift */; };
 		B1B77A30852341B2B9A88C7C /* lime_cj_number_ipad_shift.json in Resources */ = {isa = PBXBuildFile; fileRef = 6B59F0E21DC04867ACF2DF0E /* lime_cj_number_ipad_shift.json */; };
@@ -460,6 +463,7 @@
 		AE52203601D04DF6B8669D50 /* lime_array_ipad.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = lime_array_ipad.json; sourceTree = "<group>"; };
 		AF87518F21BEE3A09C5931A5 /* lime_phonetic_ipad_narrow_shift.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = lime_phonetic_ipad_narrow_shift.json; sourceTree = "<group>"; };
 		B0B1C2D3E4F5061728394B50 /* KeyboardTypePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardTypePolicy.swift; sourceTree = "<group>"; };
+		B0B1C2D3E4F5061728394BA0 /* PhoneKeyboardModePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneKeyboardModePolicy.swift; sourceTree = "<group>"; };
 		B2E2CC2294E9DD745CA44937 /* lime_hsu.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = lime_hsu.json; sourceTree = "<group>"; };
 		B3C4D5E6F7A8B9C0D1E2F3A4 /* phone_number.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = phone_number.json; sourceTree = "<group>"; };
 		B4F8A3C2D6E95F0A3B2C7D8E /* EngineLatencyBenchmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineLatencyBenchmark.swift; sourceTree = "<group>"; };
@@ -690,6 +694,7 @@
 				2C0757CC0618D9DFE1917DB1 /* ImConfig.swift */,
 				43AF70BA22361D8084D34B7F /* Keyboard.swift */,
 				B0B1C2D3E4F5061728394B50 /* KeyboardTypePolicy.swift */,
+				B0B1C2D3E4F5061728394BA0 /* PhoneKeyboardModePolicy.swift */,
 				1F1C7A1DEDC91A7AF8E2B3C4 /* KeyLayout.swift */,
 				8C4D2C17B8A1495297103E43 /* LimeToastState.swift */,
 				D0956117FEB1C2F5C09EB5C5 /* Mapping.swift */,
@@ -1358,6 +1363,7 @@
 				8D62ED56761A14A0C42204A9 /* KeyLayout.swift in Sources */,
 				F20EA45656BE08E5A291F4F5 /* Keyboard.swift in Sources */,
 				B0B1C2D3E4F5061728394B51 /* KeyboardTypePolicy.swift in Sources */,
+				B0B1C2D3E4F5061728394BA1 /* PhoneKeyboardModePolicy.swift in Sources */,
 				1DBB21F1304CE6388E830E57 /* LIMEPreferenceManager.swift in Sources */,
 				30A1639B07058FC030BD00CF /* LIMEPreferenceManagerTest.swift in Sources */,
 				8B72D83300CAD566BFCF3FE2 /* KeyboardViewControllerTest.swift in Sources */,
@@ -1409,6 +1415,7 @@
 				B125606CAD030A4BD9D6859C /* KeyLayout.swift in Sources */,
 				4C1012BD29921E3B0201DBBC /* Keyboard.swift in Sources */,
 				B0B1C2D3E4F5061728394B52 /* KeyboardTypePolicy.swift in Sources */,
+				B0B1C2D3E4F5061728394BA2 /* PhoneKeyboardModePolicy.swift in Sources */,
 				05655700F55F7F2F05431516 /* KeyboardPickerView.swift in Sources */,
 				A80635FAE2E8FE18ED2B15A4 /* LIMEPreferenceManager.swift in Sources */,
 				8C4D2C17B8A1495297103E45 /* LimeToastState.swift in Sources */,
@@ -1454,6 +1461,7 @@
 				1D81EC3041A854E106B5F67F /* KeyLayout.swift in Sources */,
 				54537083062A7847A6BAE8BC /* Keyboard.swift in Sources */,
 				B0B1C2D3E4F5061728394B53 /* KeyboardTypePolicy.swift in Sources */,
+				B0B1C2D3E4F5061728394BA3 /* PhoneKeyboardModePolicy.swift in Sources */,
 				3E81089E57F6CB90A2BFF152 /* KeyboardView.swift in Sources */,
 				F0BEEF0011223344556677B1 /* KeyModel.swift in Sources */,
 				F0BEEF0011223344556677B2 /* KeyDetector.swift in Sources */,

--- a/LimeIME-iOS/LimeKeyboard/KeyboardView.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardView.swift
@@ -847,19 +847,23 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
         // SPLIT_ONE_HAND_KB: Android-parity partition — see SplitPartition (KeyLayout.swift).
         let total = keys.reduce(0) { $0 + $1.widthPercent }
         let (leftKeys, rightKeys) = SplitPartition.partition(keys)
-        let splitGapFraction = LayoutMetrics.KeyboardRow.splitGapFraction
-        // SPLIT_ONE_HAND_KB: cap each half at the two-hand thumb reach; the shrink ratio
-        // scales unequal halves proportionally, equal halves land exactly on the cap.
-        let viewWidth = bounds.width > 0 ? bounds.width : UIScreen.main.bounds.width
-        let legacyHalf = (1 - splitGapFraction) / 2
-        let capHalf = ReachGeometry.splitHalfMaxFraction(viewWidth: viewWidth,
-                                                         sizeClass: LayoutLoader.iPadSizeClass)
-        let reachShrink = capHalf / legacyHalf   // ≤ 1; == 1 when the cap doesn't bind
+        let contentFraction: CGFloat
+        if isPad {
+            let viewWidth = bounds.width > 0 ? bounds.width : UIScreen.main.bounds.width
+            contentFraction = 2 * ReachGeometry.splitHalfMaxFraction(
+                viewWidth: viewWidth, sizeClass: LayoutLoader.iPadSizeClass)
+        } else {
+            let referenceRow = layout.rows.first { !$0.keys.isEmpty }?.keys ?? keys
+            let unit = referenceRow.map(\.widthPercent).min() ?? 1
+            let keysInRow = max(1, Int((referenceRow.reduce(0) { $0 + $1.widthPercent } / unit).rounded()))
+            contentFraction = ReachGeometry.phoneSplitContentFraction(
+                keysInRow: keysInRow, isLandscape: isLandscape)
+        }
 
         func addHalf(_ halfKeys: [KeyDef], leading: Bool) {
             guard !halfKeys.isEmpty else { return }
             let halfPercent = halfKeys.reduce(0) { $0 + $1.widthPercent }
-            let halfFraction = (halfPercent / total) * (1 - splitGapFraction) * reachShrink
+            let halfFraction = (halfPercent / total) * contentFraction
 
             let contentView = KeyTouchLayer(owner: self)
             contentView.backgroundColor = LayoutMetrics.TouchTrap.fill   // keyboard extensions drop touches on fully transparent pixels (IOS_CANDI_TOUCH.md §Resolution); .clear leaves gaps dead
@@ -878,7 +882,8 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
 
             var prevBtn: UIButton? = nil
             for keyDef in halfKeys {
-                let btn = makeKeyButton(keyDef: keyDef, rowHeight: rowHeight, totalPercent: halfPercent)
+                let btn = makeKeyButton(keyDef: keyDef, rowHeight: rowHeight,
+                                        totalPercent: halfPercent, rowWidthFraction: halfFraction)
                 contentView.addSubview(btn)
                 btn.translatesAutoresizingMaskIntoConstraints = false
                 NSLayoutConstraint.activate([
@@ -944,7 +949,8 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
         var prevButton: UIButton? = nil
 
         for (_, keyDef) in row.keys.enumerated() {
-            let btn = makeKeyButton(keyDef: keyDef, rowHeight: rowHeight, totalPercent: totalPercent)
+            let btn = makeKeyButton(keyDef: keyDef, rowHeight: rowHeight,
+                                    totalPercent: totalPercent, rowWidthFraction: widthMultiplier)
             contentView.addSubview(btn)
 
             btn.translatesAutoresizingMaskIntoConstraints = false
@@ -969,7 +975,8 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
         return rowView
     }
 
-    private func makeKeyButton(keyDef: KeyDef, rowHeight: CGFloat, totalPercent: CGFloat) -> UIButton {
+    private func makeKeyButton(keyDef: KeyDef, rowHeight: CGFloat, totalPercent: CGFloat,
+                               rowWidthFraction: CGFloat) -> UIButton {
         // Transparent spacer key: no background, no shadow, no touch.
         if keyDef.code == 0 && keyDef.label.isEmpty && keyDef.icon.isEmpty {
             let spacer = UIButton()
@@ -1047,7 +1054,8 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
             btn.addGestureRecognizer(pressFeedback)
         }
 
-        applyButtonStyle(btn, keyDef: keyDef, rowHeight: rowHeight, totalPercent: totalPercent)
+        applyButtonStyle(btn, keyDef: keyDef, rowHeight: rowHeight,
+                         totalPercent: totalPercent, rowWidthFraction: rowWidthFraction)
 
         btn.isUserInteractionEnabled = !routeBasicTapThroughOwner
         if !routeBasicTapThroughOwner {
@@ -1106,7 +1114,8 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
 
     /// Apply background color, corner radius and shadow to any key button.
     private func applyButtonStyle(_ btn: UIButton, keyDef: KeyDef,
-                                  rowHeight: CGFloat, totalPercent: CGFloat) {
+                                  rowHeight: CGFloat, totalPercent: CGFloat,
+                                  rowWidthFraction: CGFloat = 1) {
         btn.backgroundColor = restoredKeyBackgroundColor(for: keyDef)
         btn.layer.cornerRadius = keyCornerRadius
         btn.layer.masksToBounds = false
@@ -1114,7 +1123,8 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
         btn.layer.shadowOffset = CGSize(width: 0, height: LayoutMetrics.Key.shadowOffsetY)
         btn.layer.shadowOpacity = keyShadowOpacity
         btn.layer.shadowRadius = 0
-        styleKeyContent(btn: btn, keyDef: keyDef, rowHeight: rowHeight, totalPercent: totalPercent)
+        styleKeyContent(btn: btn, keyDef: keyDef, rowHeight: rowHeight,
+                        totalPercent: totalPercent, rowWidthFraction: rowWidthFraction)
     }
 
     private func restoredKeyBackgroundColor(for keyDef: KeyDef) -> UIColor {
@@ -1155,7 +1165,8 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
     ///   • Tall key  (height ≥ width): label small top,  sublabel large bottom — vertical stack
     ///   • Wide key  (width  > height): label small left, sublabel large right  — horizontal stack
     private func styleKeyContent(btn: UIButton, keyDef: KeyDef,
-                                 rowHeight: CGFloat, totalPercent: CGFloat) {
+                                 rowHeight: CGFloat, totalPercent: CGFloat,
+                                 rowWidthFraction: CGFloat) {
         clearStyledKeyContent(from: btn)
         let override    = enterKeyOverride(for: keyDef)
         // Accent (blue) Enter keys use white foreground so the icon/label
@@ -1213,13 +1224,16 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
                     // triggering horizontal layout — so skip the dimension check entirely.
                     isTall = true
                 } else {
-                    let estimatedWidth = UIScreen.main.bounds.width
-                        * (keyDef.widthPercent / totalPercent) - keyHGap
                     let usableHeight = rowHeight - 2 * keyVGap
                     // Mirror Android (LIMEKeyboardBaseView: key.height>key.width || subLabel.length()>2):
                     // also stack vertically when the letter hint is >2 chars, so the wide phone-pad
                     // keys (abc / pqrs / ()'" / +-*/ …) render up/down instead of the side-by-side split.
-                    isTall = usableHeight > estimatedWidth || displayLabel.count > 2
+                    let viewWidth = bounds.width > 0 ? bounds.width : UIScreen.main.bounds.width
+                    isTall = Self.dualLabelUsesVerticalLayout(
+                        viewWidth: viewWidth, rowWidthFraction: rowWidthFraction,
+                        keyPercent: keyDef.widthPercent, totalPercent: totalPercent,
+                        keyHGap: keyHGap, usableHeight: usableHeight,
+                        labelLength: displayLabel.count)
                 }
                 container = makeDualLabelView(primary: displayLabel, sub: keyDef.sublabel,
                                               isTall: isTall, labelColor: keyLabel)
@@ -1270,6 +1284,15 @@ final class KeyboardView: UIView, UIInputViewAudioFeedback {
                                             constant: LayoutMetrics.Key.popupIndicatorBottomInset),
             ])
         }
+    }
+
+    static func dualLabelUsesVerticalLayout(viewWidth: CGFloat, rowWidthFraction: CGFloat,
+                                            keyPercent: CGFloat, totalPercent: CGFloat,
+                                            keyHGap: CGFloat, usableHeight: CGFloat,
+                                            labelLength: Int) -> Bool {
+        guard totalPercent > 0 else { return true }
+        let keyWidth = viewWidth * rowWidthFraction * keyPercent / totalPercent - keyHGap
+        return usableHeight > keyWidth || labelLength > 2
     }
 
     private func accessibilityLabel(for keyDef: KeyDef,

--- a/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
@@ -134,6 +134,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     private var splitKeyboardMode:       Int  = 0       // 0=off, 1=on, 2=landscape-only (iPad only)
     private var oneHandMode:             Int  = 0       // 0=off, 1=left, 2=right (portrait only)
     private var numpadAnchor:            Int  = 0       // 0=fit, 1=left, 2=right, 3=center
+    // Issue #169: integrated iPhone portrait mode + separate landscape split.
+    private var phonePortraitKeyboardMode: Int  = 0     // 0=standard, 1=split, 2=left, 3=right (iPhone only)
+    private var phoneLandscapeSplit:       Bool = false  // iPhone landscape split, independent of portrait mode
 
     // MARK: - Activated IM Cycling (spec §10)
     private var activatedIMs:  [ImConfig] = []
@@ -345,6 +348,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     /// applyHeight() after settling is a plain stationary height change, which
     /// hosts track correctly (same path as keyboard_size / emoji-panel resizes).
     private var rotationSettling = false
+    /// Authoritative destination orientation supplied by UIKit during rotation.
+    /// UIScreen bounds can temporarily report the old orientation while relayout runs.
+    private var layoutIsLandscape: Bool?
     private weak var inlineMenuPanel: UIView?
     private weak var inlineMenuDismissTapGesture: UITapGestureRecognizer?
     /// Fired once when the inline menu is dismissed (完成 / tap-outside). Used by the
@@ -586,15 +592,28 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         // so view.bounds.width > view.bounds.height is always true and would
         // permanently force landscape row heights and horizontal label layout.
         let screen = UIScreen.main.bounds
-        let landscape = screen.width > screen.height
+        let landscape = layoutIsLandscape ?? (screen.width > screen.height)
         keyboardView?.isLandscape = landscape
         let isPad   = isOnPad
         let numpad  = isNumpadLayout
-        let doSplit = isPad && !numpad
+        let splitEligible = !numpad
+        let portraitMode = PhoneKeyboardPortraitMode(rawValue: phonePortraitKeyboardMode) ?? .standard
+        let doSplit: Bool
+        if isPad {
+            doSplit = splitEligible
                       && (splitKeyboardMode == 1 || (splitKeyboardMode == 2 && landscape))
+        } else {
+            // Issue #169: iPhone split — portrait reads the integrated mode, landscape
+            // reads phone_landscape_split. Applies to every iPhone (no width gate);
+            // numpad layouts never split.
+            doSplit = PhoneKeyboardModePolicy.splitActive(isLandscape: landscape,
+                                                          splitEligible: splitEligible,
+                                                          portraitMode: portraitMode,
+                                                          landscapeSplit: phoneLandscapeSplit)
+        }
         keyboardView?.splitMode = doSplit
 
-        // SPLIT_ONE_HAND_KB horizontal anchoring.
+        // SPLIT_ONE_HAND_KB / issue #169 horizontal anchoring.
         var leading: CGFloat = 0, trailing: CGFloat = 0, chevron = false
         let vw = view.bounds.width
         if isPad {
@@ -609,11 +628,18 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
                 default: break
                 }
             }
-        } else if !landscape, oneHandMode != 0,
-                  ReachGeometry.oneHandAvailable(screenWidthPt: min(screen.width, screen.height)) {
-            let free = max(0, vw - ReachGeometry.oneHandWidth(viewWidth: vw))
-            if oneHandMode == 1 { trailing = free } else { leading = free }   // 靠左 / 靠右
-            chevron = free > 0
+        } else {
+            // iPhone portrait one-hand applies to EVERY iPhone regardless of screen
+            // width — no gate. oneHandWidth still clamps to the available width, so a
+            // narrow phone gets a full-width block (free == 0, no strip/chevron) while
+            // the mode is always honored. Applies to all portrait layouts incl. numpad.
+            let anchor = PhoneKeyboardModePolicy.oneHandAnchor(isLandscape: landscape,
+                                                               portraitMode: portraitMode)
+            if anchor != 0 {
+                let free = max(0, vw - ReachGeometry.oneHandWidth(viewWidth: vw))
+                if anchor == 1 { trailing = free } else { leading = free }   // 靠左 / 靠右
+                chevron = free > 0
+            }
         }
         keyboardView?.setHorizontalAnchor(leading: leading, trailing: trailing, restoreChevron: chevron)
         // SPLIT_ONE_HAND_KB: keep the candidate bar's usable area aligned with the key block.
@@ -654,10 +680,13 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
                                      with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         rotationSettling = true
+        layoutIsLandscape = size.width > size.height
         coordinator.animate(alongsideTransition: nil) { [weak self] _ in
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 guard let self else { return }
                 self.rotationSettling = false
+                self.view.setNeedsLayout()
+                self.view.layoutIfNeeded()
                 self.applyHeight()
             }
         }
@@ -1201,6 +1230,34 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         return hot.integer(forKey: key)
     }
 
+    /// §1.8 hot-store seed for an Int pref that also needs a one-time migration when
+    /// neither hot nor cold holds it yet (issue #169 phone_portrait_keyboard_mode).
+    private func seededHotInt(_ key: String, cold: UserDefaults?, migrate: () -> Int) -> Int {
+        let hot = UserDefaults.standard
+        if hot.object(forKey: key) == nil {
+            if let seed = cold?.object(forKey: key) as? Int {
+                hot.set(seed, forKey: key)
+            } else {
+                hot.set(migrate(), forKey: key)
+            }
+        }
+        return hot.integer(forKey: key)
+    }
+
+    /// §1.8 hot-store seed for a Bool pref, with one-time migration when neither hot
+    /// nor cold holds it yet (issue #169 phone_landscape_split).
+    private func seededHotBool(_ key: String, cold: UserDefaults?, migrate: () -> Bool) -> Bool {
+        let hot = UserDefaults.standard
+        if hot.object(forKey: key) == nil {
+            if let seed = cold?.object(forKey: key) as? Bool {
+                hot.set(seed, forKey: key)
+            } else {
+                hot.set(migrate(), forKey: key)
+            }
+        }
+        return hot.bool(forKey: key)
+    }
+
     /// §1.8: reverse-lookup (per-IM) from the hot store, seeded once from cold on first read.
     /// This is the single effective reverse-lookup reader — hamburger picker, runtime commit,
     /// and menu label all route through it so the hot value always wins over stale cold (#157).
@@ -1240,6 +1297,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
             UserDefaults.standard.set(anchor, forKey: "numpad_anchor")
             numpadAnchor = anchor
         }
+        if let pp = rec.phonePortraitMode {
+            UserDefaults.standard.set(pp, forKey: "phone_portrait_keyboard_mode")
+            phonePortraitKeyboardMode = pp
+        }
+        if let pls = rec.phoneLandscapeSplit {
+            UserDefaults.standard.set(pls, forKey: "phone_landscape_split")
+            phoneLandscapeSplit = pls
+        }
         if let reverse = rec.reverseLookup {
             for (im, value) in reverse { hotPrefs.setReverseLookup(value, for: im) }
         }
@@ -1259,7 +1324,10 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
                                        oneHand: oneHandMode,
                                        numpadAnchor: numpadAnchor,
                                        reverseLookupIM: firstReverse?.key,
-                                       reverseLookupValue: firstReverse?.value)
+                                       reverseLookupValue: firstReverse?.value,
+                                       phonePortraitMode: phonePortraitKeyboardMode,
+                                       phoneLandscapeSplit: phoneLandscapeSplit,
+                                       geometryProfile: isOnPad ? "tablet" : "phone")
         return true
     }
 
@@ -1326,6 +1394,22 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         splitKeyboardMode = seededHotInt("split_keyboard_mode", cold: d)   // §1.8 hot store
         oneHandMode  = seededHotInt("one_hand_mode",  cold: d)   // §1.8 hot store
         numpadAnchor = seededHotInt("numpad_anchor",  cold: d)   // §1.8 hot store
+        // Issue #169: integrated iPhone portrait mode + landscape split. Seeded from
+        // cold; if absent, migrated once from the legacy one_hand_mode / split pair
+        // (legacyPhoneSplitSupported: false — iPhone split was never shipped, so we
+        // preserve one-hand but do not invent a legacy iPhone split).
+        phonePortraitKeyboardMode = seededHotInt("phone_portrait_keyboard_mode", cold: d, migrate: {
+            PhoneKeyboardModePolicy.migratePortraitMode(
+                legacyOneHand: d?.integer(forKey: "one_hand_mode") ?? 0,
+                legacySplit: d?.integer(forKey: "split_keyboard_mode") ?? 0,
+                legacyPhoneSplitSupported: false).rawValue
+        })
+        phoneLandscapeSplit = seededHotBool("phone_landscape_split", cold: d, migrate: {
+            PhoneKeyboardModePolicy.migrateLandscapeSplit(
+                legacySplit: d?.integer(forKey: "split_keyboard_mode") ?? 0,
+                legacyPhoneSplitSupported: false)
+        })
+        UserDefaults.standard.set(isOnPad ? "tablet" : "phone", forKey: "keyboard_geometry_profile")
         applyPrefsToSearchEngine()
     }
 
@@ -4011,10 +4095,12 @@ extension KeyboardViewController: KeyboardViewDelegate {
     }
 
     func keyboardViewDidTapOneHandRestore() {
-        // SPLIT_ONE_HAND_KB: chevron restores full width, persisted (§1.8 hot store + relay).
-        oneHandMode = 0
-        hotPrefs.oneHandMode = 0
-        _ = try? relayPrefStore.update(oneHand: 0)
+        // Issue #169: chevron restores full width by resetting the integrated portrait
+        // mode to standard, persisted (§1.8 hot store + relay back to the settings app).
+        phonePortraitKeyboardMode = PhoneKeyboardPortraitMode.standard.rawValue
+        hotPrefs.phonePortraitKeyboardMode = PhoneKeyboardPortraitMode.standard.rawValue
+        _ = try? relayPrefStore.update(phonePortraitMode: PhoneKeyboardPortraitMode.standard.rawValue,
+                                       geometryProfile: "phone")
         view.setNeedsLayout()
     }
 
@@ -4532,9 +4618,13 @@ extension KeyboardViewController: KeyboardViewDelegate {
                                   labels: ["無", "繁→簡", "簡→繁"], selected: pendingHan,
                                   onSelect: { pendingHan = $0 }))
 
-        // SPLIT_ONE_HAND_KB exclusivity: numpad layouts show 數字鍵盤位置 only;
-        // ordinary layouts show 分離鍵盤 (iPad) / 單手鍵盤 (gated iPhone).
+        // Menu exclusivity keyed off the active layout + orientation (issue #169):
+        //  · iPad ordinary  → 分離鍵盤 (tri-state); iPad numpad → 數字鍵盤位置.
+        //  · iPhone portrait → 直向鍵盤模式 (標準/分離/靠左/靠右; 分離 hidden for numpad).
+        //  · iPhone landscape → 橫向分離鍵盤 (binary; hidden for numpad).
+        // iPhone controls are shown on EVERY iPhone regardless of screen width — no gate.
         let numpadLayout = isNumpadLayout
+        let landscape = layoutIsLandscape ?? (UIScreen.main.bounds.width > UIScreen.main.bounds.height)
         var pendingSplit = max(0, min(splitKeyboardMode, 2))
         let splitStart = pendingSplit
         if isOnPad && !numpadLayout {
@@ -4542,13 +4632,27 @@ extension KeyboardViewController: KeyboardViewDelegate {
                                       labels: ["關閉", "開啟", "僅橫向"], selected: pendingSplit,
                                       onSelect: { pendingSplit = $0 }))
         }
-        var pendingOneHand = max(0, min(oneHandMode, 2))
-        let oneHandStart = pendingOneHand
-        let screenShort = min(UIScreen.main.bounds.width, UIScreen.main.bounds.height)
-        if !isOnPad && ReachGeometry.oneHandAvailable(screenWidthPt: screenShort) {
-            entries.append(.segmented(title: "單手鍵盤", icon: "keyboard",
-                                      labels: ["關閉", "靠左", "靠右"], selected: pendingOneHand,
-                                      onSelect: { pendingOneHand = $0 }))
+        // 直向鍵盤模式 (iPhone portrait): 分離 hidden for numpad layouts. pendingPortrait
+        // keeps its raw value until the user taps, so an impossible stored 分離 on a
+        // numpad layout is shown as 標準 without being rewritten on dismiss.
+        var pendingPortrait = max(0, min(phonePortraitKeyboardMode, 3))
+        let portraitStart = pendingPortrait
+        if !isOnPad && !landscape {
+            let modeValues: [Int]    = numpadLayout ? [0, 2, 3] : [0, 1, 2, 3]
+            let modeLabels: [String] = numpadLayout ? ["標準", "靠左", "靠右"]
+                                                    : ["標準", "分離", "靠左", "靠右"]
+            let selectedIdx = modeValues.firstIndex(of: pendingPortrait) ?? 0
+            entries.append(.segmented(title: "直向鍵盤模式", icon: "keyboard",
+                                      labels: modeLabels, selected: selectedIdx,
+                                      onSelect: { pendingPortrait = modeValues[$0] }))
+        }
+        // 橫向分離鍵盤 (iPhone landscape, ordinary layouts only).
+        var pendingLandscapeSplit = phoneLandscapeSplit
+        let landscapeSplitStart = pendingLandscapeSplit
+        if !isOnPad && landscape && !numpadLayout {
+            entries.append(.segmented(title: "橫向分離鍵盤", icon: "rectangle.split.2x1",
+                                      labels: ["關閉", "開啟"], selected: pendingLandscapeSplit ? 1 : 0,
+                                      onSelect: { pendingLandscapeSplit = ($0 == 1) }))
         }
         var pendingAnchor = max(0, min(numpadAnchor, 3))
         let anchorStart = pendingAnchor
@@ -4580,9 +4684,15 @@ extension KeyboardViewController: KeyboardViewDelegate {
                 self.view.setNeedsLayout()   // re-applies splitMode in viewWillLayoutSubviews
                 changed = true
             }
-            if pendingOneHand != oneHandStart {
-                self.oneHandMode = pendingOneHand
-                self.hotPrefs.oneHandMode = pendingOneHand   // §1.8 hot store, not cold
+            if pendingPortrait != portraitStart {
+                self.phonePortraitKeyboardMode = pendingPortrait
+                self.hotPrefs.phonePortraitKeyboardMode = pendingPortrait   // §1.8 hot store, not cold
+                self.view.setNeedsLayout()
+                changed = true
+            }
+            if pendingLandscapeSplit != landscapeSplitStart {
+                self.phoneLandscapeSplit = pendingLandscapeSplit
+                self.hotPrefs.phoneLandscapeSplit = pendingLandscapeSplit   // §1.8 hot store, not cold
                 self.view.setNeedsLayout()
                 changed = true
             }
@@ -4596,7 +4706,10 @@ extension KeyboardViewController: KeyboardViewDelegate {
                 _ = try? self.relayPrefStore.update(hanConvert: self.hanConvertOption,
                                                     splitKeyboard: self.splitKeyboardMode,
                                                     oneHand: self.oneHandMode,
-                                                    numpadAnchor: self.numpadAnchor)
+                                                    numpadAnchor: self.numpadAnchor,
+                                                    phonePortraitMode: self.phonePortraitKeyboardMode,
+                                                    phoneLandscapeSplit: self.phoneLandscapeSplit,
+                                                    geometryProfile: self.isOnPad ? "tablet" : "phone")
             }
         })
     }

--- a/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
+++ b/LimeIME-iOS/LimeKeyboard/KeyboardViewController.swift
@@ -4450,6 +4450,9 @@ extension KeyboardViewController: KeyboardViewDelegate {
         scroll.addSubview(stack)
 
         let iconPointSize = LayoutMetrics.InlineMenu.buttonFontSize
+        let segmentedAxis = LayoutMetrics.InlineMenu.segmentedAxis(
+            isPad: isOnPad,
+            isLandscape: layoutIsLandscape ?? (root.bounds.width > root.bounds.height))
         func addSeparator() {
             let sep = UIView()
             sep.backgroundColor = UIColor.separator
@@ -4513,7 +4516,7 @@ extension KeyboardViewController: KeyboardViewDelegate {
                     seg.selectedSegmentIndex = max(0, min(selected, labels.count - 1))
                     seg.addAction(UIAction { _ in onSelect(seg.selectedSegmentIndex) }, for: .valueChanged)
                     let col = UIStackView(arrangedSubviews: [hRow, seg])
-                    col.axis = .vertical
+                    col.axis = segmentedAxis
                     col.spacing = 8
                     col.isLayoutMarginsRelativeArrangement = true
                     col.layoutMargins = UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)
@@ -4523,7 +4526,7 @@ extension KeyboardViewController: KeyboardViewDelegate {
                     seg.selectedSegmentIndex = max(0, min(selected, labels.count - 1))
                     seg.addAction(UIAction { _ in onSelect(seg.selectedSegmentIndex) }, for: .valueChanged)
                     let col = UIStackView(arrangedSubviews: [header, seg])
-                    col.axis = .vertical
+                    col.axis = segmentedAxis
                     col.spacing = 8
                     col.isLayoutMarginsRelativeArrangement = true
                     col.layoutMargins = UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)

--- a/LimeIME-iOS/LimeKeyboard/LayoutMetrics.swift
+++ b/LimeIME-iOS/LimeKeyboard/LayoutMetrics.swift
@@ -644,7 +644,6 @@ enum ReachGeometry {
     static let splitHalfMaxMM: CGFloat = 66
     static let splitRowMaxMM: CGFloat = 12
     static let oneHandMaxWidthMM: CGFloat = 60
-    static let oneHandGateMarginMM: CGFloat = 4
     static let numpadKeyMM: CGFloat = 14
     static let numpadAnchorMaxFraction: CGFloat = 0.40
 
@@ -666,11 +665,6 @@ enum ReachGeometry {
     /// Vertical thumb-sweep cap on split-mode row height.
     static func splitRowHeightCap(sizeClass: IPadSizeClass) -> CGFloat {
         splitRowMaxMM * ptPerMM(isPad: true, sizeClass: sizeClass)
-    }
-
-    /// Gate: one-hand mode only where shrinking is meaningful (≈5.5"+ phones).
-    static func oneHandAvailable(screenWidthPt: CGFloat) -> Bool {
-        screenWidthPt > (oneHandMaxWidthMM + oneHandGateMarginMM) * ptPerMM(isPad: false, sizeClass: .small)
     }
 
     static func oneHandWidth(viewWidth: CGFloat) -> CGFloat {

--- a/LimeIME-iOS/LimeKeyboard/LayoutMetrics.swift
+++ b/LimeIME-iOS/LimeKeyboard/LayoutMetrics.swift
@@ -628,6 +628,10 @@ enum LayoutMetrics {
         static let appearDuration: TimeInterval = 0.2
         // Translation offset applied at start of the slide-in animation.
         static let appearTranslationY: CGFloat = 20
+
+        static func segmentedAxis(isPad: Bool, isLandscape: Bool) -> NSLayoutConstraint.Axis {
+            !isPad && isLandscape ? .horizontal : .vertical
+        }
     }
 
     // The expanded candidates panel (rendered by the controller) reuses
@@ -660,6 +664,13 @@ enum ReachGeometry {
         guard viewWidth > 0 else { return legacy }
         let capPt = splitHalfMaxMM * ptPerMM(isPad: true, sizeClass: sizeClass)
         return min(legacy, capPt / viewWidth)
+    }
+
+    /// Android phone parity: portrait reserves two key columns in the centre,
+    /// landscape reserves three. iPad continues to use splitHalfMaxFraction.
+    static func phoneSplitContentFraction(keysInRow: Int, isLandscape: Bool) -> CGFloat {
+        guard keysInRow > 0 else { return 1 }
+        return CGFloat(keysInRow) / CGFloat(keysInRow + (isLandscape ? 3 : 2))
     }
 
     /// Vertical thumb-sweep cap on split-mode row height.

--- a/LimeIME-iOS/LimeSettings/LimeSettingsView.swift
+++ b/LimeIME-iOS/LimeSettings/LimeSettingsView.swift
@@ -288,6 +288,8 @@ struct LimeSettingsView: View {
                             split: payload.split,
                             reverseLookupIM: payload.rlim,
                             reverseLookupValue: payload.rlval,
+                            phonePortraitMode: payload.phonePortraitMode,
+                            phoneLandscapeSplit: payload.phoneLandscapeSplit,
                             pts: payload.pts,
                             to: sharedDefaults)
         rootRelayDidReceivePayload = true

--- a/LimeIME-iOS/LimeSettings/Views/DBManagerView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/DBManagerView.swift
@@ -518,6 +518,8 @@ struct DBManagerView: View {
         try? PrefInbox.write(base: base, defaults: cold,
                              hanConvert: cold.object(forKey: "han_convert_option") as? Int,
                              splitKeyboard: cold.object(forKey: "split_keyboard_mode") as? Int,
+                             phonePortraitMode: cold.object(forKey: "phone_portrait_keyboard_mode") as? Int,
+                             phoneLandscapeSplit: cold.object(forKey: "phone_landscape_split") as? Bool,
                              activeIM: cold.string(forKey: "active_im")
                                        ?? cold.string(forKey: "keyboard_list"))
         for (key, value) in cold.dictionaryRepresentation()

--- a/LimeIME-iOS/LimeSettings/Views/PreferencesTabView.swift
+++ b/LimeIME-iOS/LimeSettings/Views/PreferencesTabView.swift
@@ -40,8 +40,11 @@ struct PreferencesTabView: View {
     @AppStorage("number_row_in_english",   store: sharedDefaults) private var numberRowInEnglish: Bool = true
     @AppStorage("show_arrow_key",          store: sharedDefaults) private var showArrowKey: Int = 0
     @AppStorage("split_keyboard_mode",     store: sharedDefaults) private var splitKeyboardMode: Int = 0
-    @AppStorage("one_hand_mode",  store: sharedDefaults) private var oneHandMode: Int = 0
     @AppStorage("numpad_anchor",  store: sharedDefaults) private var numpadAnchor: Int = 0
+    // Issue #169: integrated iPhone portrait mode + landscape split. iPhone only,
+    // every iPhone (no width gate). Shared keys/values with Android.
+    @AppStorage("phone_portrait_keyboard_mode", store: sharedDefaults) private var phonePortraitMode: Int = 0
+    @AppStorage("phone_landscape_split",        store: sharedDefaults) private var phoneLandscapeSplit: Bool = false
 
     // MARK: §8.2 Keyboard Feedback
     @AppStorage("vibrate_on_keypress",     store: sharedDefaults) private var vibrateOnKeypress: Bool = true
@@ -84,8 +87,8 @@ struct PreferencesTabView: View {
     private let arrowLabels     = ["無", "軟鍵盤上方", "軟鍵盤下方"]
     private let splitOptions    = [0, 1, 2]
     private let splitLabels     = ["關閉", "開啟", "僅橫向開啟"]
-    private let oneHandOptions      = [0, 1, 2]
-    private let oneHandLabels       = ["關閉", "靠左", "靠右"]
+    private let phonePortraitOptions = [0, 1, 2, 3]
+    private let phonePortraitLabels  = ["標準", "分離", "靠左", "靠右"]
     private let numpadAnchorOptions = [0, 1, 2, 3]
     private let numpadAnchorLabels  = ["滿版", "靠左", "靠右", "置中"]
     private let vibLevelOptions = [10, 20, 40, 60, 80]
@@ -182,16 +185,16 @@ struct PreferencesTabView: View {
                             }
                         }
                     }
-                    // SPLIT_ONE_HAND_KB: 單手鍵盤 = gated iPhones; 數字鍵盤位置 = iPad only.
-                    // 384 pt = ReachGeometry gate (64 mm × 6.0 pt/mm) — ReachGeometry lives in the
-                    // keyboard target, so the settings app inlines the constant.
-                    if UIDevice.current.userInterfaceIdiom != .pad,
-                       min(UIScreen.main.bounds.width, UIScreen.main.bounds.height) > 384 {
-                        Picker("單手鍵盤", selection: $oneHandMode) {
-                            ForEach(0..<oneHandOptions.count, id: \.self) { i in
-                                Text(oneHandLabels[i]).tag(oneHandOptions[i])
+                    // Issue #169: integrated iPhone portrait mode + landscape split.
+                    // Shown on EVERY iPhone regardless of screen width (no gate);
+                    // 數字鍵盤位置 stays iPad-only below.
+                    if UIDevice.current.userInterfaceIdiom != .pad {
+                        Picker("直向鍵盤模式", selection: $phonePortraitMode) {
+                            ForEach(0..<phonePortraitOptions.count, id: \.self) { i in
+                                Text(phonePortraitLabels[i]).tag(phonePortraitOptions[i])
                             }
                         }
+                        Toggle(isOn: $phoneLandscapeSplit) { prefRow("橫向分離鍵盤", "橫向時將鍵盤左右分離") }
                     }
                     if UIDevice.current.userInterfaceIdiom == .pad {
                         Picker("數字鍵盤位置", selection: $numpadAnchor) {
@@ -306,20 +309,43 @@ struct PreferencesTabView: View {
             // writes cold for this view's own display + the keyboard's first-run seed.
             .onChange(of: hanConvertOption) { newValue in writeHamburgerPrefInbox(han: newValue) }
             .onChange(of: splitKeyboardMode) { newValue in writeHamburgerPrefInbox(split: newValue) }
-            .onChange(of: oneHandMode)  { newValue in writeHamburgerPrefInbox(oneHand: newValue) }
             .onChange(of: numpadAnchor) { newValue in writeHamburgerPrefInbox(numpadAnchor: newValue) }
+            // Issue #169: integrated iPhone portrait mode + landscape split.
+            .onChange(of: phonePortraitMode) { newValue in writeHamburgerPrefInbox(phonePortraitMode: newValue) }
+            .onChange(of: phoneLandscapeSplit) { newValue in writeHamburgerPrefInbox(phoneLandscapeSplit: newValue) }
         }
     }
 
     private func writeHamburgerPrefInbox(han: Int? = nil, split: Int? = nil,
-                                         oneHand: Int? = nil, numpadAnchor: Int? = nil) {
+                                         oneHand: Int? = nil, numpadAnchor: Int? = nil,
+                                         phonePortraitMode: Int? = nil,
+                                         phoneLandscapeSplit: Bool? = nil) {
         guard let base = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: LIMEPreferenceManager.suiteName) else { return }
         try? PrefInbox.write(base: base, defaults: sharedDefaults, hanConvert: han,
-                             splitKeyboard: split, oneHand: oneHand, numpadAnchor: numpadAnchor)
+                             splitKeyboard: split, oneHand: oneHand, numpadAnchor: numpadAnchor,
+                             phonePortraitMode: phonePortraitMode,
+                             phoneLandscapeSplit: phoneLandscapeSplit)
     }
 
     private func migrateRemovedPreferences() {
+        // Issue #169: one-time cold migration of the integrated iPhone portrait mode +
+        // landscape split from the legacy one_hand_mode / split pair. Key presence is the
+        // migration marker. legacyPhoneSplitSupported: false — iPhone split was never
+        // shipped, so preserve one-hand but never invent a legacy iPhone split.
+        if sharedDefaults.object(forKey: "phone_portrait_keyboard_mode") == nil {
+            let migrated = PhoneKeyboardModePolicy.migratePortraitMode(
+                legacyOneHand: sharedDefaults.integer(forKey: "one_hand_mode"),
+                legacySplit: sharedDefaults.integer(forKey: "split_keyboard_mode"),
+                legacyPhoneSplitSupported: false)
+            phonePortraitMode = migrated.rawValue
+        }
+        if sharedDefaults.object(forKey: "phone_landscape_split") == nil {
+            phoneLandscapeSplit = PhoneKeyboardModePolicy.migrateLandscapeSplit(
+                legacySplit: sharedDefaults.integer(forKey: "split_keyboard_mode"),
+                legacyPhoneSplitSupported: false)
+        }
+
         guard sharedDefaults.object(forKey: "enable_emoji") != nil else { return }
         if sharedDefaults.bool(forKey: "enable_emoji") == false {
             emojiPosition = 0

--- a/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
+++ b/LimeIME-iOS/LimeTests/KeyboardViewControllerTest.swift
@@ -340,6 +340,19 @@ final class KeyboardViewControllerTest: XCTestCase {
                                                                     keyDef: dualGlyphKey))
     }
 
+    func testInlineMenuUsesHorizontalSegmentedRowsOnlyOnIPhoneLandscape() {
+        XCTAssertEqual(LayoutMetrics.InlineMenu.segmentedAxis(isPad: false, isLandscape: true), .horizontal)
+        XCTAssertEqual(LayoutMetrics.InlineMenu.segmentedAxis(isPad: false, isLandscape: false), .vertical)
+        XCTAssertEqual(LayoutMetrics.InlineMenu.segmentedAxis(isPad: true, isLandscape: true), .vertical)
+    }
+
+    func testSplitPhoneDualLabelsUseRenderedHalfWidth() {
+        XCTAssertTrue(KeyboardView.dualLabelUsesVerticalLayout(
+            viewWidth: 393, rowWidthFraction: 10.0 / 24.0,
+            keyPercent: 10, totalPercent: 50, keyHGap: 3,
+            usableHeight: 42, labelLength: 1))
+    }
+
     func testShiftedSymbolKeysDoNotShowChineseRootSubLabels() throws {
         let layoutIDs = [
             "lime_phonetic_shift",

--- a/LimeIME-iOS/LimeTests/PreferenceBackupAdapterTest.swift
+++ b/LimeIME-iOS/LimeTests/PreferenceBackupAdapterTest.swift
@@ -170,6 +170,38 @@ final class PreferenceBackupAdapterTest: XCTestCase {
         XCTAssertNil(defaults.object(forKey: "physical_keyboard_sort"))
     }
 
+    func testRestoreLegacyAndroidBackupMigratesPhoneProfileOverPersistedDefaults() throws {
+        defaults.set(PhoneKeyboardPortraitMode.standard.rawValue, forKey: "phone_portrait_keyboard_mode")
+        defaults.set(false, forKey: "phone_landscape_split")
+        let data = try JSONSerialization.data(withJSONObject: [
+            "schema": 1,
+            "sourcePlatform": "android",
+            "preferences": ["split_keyboard_mode": 1, "one_hand_mode": 0]
+        ])
+
+        XCTAssertTrue(try PreferenceBackupAdapter.restoreManifestData(data, defaults: defaults))
+        XCTAssertEqual(defaults.integer(forKey: "phone_portrait_keyboard_mode"),
+                       PhoneKeyboardPortraitMode.split.rawValue)
+        XCTAssertTrue(defaults.bool(forKey: "phone_landscape_split"))
+        XCTAssertEqual(defaults.integer(forKey: "split_keyboard_mode"), 1)
+    }
+
+    func testRestoreLegacyIosBackupPreservesOneHandWithoutInventingPhoneSplit() throws {
+        defaults.set(PhoneKeyboardPortraitMode.standard.rawValue, forKey: "phone_portrait_keyboard_mode")
+        defaults.set(true, forKey: "phone_landscape_split")
+        let data = try JSONSerialization.data(withJSONObject: [
+            "schema": 1,
+            "sourcePlatform": "ios",
+            "preferences": ["split_keyboard_mode": 1, "one_hand_mode": 2]
+        ])
+
+        XCTAssertTrue(try PreferenceBackupAdapter.restoreManifestData(data, defaults: defaults))
+        XCTAssertEqual(defaults.integer(forKey: "phone_portrait_keyboard_mode"),
+                       PhoneKeyboardPortraitMode.oneHandRight.rawValue)
+        XCTAssertFalse(defaults.bool(forKey: "phone_landscape_split"))
+        XCTAssertEqual(defaults.integer(forKey: "split_keyboard_mode"), 1)
+    }
+
     func testRestoreManifestIgnoresWrongTypesAndRejectsInvalidSchema() throws {
         let wrongTypes = """
         {
@@ -206,6 +238,10 @@ final class PreferenceBackupAdapterTest: XCTestCase {
             "number_row_in_english": false,
             "show_arrow_key": 2,
             "split_keyboard_mode": 1,
+            "one_hand_mode": 2,
+            "phone_portrait_keyboard_mode": 3,
+            "phone_landscape_split": true,
+            "numpad_anchor": 2,
             "vibrate_on_keypress": false,
             "vibrate_level": 80,
             "sound_on_keypress": true,

--- a/LimeIME-iOS/LimeTests/ReachGeometryTests.swift
+++ b/LimeIME-iOS/LimeTests/ReachGeometryTests.swift
@@ -41,16 +41,10 @@ final class ReachGeometryTests: XCTestCase {
         XCTAssertEqual(f, (1 - LayoutMetrics.KeyboardRow.splitGapFraction) / 2, accuracy: 0.001)
     }
 
-    // Gate = 64 mm × 6.0 = 384 pt: Pro-Max (430) and 6.1" (390) pass, mini/SE (375) fail.
-    func testOneHandGate() {
-        XCTAssertTrue(ReachGeometry.oneHandAvailable(screenWidthPt: 430))
-        XCTAssertTrue(ReachGeometry.oneHandAvailable(screenWidthPt: 390))
-        XCTAssertFalse(ReachGeometry.oneHandAvailable(screenWidthPt: 375))
-    }
-
     func testOneHandWidth() {
-        XCTAssertEqual(ReachGeometry.oneHandWidth(viewWidth: 430), 60 * 6.0, accuracy: 0.001)
-        XCTAssertEqual(ReachGeometry.oneHandWidth(viewWidth: 300), 300, accuracy: 0.001)
+        XCTAssertEqual(ReachGeometry.oneHandWidth(viewWidth: 430), 360, accuracy: 0.01)
+        XCTAssertEqual(ReachGeometry.oneHandWidth(viewWidth: 375), 360, accuracy: 0.01)
+        XCTAssertEqual(ReachGeometry.oneHandWidth(viewWidth: 320), 320, accuracy: 0.01)
     }
 
     // 11" landscape (1194 pt, .medium): 5 × 14 mm × 5.20 = 364 pt < 40% cap (477.6);
@@ -90,5 +84,71 @@ final class ReachGeometryTests: XCTestCase {
         XCTAssertEqual(right.count, 7)
         XCTAssertEqual(left.reduce(0) { $0 + $1.widthPercent },
                        right.reduce(0) { $0 + $1.widthPercent }, accuracy: 0.001)
+    }
+
+    func testPhonePortraitMigrationAlignsWithAndroidWithoutInventingLegacyIPhoneSplit() {
+        XCTAssertEqual(PhoneKeyboardModePolicy.migratePortraitMode(legacyOneHand: 1,
+                                                                    legacySplit: 1,
+                                                                    legacyPhoneSplitSupported: false),
+                       .oneHandLeft)
+        XCTAssertEqual(PhoneKeyboardModePolicy.migratePortraitMode(legacyOneHand: 0,
+                                                                    legacySplit: 1,
+                                                                    legacyPhoneSplitSupported: false),
+                       .standard)
+        XCTAssertFalse(PhoneKeyboardModePolicy.migrateLandscapeSplit(legacySplit: 1,
+                                                                      legacyPhoneSplitSupported: false))
+    }
+
+    func testPhonePortraitModesAreMutuallyExclusive() {
+        XCTAssertTrue(PhoneKeyboardModePolicy.splitActive(isLandscape: false,
+                                                           splitEligible: true,
+                                                           portraitMode: .split,
+                                                           landscapeSplit: false))
+        XCTAssertFalse(PhoneKeyboardModePolicy.splitActive(isLandscape: false,
+                                                            splitEligible: true,
+                                                            portraitMode: .oneHandLeft,
+                                                            landscapeSplit: true))
+        XCTAssertEqual(PhoneKeyboardModePolicy.oneHandAnchor(isLandscape: false,
+                                                              portraitMode: .oneHandLeft), 1)
+        XCTAssertEqual(PhoneKeyboardModePolicy.oneHandAnchor(isLandscape: false,
+                                                              portraitMode: .oneHandRight), 2)
+        XCTAssertEqual(PhoneKeyboardModePolicy.oneHandAnchor(isLandscape: false,
+                                                              portraitMode: .split), 0)
+    }
+
+    func testPhoneLandscapeUsesOnlyLandscapeSplitAndNumpadNeverSplits() {
+        XCTAssertTrue(PhoneKeyboardModePolicy.splitActive(isLandscape: true,
+                                                           splitEligible: true,
+                                                           portraitMode: .standard,
+                                                           landscapeSplit: true))
+        XCTAssertFalse(PhoneKeyboardModePolicy.splitActive(isLandscape: true,
+                                                            splitEligible: true,
+                                                            portraitMode: .split,
+                                                            landscapeSplit: false))
+        XCTAssertFalse(PhoneKeyboardModePolicy.splitActive(isLandscape: true,
+                                                            splitEligible: false,
+                                                            portraitMode: .split,
+                                                            landscapeSplit: true))
+    }
+
+    // Issue #169: the integrated phone controls apply to EVERY iPhone and NEVER to
+    // iPad — no screen-width or physical-size gate.
+    func testPhoneControlsApplyToEveryPhoneNeverPad() {
+        XCTAssertTrue(PhoneKeyboardModePolicy.phoneControlsApply(isPad: false))
+        XCTAssertFalse(PhoneKeyboardModePolicy.phoneControlsApply(isPad: true))
+    }
+
+    // A narrow iPhone (previously below the removed one-hand width gate) still resolves
+    // its portrait one-hand anchor purely from the stored mode — width is not an input.
+    func testNarrowPhoneStillResolvesPortraitOneHandWithoutWidthGate() {
+        XCTAssertTrue(PhoneKeyboardModePolicy.phoneControlsApply(isPad: false))
+        XCTAssertEqual(PhoneKeyboardModePolicy.oneHandAnchor(isLandscape: false,
+                                                             portraitMode: .oneHandLeft), 1)
+        XCTAssertEqual(PhoneKeyboardModePolicy.oneHandAnchor(isLandscape: false,
+                                                             portraitMode: .oneHandRight), 2)
+        XCTAssertTrue(PhoneKeyboardModePolicy.splitActive(isLandscape: false,
+                                                          splitEligible: true,
+                                                          portraitMode: .split,
+                                                          landscapeSplit: false))
     }
 }

--- a/LimeIME-iOS/LimeTests/ReachGeometryTests.swift
+++ b/LimeIME-iOS/LimeTests/ReachGeometryTests.swift
@@ -41,6 +41,13 @@ final class ReachGeometryTests: XCTestCase {
         XCTAssertEqual(f, (1 - LayoutMetrics.KeyboardRow.splitGapFraction) / 2, accuracy: 0.001)
     }
 
+    func testPhoneSplitContentFractionMatchesAndroidReservedColumns() {
+        XCTAssertEqual(ReachGeometry.phoneSplitContentFraction(keysInRow: 10, isLandscape: false),
+                       10.0 / 12.0, accuracy: 0.001)
+        XCTAssertEqual(ReachGeometry.phoneSplitContentFraction(keysInRow: 10, isLandscape: true),
+                       10.0 / 13.0, accuracy: 0.001)
+    }
+
     func testOneHandWidth() {
         XCTAssertEqual(ReachGeometry.oneHandWidth(viewWidth: 430), 360, accuracy: 0.01)
         XCTAssertEqual(ReachGeometry.oneHandWidth(viewWidth: 375), 360, accuracy: 0.01)

--- a/LimeIME-iOS/LimeTests/RelayPayloadTest.swift
+++ b/LimeIME-iOS/LimeTests/RelayPayloadTest.swift
@@ -57,6 +57,56 @@ final class RelayPayloadTest: XCTestCase {
         XCTAssertNil(decoded.numpadAnchor)
     }
 
+    func testEncodeDecodeRoundTripsPhonePortraitAndLandscapeSplit() throws {
+        // Issue #169: the integrated iPhone phone prefs ride the FA-off text relay so a
+        // globe-menu change reaches the settings app.
+        let prefs = LimeIME.RelayPrefState(hanConvert: 0, splitKeyboard: 0, updatedAt: 42.0,
+                                           phonePortraitMode: 3, phoneLandscapeSplit: true)
+        let payload = LimeIME.encodeRelayPayload(faOn: true, ts: 1_234.5, prefs: prefs)
+        let decoded = try XCTUnwrap(LimeIME.decodeRelayPayload(LimeIME.RelayToken.request + payload))
+
+        XCTAssertEqual(decoded.phonePortraitMode, 3)
+        XCTAssertEqual(decoded.phoneLandscapeSplit, true)
+    }
+
+    func testDecodeDefaultsPhonePrefsWhenAbsent() throws {
+        // Older keyboard builds emit no pp=/pls= fields.
+        let payload = LimeIME.encodeRelayPayload(faOn: true, ts: 1_234.5)
+        let decoded = try XCTUnwrap(LimeIME.decodeRelayPayload(LimeIME.RelayToken.request + payload))
+
+        XCTAssertNil(decoded.phonePortraitMode)
+        XCTAssertNil(decoded.phoneLandscapeSplit)
+    }
+
+    func testLegacyRelayStateDoesNotInventCanonicalPhoneValues() throws {
+        let prefs = LimeIME.RelayPrefState(hanConvert: 0, splitKeyboard: 1, updatedAt: 42.0)
+        let payload = LimeIME.encodeRelayPayload(faOn: true, ts: 1_234.5, prefs: prefs)
+        XCTAssertFalse(payload.contains(";pp="))
+        XCTAssertFalse(payload.contains(";pls="))
+        let decoded = try XCTUnwrap(LimeIME.decodeRelayPayload(payload))
+        XCTAssertNil(decoded.phonePortraitMode)
+        XCTAssertNil(decoded.phoneLandscapeSplit)
+    }
+
+    func testRelayPayloadScopesGeometryToCurrentDeviceProfile() throws {
+        let phone = LimeIME.RelayPrefState(hanConvert: 0, splitKeyboard: 1, updatedAt: 42.0,
+                                          oneHand: 2, numpadAnchor: 3,
+                                          phonePortraitMode: 2, phoneLandscapeSplit: true,
+                                          geometryProfile: "phone")
+        let phonePayload = LimeIME.encodeRelayPayload(faOn: true, ts: 1, prefs: phone)
+        XCTAssertFalse(phonePayload.contains(";split="))
+        XCTAssertFalse(phonePayload.contains(";na="))
+        XCTAssertTrue(phonePayload.contains(";pp=2"))
+
+        var tablet = phone
+        tablet.geometryProfile = "tablet"
+        let tabletPayload = LimeIME.encodeRelayPayload(faOn: true, ts: 1, prefs: tablet)
+        XCTAssertTrue(tabletPayload.contains(";split=1"))
+        XCTAssertTrue(tabletPayload.contains(";na=3"))
+        XCTAssertFalse(tabletPayload.contains(";pp="))
+        XCTAssertFalse(tabletPayload.contains(";pls="))
+    }
+
     func testDecodeRejectsTokenAndGarbage() {
         XCTAssertNil(LimeIME.decodeRelayPayload(LimeIME.RelayToken.request))
         XCTAssertNil(LimeIME.decodeRelayPayload("not a relay"))

--- a/LimeIME-iOS/LimeTests/RelayPrefSyncTest.swift
+++ b/LimeIME-iOS/LimeTests/RelayPrefSyncTest.swift
@@ -62,6 +62,21 @@ final class RelayPrefSyncTest: XCTestCase {
         XCTAssertEqual(try store.read(), updated)
     }
 
+    func testOldRelayJsonDoesNotResetMigratedPhonePreferences() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let oldJson = #"{"hanConvert":0,"splitKeyboard":1,"updatedAt":42}"#.data(using: .utf8)!
+        try oldJson.write(to: dir.appendingPathComponent("relay-prefs.json"))
+
+        let state = try XCTUnwrap(try LimeIME.KeyboardRelayPrefStore(baseDirectory: dir).read())
+        XCTAssertNil(state.phonePortraitMode)
+        XCTAssertNil(state.phoneLandscapeSplit)
+        let payload = LimeIME.encodeRelayPayload(faOn: false, ts: 43, prefs: state)
+        XCTAssertFalse(payload.contains(";pp="))
+        XCTAssertFalse(payload.contains(";pls="))
+    }
+
     func testRelayPrefApplyIsLastWriterWins() throws {
         let (defaults, suite) = try makeDefaults()
         defer { UserDefaults.standard.removePersistentDomain(forName: suite) }

--- a/LimeIME-iOS/LimeTests/SyncContractTest.swift
+++ b/LimeIME-iOS/LimeTests/SyncContractTest.swift
@@ -93,6 +93,38 @@ final class SyncContractTest: XCTestCase {
         XCTAssertEqual(rec.seq, 2)
     }
 
+    func testPrefInboxCarriesPhonePortraitAndLandscapeSplit() throws {
+        // Issue #169: app→keyboard inbox carries the integrated iPhone phone prefs; later
+        // writes merge per-field, so the first still carries forward.
+        let base = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("prefinbox-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        let suite = "prefinbox-test-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        try PrefInbox.write(base: base, defaults: defaults, phonePortraitMode: 2)       // seq 1
+        try PrefInbox.write(base: base, defaults: defaults, phoneLandscapeSplit: true)  // seq 2
+        let rec = try XCTUnwrap(PrefInbox.read(base: base))
+        XCTAssertEqual(rec.phonePortraitMode, 2)
+        XCTAssertEqual(rec.phoneLandscapeSplit, true)
+        XCTAssertEqual(rec.seq, 2)
+    }
+
+    func testRelayPrefSyncAppliesPhonePortraitMode() {
+        // Issue #169: a globe-menu phone-portrait change relays back and updates the
+        // settings app's cold store, exactly like split does.
+        let suite = "relaysync-test-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertTrue(RelayPrefSync.apply(han: nil, split: nil,
+                                          phonePortraitMode: 3, phoneLandscapeSplit: true,
+                                          pts: 100, to: defaults))
+        XCTAssertEqual(defaults.integer(forKey: "phone_portrait_keyboard_mode"), 3)
+        XCTAssertTrue(defaults.bool(forKey: "phone_landscape_split"))
+    }
+
     func testEditorRefreshPayloadsRoundTrip() throws {
         let request = EditorRefreshRequest(requestUUID: "req-1",
                                            table: "custom",

--- a/LimeIME-iOS/Shared/Database/SyncContract.swift
+++ b/LimeIME-iOS/Shared/Database/SyncContract.swift
@@ -127,6 +127,13 @@ struct RelayPrefState: Codable, Equatable {
     // set" stays distinguishable from "explicitly set to 0" — older stored JSON still decodes.
     var oneHand: Int? = nil
     var numpadAnchor: Int? = nil
+    // Issue #169: integrated iPhone portrait mode + landscape split mirrors. Optional so
+    // older stored JSON still decodes and "never set" stays distinguishable from 0/false.
+    var phonePortraitMode: Int? = nil
+    var phoneLandscapeSplit: Bool? = nil
+    // Device-class scope for geometry fields. Older relay files omit this and retain
+    // their legacy payload shape; new writes use "phone" or "tablet".
+    var geometryProfile: String? = nil
 }
 
 final class KeyboardRelayPrefStore {
@@ -156,6 +163,9 @@ final class KeyboardRelayPrefStore {
                 numpadAnchor: Int? = nil,
                 reverseLookupIM: String? = nil,
                 reverseLookupValue: String? = nil,
+                phonePortraitMode: Int? = nil,
+                phoneLandscapeSplit: Bool? = nil,
+                geometryProfile: String? = nil,
                 updatedAt: TimeInterval = Date().timeIntervalSince1970) throws -> RelayPrefState {
         let current = try read()
         let state = RelayPrefState(hanConvert: hanConvert ?? current?.hanConvert ?? 0,
@@ -164,7 +174,10 @@ final class KeyboardRelayPrefStore {
                                    reverseLookupIM: reverseLookupIM ?? current?.reverseLookupIM,
                                    reverseLookupValue: reverseLookupValue ?? current?.reverseLookupValue,
                                    oneHand: oneHand ?? current?.oneHand,
-                                   numpadAnchor: numpadAnchor ?? current?.numpadAnchor)
+                                   numpadAnchor: numpadAnchor ?? current?.numpadAnchor,
+                                   phonePortraitMode: phonePortraitMode ?? current?.phonePortraitMode,
+                                   phoneLandscapeSplit: phoneLandscapeSplit ?? current?.phoneLandscapeSplit,
+                                   geometryProfile: geometryProfile ?? current?.geometryProfile)
         try write(state)
         return state
     }
@@ -181,6 +194,9 @@ struct PrefInboxRecord: Codable, Equatable {
     var splitKeyboard: Int?
     var oneHand: Int?
     var numpadAnchor: Int?
+    // Issue #169: integrated iPhone portrait mode + landscape split.
+    var phonePortraitMode: Int?
+    var phoneLandscapeSplit: Bool?
     var reverseLookup: [String: String]?
     /// Active IM — only ever set by a wholesale restore (the restored backup's active IM).
     var activeIM: String?
@@ -200,6 +216,8 @@ enum PrefInbox {
                       splitKeyboard: Int? = nil,
                       oneHand: Int? = nil,
                       numpadAnchor: Int? = nil,
+                      phonePortraitMode: Int? = nil,
+                      phoneLandscapeSplit: Bool? = nil,
                       reverseLookup: (im: String, value: String)? = nil,
                       activeIM: String? = nil) throws {
         let url = SyncPaths.prefInbox(base)
@@ -216,6 +234,8 @@ enum PrefInbox {
             splitKeyboard: splitKeyboard ?? current?.splitKeyboard,
             oneHand: oneHand ?? current?.oneHand,
             numpadAnchor: numpadAnchor ?? current?.numpadAnchor,
+            phonePortraitMode: phonePortraitMode ?? current?.phonePortraitMode,
+            phoneLandscapeSplit: phoneLandscapeSplit ?? current?.phoneLandscapeSplit,
             reverseLookup: mergedReverse.isEmpty ? nil : mergedReverse,
             activeIM: activeIM ?? current?.activeIM)
         try FileManager.default.createDirectory(at: SyncPaths.inboxDir(base),
@@ -241,6 +261,8 @@ enum PrefInbox {
 enum RelayPrefSync {
     static let hanConvertKey = "han_convert_option"
     static let splitKeyboardKey = "split_keyboard_mode"
+    static let phonePortraitModeKey = "phone_portrait_keyboard_mode"
+    static let phoneLandscapeSplitKey = "phone_landscape_split"
     static let appliedAtKey = "relay_pref_applied_at"
 
     /// Reverse-lookup is stored per-IM under `<IM>_im_reverselookup` (see
@@ -252,21 +274,33 @@ enum RelayPrefSync {
                       split: Int?,
                       reverseLookupIM: String? = nil,
                       reverseLookupValue: String? = nil,
+                      phonePortraitMode: Int? = nil,
+                      phoneLandscapeSplit: Bool? = nil,
                       pts: TimeInterval?,
                       to defaults: UserDefaults) -> Bool {
         guard let pts, pts > defaults.double(forKey: appliedAtKey) else { return false }
         let validHan = han.flatMap { (0...2).contains($0) ? $0 : nil }
         let validSplit = split.flatMap { (0...2).contains($0) ? $0 : nil }
+        // Issue #169: relay the integrated iPhone portrait mode back so a globe-menu
+        // change updates the settings app (FA-off path), exactly like split does.
+        let validPortrait = phonePortraitMode.flatMap { (0...3).contains($0) ? $0 : nil }
         let rlIM = reverseLookupIM.flatMap { $0.isEmpty ? nil : $0 }
         let rlVal = reverseLookupValue.flatMap { $0.isEmpty ? nil : $0 }
         let hasReverseLookup = rlIM != nil && rlVal != nil
-        guard validHan != nil || validSplit != nil || hasReverseLookup else { return false }
+        guard validHan != nil || validSplit != nil || hasReverseLookup
+              || validPortrait != nil || phoneLandscapeSplit != nil else { return false }
 
         if let validHan {
             defaults.set(validHan, forKey: hanConvertKey)
         }
         if let validSplit {
             defaults.set(validSplit, forKey: splitKeyboardKey)
+        }
+        if let validPortrait {
+            defaults.set(validPortrait, forKey: phonePortraitModeKey)
+        }
+        if let phoneLandscapeSplit {
+            defaults.set(phoneLandscapeSplit, forKey: phoneLandscapeSplitKey)
         }
         if let rlIM, let rlVal {
             defaults.set(rlVal, forKey: reverseLookupKey(for: rlIM))
@@ -298,7 +332,15 @@ enum RelayPrefSync {
 func encodeRelayPayload(faOn: Bool, ts: TimeInterval, prefs: RelayPrefState? = nil) -> String {
     var payload = "LIMERLY!v1;fa=\(faOn ? 1 : 0);ts=\(ts)"
     if let prefs {
-        payload += ";han=\(prefs.hanConvert);split=\(prefs.splitKeyboard);oh=\(prefs.oneHand ?? 0);na=\(prefs.numpadAnchor ?? 0);pts=\(prefs.updatedAt)"
+        payload += ";han=\(prefs.hanConvert)"
+        if prefs.geometryProfile != "phone" {
+            payload += ";split=\(prefs.splitKeyboard);oh=\(prefs.oneHand ?? 0);na=\(prefs.numpadAnchor ?? 0)"
+        }
+        if prefs.geometryProfile != "tablet" {
+            if let portrait = prefs.phonePortraitMode { payload += ";pp=\(portrait)" }
+            if let landscape = prefs.phoneLandscapeSplit { payload += ";pls=\(landscape ? 1 : 0)" }
+        }
+        payload += ";pts=\(prefs.updatedAt)"
         if let im = prefs.reverseLookupIM, let val = prefs.reverseLookupValue,
            !im.isEmpty, !val.isEmpty {
             payload += ";rlim=\(im);rlval=\(val)"
@@ -307,7 +349,7 @@ func encodeRelayPayload(faOn: Bool, ts: TimeInterval, prefs: RelayPrefState? = n
     return payload
 }
 
-func decodeRelayPayload(_ text: String) -> (proto: Int, faOn: Bool, ts: TimeInterval, han: Int?, split: Int?, oneHand: Int?, numpadAnchor: Int?, pts: TimeInterval?, rlim: String?, rlval: String?)? {
+func decodeRelayPayload(_ text: String) -> (proto: Int, faOn: Bool, ts: TimeInterval, han: Int?, split: Int?, oneHand: Int?, numpadAnchor: Int?, phonePortraitMode: Int?, phoneLandscapeSplit: Bool?, pts: TimeInterval?, rlim: String?, rlval: String?)? {
     let marker = "LIMERLY!v"
     guard let start = text.range(of: marker)?.lowerBound else { return nil }
     // Lenient: the original fa/ts fields remain mandatory; optional pref fields are
@@ -329,6 +371,8 @@ func decodeRelayPayload(_ text: String) -> (proto: Int, faOn: Bool, ts: TimeInte
     var split: Int?
     var oneHand: Int?
     var numpadAnchor: Int?
+    var phonePortraitMode: Int?
+    var phoneLandscapeSplit: Bool?
     var pts: TimeInterval?
     var rlim: String?
     var rlval: String?
@@ -356,6 +400,12 @@ func decodeRelayPayload(_ text: String) -> (proto: Int, faOn: Bool, ts: TimeInte
         case "na":
             let digits = value.prefix { $0.isNumber || $0 == "-" }
             numpadAnchor = Int(digits)
+        case "pp":
+            let digits = value.prefix { $0.isNumber || $0 == "-" }
+            phonePortraitMode = Int(digits)
+        case "pls":
+            let digits = value.prefix { $0.isNumber || $0 == "-" }
+            if let v = Int(digits) { phoneLandscapeSplit = (v != 0) }
         case "pts":
             let digits = value.prefix { $0.isNumber || $0 == "." || $0 == "-" }
             if let parsed = Double(digits), parsed.isFinite {
@@ -369,7 +419,7 @@ func decodeRelayPayload(_ text: String) -> (proto: Int, faOn: Bool, ts: TimeInte
             continue
         }
     }
-    return (proto: proto, faOn: fa == 1, ts: ts, han: han, split: split, oneHand: oneHand, numpadAnchor: numpadAnchor, pts: pts, rlim: rlim, rlval: rlval)
+    return (proto: proto, faOn: fa == 1, ts: ts, han: han, split: split, oneHand: oneHand, numpadAnchor: numpadAnchor, phonePortraitMode: phonePortraitMode, phoneLandscapeSplit: phoneLandscapeSplit, pts: pts, rlim: rlim, rlval: rlval)
 }
 
 func isRelayRequestContext(before: String?, after: String? = nil) -> Bool {

--- a/LimeIME-iOS/Shared/Database/TableSyncEngine.swift
+++ b/LimeIME-iOS/Shared/Database/TableSyncEngine.swift
@@ -140,7 +140,7 @@ final class TableSyncEngine {
         }
         try Self.renameReplacing(tempURL, with: snapshotURL)
 
-        // §1.8: the four keyboard-owned hamburger prefs live in the extension's own
+        // §1.8: keyboard-owned hamburger prefs live in the extension's own
         // container, not this hot DB. Backup is the one FA-on moment the keyboard may write
         // the App Group, so flush them to cold now — the app's preference sidecar then
         // captures the CURRENT values, not cold's stale copy.
@@ -154,14 +154,26 @@ final class TableSyncEngine {
                         to: SyncPaths.receipt(appGroupBaseURL))
     }
 
-    /// §1.8: copy the four keyboard-owned prefs from the extension's own container
+    /// §1.8: copy the active device profile's keyboard-owned prefs from the extension's own container
     /// (`UserDefaults.standard`) to the App Group (cold) so a backup's preference sidecar
     /// captures current values. Runs only inside the FA-on backup handshake — the one time
     /// the keyboard may write the App Group.
     private func flushHotPrefsToColdForBackup() {
         let hot = UserDefaults.standard
         guard let cold = UserDefaults(suiteName: LIMEPreferenceManager.suiteName) else { return }
-        for key in ["han_convert_option", "split_keyboard_mode"] {
+        // Issue #169: flush only the active device-class geometry profile. The cold
+        // store keeps the other profile dormant; a phone must never rewrite iPad
+        // split/numpad values, and an iPad must never rewrite phone values.
+        var keys = ["han_convert_option"]
+        switch hot.string(forKey: "keyboard_geometry_profile") {
+        case "phone":
+            keys += ["phone_portrait_keyboard_mode", "phone_landscape_split"]
+        case "tablet":
+            keys += ["split_keyboard_mode", "numpad_anchor"]
+        default:
+            break
+        }
+        for key in keys {
             if let value = hot.object(forKey: key) { cold.set(value, forKey: key) }
         }
         if let activeIM = hot.string(forKey: "active_im"), !activeIM.isEmpty {

--- a/LimeIME-iOS/Shared/Models/PhoneKeyboardModePolicy.swift
+++ b/LimeIME-iOS/Shared/Models/PhoneKeyboardModePolicy.swift
@@ -1,0 +1,98 @@
+/*
+ *
+ *  *
+ *  **    Copyright 2026, The LimeIME Open Source Project
+ *  **
+ *  **    Project Url: http://github.com/lime-ime/limeime/
+ *  **
+ *  **    This program is free software: you can redistribute it and/or modify
+ *  **    it under the terms of the GNU General Public License as published by
+ *  **    the Free Software Foundation, either version 3 of the License, or
+ *  **    (at your option) any later version.
+ *  *
+ *  **    This program is distributed in the hope that it will be useful,
+ *  **    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  **    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  **    GNU General Public License for more details.
+ *  *
+ *  **    You should have received a copy of the GNU General Public License
+ *  **    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  *
+ *
+ */
+
+// Issue #169: shared phone keyboard geometry semantics for migration and
+// rendering. This is a byte-for-byte semantic mirror of the Android
+// `org.limeime.keyboard.PhoneKeyboardModePolicy` so iPhone and Android phone
+// behaviour and stored key values stay aligned. Pure logic (no UIKit) so it is
+// linkable from the keyboard extension, the settings app, and the unit tests.
+//
+// Canonical shared keys/values:
+//   phone_portrait_keyboard_mode: 0 standard, 1 split, 2 one-hand left, 3 one-hand right
+//   phone_landscape_split:        boolean
+
+/// Integrated phone portrait keyboard mode. Mutually exclusive: split and
+/// one-hand both own the same horizontal key geometry.
+enum PhoneKeyboardPortraitMode: Int {
+    case standard = 0
+    case split = 1
+    case oneHandLeft = 2
+    case oneHandRight = 3
+}
+
+enum PhoneKeyboardModePolicy {
+
+    /// Migrate the legacy `one_hand_mode` (0 off / 1 left / 2 right) +
+    /// `split_keyboard_mode` (0 off / 1 always / 2 landscape-only) pair into the
+    /// integrated portrait mode. Deterministic precedence: explicit one-hand wins,
+    /// then legacy "always" split, else standard.
+    ///
+    /// `legacyPhoneSplitSupported` is true on Android (legacy phone portrait split
+    /// existed) and false on iOS (iPhone split was never shipped, so migration must
+    /// not invent a legacy iPhone split).
+    static func migratePortraitMode(legacyOneHand: Int,
+                                    legacySplit: Int,
+                                    legacyPhoneSplitSupported: Bool) -> PhoneKeyboardPortraitMode {
+        if legacyOneHand == 1 { return .oneHandLeft }
+        if legacyOneHand == 2 { return .oneHandRight }
+        if legacyPhoneSplitSupported && legacySplit == 1 { return .split }
+        return .standard
+    }
+
+    /// Migrate the legacy split value into the separate phone landscape split
+    /// boolean. Android derives it from any nonzero legacy split; iOS defaults it
+    /// off because iPhone split did not previously exist.
+    static func migrateLandscapeSplit(legacySplit: Int,
+                                      legacyPhoneSplitSupported: Bool) -> Bool {
+        return legacyPhoneSplitSupported && legacySplit != 0
+    }
+
+    /// Whether split rendering is active for a phone keyboard instance. Landscape
+    /// reads only `phone_landscape_split`; portrait reads only the integrated mode.
+    /// Numpad-based layouts (`splitEligible == false`) never split.
+    static func splitActive(isLandscape: Bool,
+                            splitEligible: Bool,
+                            portraitMode: PhoneKeyboardPortraitMode,
+                            landscapeSplit: Bool) -> Bool {
+        if !splitEligible { return false }
+        return isLandscape ? landscapeSplit : (portraitMode == .split)
+    }
+
+    /// Portrait one-hand anchor: 0 none, 1 left, 2 right. Landscape never anchors.
+    static func oneHandAnchor(isLandscape: Bool,
+                              portraitMode: PhoneKeyboardPortraitMode) -> Int {
+        if isLandscape { return 0 }
+        switch portraitMode {
+        case .oneHandLeft: return 1
+        case .oneHandRight: return 2
+        default: return 0
+        }
+    }
+
+    /// Issue #169: the integrated phone controls apply to EVERY iPhone and NEVER
+    /// to iPad — there is no screen-width or physical-size gate. iPad uses the
+    /// split/numpad_anchor model instead.
+    static func phoneControlsApply(isPad: Bool) -> Bool {
+        return !isPad
+    }
+}

--- a/LimeIME-iOS/Shared/Preferences/LIMEPreferenceManager.swift
+++ b/LimeIME-iOS/Shared/Preferences/LIMEPreferenceManager.swift
@@ -135,6 +135,22 @@ final class LIMEPreferenceManager {
         set { defaults.set(newValue, forKey: "one_hand_mode") }
     }
 
+    /// Issue #169: integrated phone portrait keyboard mode. 0=standard, 1=split,
+    /// 2=one-hand left, 3=one-hand right. iPhone only; applies to every iPhone
+    /// regardless of screen width (no gate). Shared key/value semantics with
+    /// Android `phone_portrait_keyboard_mode` (see PhoneKeyboardModePolicy).
+    var phonePortraitKeyboardMode: Int {
+        get { intValue("phone_portrait_keyboard_mode", default: 0) }
+        set { defaults.set(newValue, forKey: "phone_portrait_keyboard_mode") }
+    }
+
+    /// Issue #169: separate phone landscape split toggle, independent of the
+    /// portrait mode. iPhone only. Shared key with Android `phone_landscape_split`.
+    var phoneLandscapeSplit: Bool {
+        get { boolValue("phone_landscape_split", default: false) }
+        set { defaults.set(newValue, forKey: "phone_landscape_split") }
+    }
+
     /// Numpad-based layout horizontal anchor. 0=fit, 1=left, 2=right, 3=center.
     var numpadAnchor: Int {
         get { intValue("numpad_anchor", default: 0) }

--- a/LimeIME-iOS/Shared/Preferences/PreferenceBackupAdapter.swift
+++ b/LimeIME-iOS/Shared/Preferences/PreferenceBackupAdapter.swift
@@ -47,6 +47,13 @@ enum PreferenceBackupAdapter {
         Spec(key: "number_row_in_english", type: .bool, iosSupported: true),
         Spec(key: "show_arrow_key", type: .int, iosSupported: true),
         Spec(key: "split_keyboard_mode", type: .int, iosSupported: true),
+        Spec(key: "one_hand_mode", type: .int, iosSupported: true),
+        // Issue #169: integrated iPhone portrait mode + landscape split. Backed up
+        // alongside the tablet/iPad split key so a backup restored across form factors
+        // preserves both the phone and tablet profiles without cross-writing.
+        Spec(key: "phone_portrait_keyboard_mode", type: .int, iosSupported: true),
+        Spec(key: "phone_landscape_split", type: .bool, iosSupported: true),
+        Spec(key: "numpad_anchor", type: .int, iosSupported: true),
         Spec(key: "vibrate_on_keypress", type: .bool, iosSupported: true),
         Spec(key: "vibrate_level", type: .int, iosSupported: true),
         Spec(key: "sound_on_keypress", type: .bool, iosSupported: true),
@@ -160,6 +167,29 @@ enum PreferenceBackupAdapter {
         for (key, value) in preferences where isSupportedDynamicKey(key) {
             if let boolValue = value as? Bool {
                 standardDefaults.set(boolValue, forKey: key)
+            }
+        }
+        // Issue #169: old manifests contain only the separate split/one-hand keys. Derive
+        // canonical phone keys during restore even when new-key defaults already exist locally.
+        // Legacy iOS split was iPad-only; only an Android source may infer phone split from it.
+        let hasLegacyGeometry = preferences["split_keyboard_mode"] != nil
+            || preferences["one_hand_mode"] != nil
+        if hasLegacyGeometry {
+            let legacySplit = preferences["split_keyboard_mode"] as? Int ?? 0
+            let legacyOneHand = preferences["one_hand_mode"] as? Int ?? 0
+            let legacyPhoneSplitSupported = (root["sourcePlatform"] as? String)?.lowercased() != "ios"
+            if preferences["phone_portrait_keyboard_mode"] == nil {
+                let migrated = PhoneKeyboardModePolicy.migratePortraitMode(
+                    legacyOneHand: legacyOneHand,
+                    legacySplit: legacySplit,
+                    legacyPhoneSplitSupported: legacyPhoneSplitSupported)
+                defaults.set(migrated.rawValue, forKey: "phone_portrait_keyboard_mode")
+            }
+            if preferences["phone_landscape_split"] == nil {
+                let migrated = PhoneKeyboardModePolicy.migrateLandscapeSplit(
+                    legacySplit: legacySplit,
+                    legacyPhoneSplitSupported: legacyPhoneSplitSupported)
+                defaults.set(migrated, forKey: "phone_landscape_split")
             }
         }
         defaults.synchronize()

--- a/LimeStudio/app/src/androidTest/java/org/limeime/PhoneKeyboardPreferenceMigrationTest.java
+++ b/LimeStudio/app/src/androidTest/java/org/limeime/PhoneKeyboardPreferenceMigrationTest.java
@@ -1,0 +1,106 @@
+package org.limeime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.limeime.global.LIMEPreferenceManager;
+import org.limeime.keyboard.PhoneKeyboardModePolicy;
+
+@RunWith(AndroidJUnit4.class)
+public class PhoneKeyboardPreferenceMigrationTest {
+    private SharedPreferences prefs;
+    private LIMEPreferenceManager manager;
+
+    @Before
+    public void setUp() {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        prefs.edit()
+                .remove("phone_portrait_keyboard_mode")
+                .remove("phone_landscape_split")
+                .remove("one_hand_mode")
+                .remove("split_keyboard_mode")
+                .commit();
+        manager = new LIMEPreferenceManager(context);
+    }
+
+    @After
+    public void tearDown() {
+        prefs.edit()
+                .remove("phone_portrait_keyboard_mode")
+                .remove("phone_landscape_split")
+                .remove("one_hand_mode")
+                .remove("split_keyboard_mode")
+                .commit();
+    }
+
+    @Test
+    public void splitOnlyUserMigratesToPortraitAndLandscapeSplitWithoutChangingTabletPref() {
+        prefs.edit().putString("split_keyboard_mode", "1").commit();
+
+        assertEquals(PhoneKeyboardModePolicy.PORTRAIT_SPLIT,
+                manager.getPhonePortraitKeyboardMode());
+        assertTrue(manager.getPhoneLandscapeSplit());
+        assertEquals("1", prefs.getString("split_keyboard_mode", null));
+        assertTrue(prefs.contains("phone_portrait_keyboard_mode"));
+        assertTrue(prefs.contains("phone_landscape_split"));
+    }
+
+    @Test
+    public void explicitOneHandWinsButLegacyTabletSplitRemainsPortable() {
+        prefs.edit()
+                .putString("split_keyboard_mode", "1")
+                .putString("one_hand_mode", "2")
+                .commit();
+
+        assertEquals(PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_RIGHT,
+                manager.getPhonePortraitKeyboardMode());
+        assertEquals("1", prefs.getString("split_keyboard_mode", null));
+    }
+
+    @Test
+    public void canonicalPhoneChangesNeverRewriteTabletSplitOrLegacyOneHand() {
+        prefs.edit()
+                .putString("split_keyboard_mode", "2")
+                .putString("one_hand_mode", "1")
+                .commit();
+
+        manager.setPhonePortraitKeyboardMode(PhoneKeyboardModePolicy.PORTRAIT_SPLIT);
+        manager.setPhoneLandscapeSplit(false);
+
+        assertEquals("2", prefs.getString("split_keyboard_mode", null));
+        assertEquals("1", prefs.getString("one_hand_mode", null));
+        assertEquals(PhoneKeyboardModePolicy.PORTRAIT_SPLIT,
+                manager.getPhonePortraitKeyboardMode());
+        assertFalse(manager.getPhoneLandscapeSplit());
+    }
+
+    @Test
+    public void migrationWritesBothKeysAtomicallyWhilePreservingAnExistingCanonicalValue() {
+        prefs.edit()
+                .putString("split_keyboard_mode", "2")
+                .putString("one_hand_mode", "1")
+                .putString("phone_portrait_keyboard_mode", "3")
+                .remove("phone_landscape_split")
+                .commit();
+
+        manager.ensurePhoneKeyboardPreferencesMigrated();
+
+        assertEquals("3", prefs.getString("phone_portrait_keyboard_mode", null));
+        assertTrue(prefs.getBoolean("phone_landscape_split", false));
+        assertTrue(prefs.contains("phone_portrait_keyboard_mode"));
+        assertTrue(prefs.contains("phone_landscape_split"));
+    }
+}

--- a/LimeStudio/app/src/androidTest/java/org/limeime/PortraitModeMenuLayoutTest.java
+++ b/LimeStudio/app/src/androidTest/java/org/limeime/PortraitModeMenuLayoutTest.java
@@ -1,0 +1,76 @@
+package org.limeime;
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.Context;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.google.android.material.button.MaterialButtonToggleGroup;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.limeime.ui.view.SegmentedHanPreference;
+
+@RunWith(AndroidJUnit4.class)
+public class PortraitModeMenuLayoutTest {
+
+    @Test
+    public void portraitModeChoicesStayOnOneLineWhenWidthIsEnough() {
+        Context context = new ContextThemeWrapper(
+                InstrumentationRegistry.getInstrumentation().getTargetContext(),
+                R.style.LIMESettingsTheme);
+        View panel = LayoutInflater.from(context).inflate(R.layout.keyboard_menu_panel, null);
+        MaterialButtonToggleGroup group = panel.findViewById(R.id.portrait_mode_toggle_group);
+        group.measure(View.MeasureSpec.makeMeasureSpec(800, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+        group.layout(0, 0, group.getMeasuredWidth(), group.getMeasuredHeight());
+
+        SegmentedHanPreference.stackIfClippedNow(group);
+
+        assertEquals(LinearLayout.HORIZONTAL, group.getOrientation());
+    }
+
+    @Test
+    public void portraitModeMovesChoicesBelowTitleBeforeStackingButtons() {
+        Context context = new ContextThemeWrapper(
+                InstrumentationRegistry.getInstrumentation().getTargetContext(),
+                R.style.LIMESettingsTheme);
+        View panel = LayoutInflater.from(context).inflate(R.layout.keyboard_menu_panel, null);
+        LinearLayout row = panel.findViewById(R.id.menu_portrait_mode_block);
+        MaterialButtonToggleGroup group = panel.findViewById(R.id.portrait_mode_toggle_group);
+        row.setVisibility(View.VISIBLE);
+        group.measure(View.MeasureSpec.makeMeasureSpec(200, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+        group.layout(0, 0, group.getMeasuredWidth(), group.getMeasuredHeight());
+
+        SegmentedHanPreference.stackIfClippedNow(group);
+
+        assertEquals(LinearLayout.VERTICAL, row.getOrientation());
+        assertEquals(LinearLayout.HORIZONTAL, group.getOrientation());
+        assertEquals(LinearLayout.LayoutParams.MATCH_PARENT, group.getLayoutParams().width);
+        assertEquals(0, ((LinearLayout.LayoutParams) group.getLayoutParams()).getMarginStart());
+    }
+
+    @Test
+    public void controlsBelowTitlesUseFullAvailableWidth() {
+        Context context = new ContextThemeWrapper(
+                InstrumentationRegistry.getInstrumentation().getTargetContext(),
+                R.style.LIMESettingsTheme);
+        View panel = LayoutInflater.from(context).inflate(R.layout.keyboard_menu_panel, null);
+        int[] groupIds = { R.id.han_toggle_group, R.id.split_toggle_group,
+                R.id.landscape_split_toggle_group, R.id.numpad_anchor_toggle_group };
+
+        for (int id : groupIds) {
+            View group = panel.findViewById(id);
+            LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) group.getLayoutParams();
+            assertEquals(LinearLayout.LayoutParams.MATCH_PARENT, params.width);
+            assertEquals(0, params.getMarginStart());
+        }
+    }
+}

--- a/LimeStudio/app/src/androidTest/java/org/limeime/PreferenceBackupAdapterTest.java
+++ b/LimeStudio/app/src/androidTest/java/org/limeime/PreferenceBackupAdapterTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 
 import androidx.preference.PreferenceManager;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -115,6 +116,74 @@ public class PreferenceBackupAdapterTest {
     }
 
     @Test
+    public void restoreLegacyAndroidBackupMigratesPhoneProfileEvenWhenDefaultsAlreadyExist() throws Exception {
+        prefs.edit()
+                .putString("phone_portrait_keyboard_mode", "0")
+                .putBoolean("phone_landscape_split", false)
+                .putLong("startup_config_version", 123L)
+                .commit();
+        JSONObject values = new JSONObject()
+                .put("split_keyboard_mode", 1)
+                .put("one_hand_mode", 0);
+        JSONObject manifest = new JSONObject()
+                .put("schema", 1)
+                .put("sourcePlatform", "android")
+                .put("preferences", values);
+
+        assertTrue(PreferenceBackupAdapter.restoreManifest(context, manifest));
+
+        assertEquals("1", prefs.getString("phone_portrait_keyboard_mode", null));
+        assertTrue(prefs.getBoolean("phone_landscape_split", false));
+        assertEquals("1", prefs.getString("split_keyboard_mode", null));
+        assertTrue(prefs.getLong("startup_config_version", 0L) > 123L);
+    }
+
+    @Test
+    public void restoreLegacyIosBackupPreservesOneHandButDoesNotInventPhoneSplit() throws Exception {
+        prefs.edit()
+                .putString("phone_portrait_keyboard_mode", "0")
+                .putBoolean("phone_landscape_split", true)
+                .commit();
+        JSONObject values = new JSONObject()
+                .put("split_keyboard_mode", 1)
+                .put("one_hand_mode", 2);
+        JSONObject manifest = new JSONObject()
+                .put("schema", 1)
+                .put("sourcePlatform", "ios")
+                .put("preferences", values);
+
+        assertTrue(PreferenceBackupAdapter.restoreManifest(context, manifest));
+
+        assertEquals("3", prefs.getString("phone_portrait_keyboard_mode", null));
+        assertFalse(prefs.getBoolean("phone_landscape_split", true));
+        assertEquals("1", prefs.getString("split_keyboard_mode", null));
+    }
+
+    @Test
+    public void restoreLegacyMixedGeometryOnTabletDoesNotDeriveDormantPhoneProfile() throws Exception {
+        prefs.edit()
+                .putString("phone_portrait_keyboard_mode", "3")
+                .putBoolean("phone_landscape_split", false)
+                .commit();
+        JSONObject values = new JSONObject()
+                .put("split_keyboard_mode", 1)
+                .put("one_hand_mode", 0);
+        JSONObject manifest = new JSONObject()
+                .put("schema", PreferenceBackupAdapter.SCHEMA_VERSION)
+                .put("sourcePlatform", "android")
+                .put("preferences", values);
+        Configuration tabletConfig = new Configuration(context.getResources().getConfiguration());
+        tabletConfig.smallestScreenWidthDp = 600;
+        Context tabletContext = context.createConfigurationContext(tabletConfig);
+
+        assertTrue(PreferenceBackupAdapter.restoreManifest(tabletContext, manifest));
+
+        assertEquals("3", prefs.getString("phone_portrait_keyboard_mode", null));
+        assertFalse(prefs.getBoolean("phone_landscape_split", true));
+        assertEquals("1", prefs.getString("split_keyboard_mode", null));
+    }
+
+    @Test
     public void restoreManifestRestoresEveryAndroidPrefsTableValue() throws Exception {
         Map<String, Object> expected = fullAndroidPrefsTableFixture();
         JSONObject values = new JSONObject();
@@ -193,6 +262,10 @@ public class PreferenceBackupAdapterTest {
         values.put("number_row_in_english", false);
         values.put("show_arrow_key", 2);
         values.put("split_keyboard_mode", 1);
+        values.put("one_hand_mode", 2);
+        values.put("phone_portrait_keyboard_mode", 3);
+        values.put("phone_landscape_split", true);
+        values.put("numpad_anchor", 2);
         values.put("vibrate_on_keypress", false);
         values.put("vibrate_level", 80);
         values.put("sound_on_keypress", true);
@@ -285,6 +358,9 @@ public class PreferenceBackupAdapterTest {
                 "keyboard_theme",
                 "show_arrow_key",
                 "split_keyboard_mode",
+                "one_hand_mode",
+                "phone_portrait_keyboard_mode",
+                "numpad_anchor",
                 "vibrate_level",
                 "enable_emoji_position",
                 "similiar_list",

--- a/LimeStudio/app/src/main/java/org/limeime/LIMEKeyboardSwitcher.java
+++ b/LimeStudio/app/src/main/java/org/limeime/LIMEKeyboardSwitcher.java
@@ -34,6 +34,7 @@ import org.limeime.global.LIMEPreferenceManager;
 import org.limeime.keyboard.LIMEBaseKeyboard;
 import org.limeime.keyboard.LIMEKeyboard;
 import org.limeime.keyboard.LIMEKeyboardView;
+import org.limeime.keyboard.PhoneKeyboardModePolicy;
 import org.limeime.keyboard.ReachGeometry;
 
 import android.content.Context;
@@ -315,11 +316,37 @@ public class LIMEKeyboardSwitcher {
 				if(DEBUG)
 					Log.i(TAG,"getKeyboard() keyboard for id, " + id + ", is not exist. create one now.");
 	        	boolean numpadXml = isNumpadXml(id.mXml);
-	        	LIMEKeyboard keyboard = new LIMEKeyboard(
+				boolean splitEligible = !numpadXml; // SPLIT_ONE_HAND_KB: numpad-based layouts never split
+				DisplayMetrics dmBuild = mThemedContext.getResources().getDisplayMetrics();
+				boolean isTabletBuild =
+						mThemedContext.getResources().getConfiguration().smallestScreenWidthDp >= 600;
+				boolean landscapeBuild = dmBuild.widthPixels > dmBuild.heightPixels;
+				// Issue #169: tablets keep the legacy split_keyboard_mode value; phones use
+				// the integrated portrait mode + separate landscape split, resolved here so
+				// the keyboard reads exactly one canonical decision.
+				int splitArg;
+				boolean phoneSplitForced;
+				int phoneOneHandAnchor;
+				if (isTabletBuild) {
+					splitArg = numpadXml ? LIMEBaseKeyboard.SPLIT_KEYBOARD_NEVER : mLIMEPref.getSplitKeyboard();
+					phoneSplitForced = false;
+					phoneOneHandAnchor = 0;
+				} else {
+					int portraitMode = mLIMEPref.getPhonePortraitKeyboardMode();
+					boolean landscapeSplit = mLIMEPref.getPhoneLandscapeSplit();
+					splitArg = LIMEBaseKeyboard.SPLIT_KEYBOARD_NEVER;
+					phoneSplitForced = splitEligible
+							&& ((landscapeBuild && mLIMEPref.getShowArrowKeys() != 0)
+							|| PhoneKeyboardModePolicy.phoneSplitActive(
+									landscapeBuild, true, portraitMode, landscapeSplit));
+					phoneOneHandAnchor = PhoneKeyboardModePolicy.oneHandAnchorMode(landscapeBuild, portraitMode);
+				}
+				LIMEKeyboard keyboard = new LIMEKeyboard(
 						mThemedContext, id.mXml, id.mMode, mKeySizeScale,
 	                mLIMEPref.getShowArrowKeys(), //Jeremy '12,5,21 add the show arrow keys option
-	                numpadXml ? LIMEBaseKeyboard.SPLIT_KEYBOARD_NEVER : mLIMEPref.getSplitKeyboard(), //Jeremy '12,5,27 add the split keyboard option
-	                !numpadXml // SPLIT_ONE_HAND_KB: numpad-based layouts never split
+	                splitArg, //Jeremy '12,5,27 add the split keyboard option
+	                splitEligible,
+	                phoneSplitForced // issue #169: resolved phone portrait/landscape split
                 );
                 keyboard.setKeyboardSwitcher(this);
                 if (id.mCjSemicolonKey) {
@@ -328,26 +355,24 @@ public class LIMEKeyboardSwitcher {
                 if (id.mEnableShiftLock) {
                     keyboard.enableShiftLock();
                 }
-	            // SPLIT_ONE_HAND_KB: horizontal anchoring. One-hand = gated phones, portrait
-	            // only (iOS built-in parity); numpad anchoring = tablets, numpad layouts only.
-	            DisplayMetrics dm = mThemedContext.getResources().getDisplayMetrics();
-	            boolean isTablet = mThemedContext.getResources().getConfiguration().smallestScreenWidthDp >= 600;
-	            boolean portrait = dm.widthPixels < dm.heightPixels;
-	            if (isTablet && numpadXml) {
+	            // SPLIT_ONE_HAND_KB / issue #169: horizontal anchoring. Phone portrait
+	            // one-hand applies to EVERY phone regardless of screen width (no gate);
+	            // numpad anchoring = tablets, numpad layouts only. oneHandWidth still
+	            // clamps to the available width, so a narrow phone simply gets a full-width
+	            // block, but the mode is always honored — never gated by device size.
+	            if (isTabletBuild && numpadXml) {
 	                int anchor = mLIMEPref.getNumpadAnchor();
 	                if (anchor != 0)
 	                    keyboard.applyHorizontalAnchor(
-	                            ReachGeometry.numpadWidth(keyboard.getDisplayWidth(), 5, dm.xdpi),
+	                            ReachGeometry.numpadWidth(keyboard.getDisplayWidth(), 5, dmBuild.xdpi),
 	                            anchor, false);
-	            } else if (!isTablet && portrait) {
-	                // Phone split renders landscape-only (LIMEBaseKeyboard gate), so
-	                // portrait always belongs to one-hand mode regardless of split pref.
-	                int mode = mLIMEPref.getOneHandMode();
-	                if (mode != 0 && ReachGeometry.oneHandAvailable(dm.widthPixels, dm.xdpi))
-	                    keyboard.applyHorizontalAnchor(
-	                            ReachGeometry.oneHandWidth(keyboard.getDisplayWidth(), dm.xdpi),
-	                            mode == 1 ? LIMEBaseKeyboard.ANCHOR_LEFT : LIMEBaseKeyboard.ANCHOR_RIGHT,
-	                            true);
+	            } else if (!isTabletBuild && phoneOneHandAnchor != 0) {
+	                // Issue #169: portrait one-hand (oneHandAnchorMode returns 0 in landscape),
+	                // applies to all portrait layouts including numpad-based ones.
+	                keyboard.applyHorizontalAnchor(
+	                        ReachGeometry.oneHandWidth(keyboard.getDisplayWidth(), dmBuild.xdpi),
+	                        phoneOneHandAnchor == 1 ? LIMEBaseKeyboard.ANCHOR_LEFT : LIMEBaseKeyboard.ANCHOR_RIGHT,
+	                        true);
 	            }
 	            mKeyboards.put(id, keyboard);
 	        }

--- a/LimeStudio/app/src/main/java/org/limeime/LIMEService.java
+++ b/LimeStudio/app/src/main/java/org/limeime/LIMEService.java
@@ -2276,9 +2276,12 @@ public class LIMEService extends InputMethodService
         } else if (primaryCode == LIMEKeyboardView.KEYCODE_OPTIONS) {
             handleOptions();
         } else if (primaryCode == LIMEBaseKeyboard.KEYCODE_ONE_HAND_RESTORE) {
-            // SPLIT_ONE_HAND_KB: chevron tap restores full width, persisted (spec).
+            // Issue #169: chevron tap restores full width by setting the integrated
+            // portrait mode back to standard, persisted (spec).
             // Rebuild in place — handleClose() would requestHideSelf() and dismiss the IME.
-            mLIMEPref.setOneHandMode(0);
+            mLIMEPref.setPhonePortraitKeyboardMode(
+                    org.limeime.keyboard.PhoneKeyboardModePolicy.PORTRAIT_STANDARD);
+            invalidateStartupConfigSnapshot();
             applyGeometryChangeInPlace();
         } else if (primaryCode == LIMEKeyboardView.KEYCODE_SPACE_LONGPRESS) {
             showIMPicker();
@@ -3685,14 +3688,20 @@ public class LIMEService extends InputMethodService
         // ordinary layouts show 分離鍵盤 / 單手鍵盤. (spec: keyboard-menu rule)
         final boolean isNumpadKb = mKeyboardSwitcher.isNumpadKeyboard();
         final boolean isTablet = getResources().getConfiguration().smallestScreenWidthDp >= 600;
-        // Phones show only the control that affects the current orientation: portrait
-        // is one-hand territory, landscape is split territory (split renders
-        // landscape-only on phones). Tablets keep the split control in both.
-        final boolean hasSplitOption = !isNumpadKb && !(isLandScape && mShowArrowKeys > 0)
-                && (isTablet || isLandScape);
-        final boolean hasOneHandOption = !isTablet && !isLandScape
-                && org.limeime.keyboard.ReachGeometry.oneHandAvailable(
-                        Math.min(displayWidth, displayHeight), dm.xdpi);
+        // Issue #169: tablets keep the tri-state 分離鍵盤 control (ordinary layouts) and
+        // 數字鍵盤位置 (numpad layouts). Phones use the integrated 直向鍵盤模式 in portrait
+        // and the binary 橫向分離鍵盤 in landscape — shown on EVERY phone regardless of
+        // screen width (no gate). Numpad layouts never split, so on a phone the portrait
+        // control hides its 分離 segment and the landscape control is not shown.
+        final boolean phoneControls =
+                org.limeime.keyboard.PhoneKeyboardModePolicy.phoneControlsApply(isTablet);
+        final boolean hasTabletSplitOption = isTablet && !isNumpadKb
+                && !(isLandScape && mShowArrowKeys > 0);
+        final boolean hasPhonePortraitMode = phoneControls && !isLandScape;
+        // Android's legacy landscape arrow-key layout requires the centre split. Hide the
+        // binary preference while arrows force it on, because 關閉 could not take effect.
+        final boolean hasPhoneLandscapeSplit = phoneControls && isLandScape && !isNumpadKb
+                && mShowArrowKeys == 0;
         final boolean hasNumpadAnchorOption = isTablet && isNumpadKb;
 
         // Custom panel: every entry is a styled row and 簡繁轉換 hosts its segmented
@@ -3747,23 +3756,16 @@ public class LIMEService extends InputMethodService
             org.limeime.ui.view.SegmentedHanPreference.stackIfClipped(hanGroup);
         }
 
-        // 分離鍵盤 inline segmented control (0=關閉 1=開啟 2=僅橫向), shown only when
-        // the split option is available in the current orientation.
+        // 分離鍵盤 inline segmented control (0=關閉 1=開啟 2=僅橫向), tablets only —
+        // ordinary (non-numpad) layouts. Phones use 直向鍵盤模式 / 橫向分離鍵盤 below.
         final int splitCurrent = clampIndex(mSplitKeyboard, 3);
         final int[] pendingSplit = { splitCurrent };
-        if (hasSplitOption) {
+        if (hasTabletSplitOption) {
             panel.findViewById(R.id.menu_split_block).setVisibility(android.view.View.VISIBLE);
             com.google.android.material.button.MaterialButtonToggleGroup splitGroup =
                     panel.findViewById(R.id.split_toggle_group);
             final int[] splitIds = { R.id.split_opt_off, R.id.split_opt_on, R.id.split_opt_landscape };
-            if (!isTablet) {
-                // Phones: split renders landscape-only, so 開啟 and 僅橫向 are the same
-                // thing — binary control. Stored 僅橫向 lights 開啟.
-                panel.findViewById(R.id.split_opt_landscape).setVisibility(android.view.View.GONE);
-                splitGroup.check(splitIds[splitCurrent == 0 ? 0 : 1]);
-            } else {
-                splitGroup.check(splitIds[splitCurrent]);
-            }
+            splitGroup.check(splitIds[splitCurrent]);
             splitGroup.addOnButtonCheckedListener((g, checkedId, isChecked) -> {
                 if (!isChecked) return;
                 for (int i = 0; i < splitIds.length; i++) {
@@ -3773,23 +3775,52 @@ public class LIMEService extends InputMethodService
             org.limeime.ui.view.SegmentedHanPreference.stackIfClipped(splitGroup);
         }
 
-        // 單手鍵盤 inline segmented control (0=關閉 1=靠左 2=靠右), shown only when
-        // the screen is wide enough for one-hand shrinking to be meaningful.
-        final int oneHandCurrent = clampIndex(mLIMEPref.getOneHandMode(), 3);
-        final int[] pendingOneHand = { oneHandCurrent };
-        if (hasOneHandOption) {
-            panel.findViewById(R.id.menu_onehand_block).setVisibility(android.view.View.VISIBLE);
-            com.google.android.material.button.MaterialButtonToggleGroup oneHandGroup =
-                    panel.findViewById(R.id.onehand_toggle_group);
-            final int[] oneHandIds = { R.id.onehand_opt_off, R.id.onehand_opt_left, R.id.onehand_opt_right };
-            oneHandGroup.check(oneHandIds[oneHandCurrent]);
-            oneHandGroup.addOnButtonCheckedListener((g, checkedId, isChecked) -> {
+        // 直向鍵盤模式 integrated phone-portrait control (0=標準 1=分離 2=靠左 3=靠右).
+        // Issue #169: shown on every phone in portrait, no width gate. 分離 is hidden
+        // for numpad layouts (numpads never split); if a stored 分離 meets a numpad
+        // layout it is shown as 標準 without rewriting the stored value.
+        final int portraitCurrent = clampIndex(mLIMEPref.getPhonePortraitKeyboardMode(), 4);
+        final int[] pendingPortrait = { portraitCurrent };
+        if (hasPhonePortraitMode) {
+            panel.findViewById(R.id.menu_portrait_mode_block).setVisibility(android.view.View.VISIBLE);
+            com.google.android.material.button.MaterialButtonToggleGroup portraitGroup =
+                    panel.findViewById(R.id.portrait_mode_toggle_group);
+            final int[] portraitIds = { R.id.portrait_opt_standard, R.id.portrait_opt_split,
+                    R.id.portrait_opt_left, R.id.portrait_opt_right };
+            if (isNumpadKb) {
+                panel.findViewById(R.id.portrait_opt_split).setVisibility(android.view.View.GONE);
+                portraitGroup.check(portraitIds[portraitCurrent
+                        == org.limeime.keyboard.PhoneKeyboardModePolicy.PORTRAIT_SPLIT
+                        ? org.limeime.keyboard.PhoneKeyboardModePolicy.PORTRAIT_STANDARD
+                        : portraitCurrent]);
+            } else {
+                portraitGroup.check(portraitIds[portraitCurrent]);
+            }
+            portraitGroup.addOnButtonCheckedListener((g, checkedId, isChecked) -> {
                 if (!isChecked) return;
-                for (int i = 0; i < oneHandIds.length; i++) {
-                    if (oneHandIds[i] == checkedId) { pendingOneHand[0] = i; break; }
+                for (int i = 0; i < portraitIds.length; i++) {
+                    if (portraitIds[i] == checkedId) { pendingPortrait[0] = i; break; }
                 }
             });
-            org.limeime.ui.view.SegmentedHanPreference.stackIfClipped(oneHandGroup);
+            org.limeime.ui.view.SegmentedHanPreference.stackIfClipped(portraitGroup);
+        }
+
+        // 橫向分離鍵盤 binary phone-landscape control (關閉 / 開啟), independent of the
+        // portrait mode. Issue #169: shown on every phone in landscape (ordinary
+        // layouts only; numpads never split), no width gate.
+        final boolean landscapeSplitCurrent = mLIMEPref.getPhoneLandscapeSplit();
+        final boolean[] pendingLandscapeSplit = { landscapeSplitCurrent };
+        if (hasPhoneLandscapeSplit) {
+            panel.findViewById(R.id.menu_landscape_split_block).setVisibility(android.view.View.VISIBLE);
+            com.google.android.material.button.MaterialButtonToggleGroup landscapeSplitGroup =
+                    panel.findViewById(R.id.landscape_split_toggle_group);
+            final int[] landscapeSplitIds = { R.id.landscape_split_opt_off, R.id.landscape_split_opt_on };
+            landscapeSplitGroup.check(landscapeSplitIds[landscapeSplitCurrent ? 1 : 0]);
+            landscapeSplitGroup.addOnButtonCheckedListener((g, checkedId, isChecked) -> {
+                if (!isChecked) return;
+                pendingLandscapeSplit[0] = checkedId == R.id.landscape_split_opt_on;
+            });
+            org.limeime.ui.view.SegmentedHanPreference.stackIfClipped(landscapeSplitGroup);
         }
 
         // 數字鍵盤位置 inline segmented control (0=滿版 1=靠左 2=靠右 3=置中), shown only
@@ -3822,8 +3853,12 @@ public class LIMEService extends InputMethodService
                 mLIMEPref.setSplitKeyboard(pendingSplit[0]);
                 geometryChanged = true;
             }
-            if (pendingOneHand[0] != oneHandCurrent) {
-                mLIMEPref.setOneHandMode(pendingOneHand[0]);
+            if (pendingPortrait[0] != portraitCurrent) {
+                mLIMEPref.setPhonePortraitKeyboardMode(pendingPortrait[0]);
+                geometryChanged = true;
+            }
+            if (pendingLandscapeSplit[0] != landscapeSplitCurrent) {
+                mLIMEPref.setPhoneLandscapeSplit(pendingLandscapeSplit[0]);
                 geometryChanged = true;
             }
             if (pendingAnchor[0] != anchorCurrent) {

--- a/LimeStudio/app/src/main/java/org/limeime/global/LIMEPreferenceManager.java
+++ b/LimeStudio/app/src/main/java/org/limeime/global/LIMEPreferenceManager.java
@@ -30,6 +30,7 @@ import android.content.SharedPreferences;
 import androidx.preference.PreferenceManager;
 
 import org.limeime.data.ImConfig;
+import org.limeime.keyboard.PhoneKeyboardModePolicy;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -668,6 +669,61 @@ public class LIMEPreferenceManager {
 		putStringAndBumpStartupConfigVersionIfChanged(sp, "one_hand_mode", Integer.toString(mode));
 	}
 
+	public synchronized void ensurePhoneKeyboardPreferencesMigrated(){
+		SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(ctx);
+		boolean migratePortrait = !sp.contains("phone_portrait_keyboard_mode");
+		boolean migrateLandscape = !sp.contains("phone_landscape_split");
+		if(!migratePortrait && !migrateLandscape) return;
+
+		int legacyOneHand = Integer.parseInt(sp.getString("one_hand_mode", "0"));
+		int legacySplit = Integer.parseInt(sp.getString("split_keyboard_mode", "0"));
+		SharedPreferences.Editor editor = sp.edit();
+		if(migratePortrait){
+			editor.putString("phone_portrait_keyboard_mode", Integer.toString(
+					PhoneKeyboardModePolicy.migratePortraitMode(legacyOneHand, legacySplit, true)));
+		}
+		if(migrateLandscape){
+			editor.putBoolean("phone_landscape_split",
+					PhoneKeyboardModePolicy.migrateLandscapeSplit(legacySplit, true));
+		}
+		putNextStartupConfigVersion(sp, editor);
+		editor.commit();
+	}
+
+	public int getPhonePortraitKeyboardMode(){
+		ensurePhoneKeyboardPreferencesMigrated();
+		SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(ctx);
+		int mode = Integer.parseInt(sp.getString("phone_portrait_keyboard_mode", "0"));
+		return mode >= PhoneKeyboardModePolicy.PORTRAIT_STANDARD
+				&& mode <= PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_RIGHT
+				? mode : PhoneKeyboardModePolicy.PORTRAIT_STANDARD;
+	}
+
+	public void setPhonePortraitKeyboardMode(int mode){
+		if(mode < PhoneKeyboardModePolicy.PORTRAIT_STANDARD
+				|| mode > PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_RIGHT){
+			mode = PhoneKeyboardModePolicy.PORTRAIT_STANDARD;
+		}
+		SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(ctx);
+		putStringAndBumpStartupConfigVersionIfChanged(
+				sp, "phone_portrait_keyboard_mode", Integer.toString(mode));
+	}
+
+	public boolean getPhoneLandscapeSplit(){
+		ensurePhoneKeyboardPreferencesMigrated();
+		SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(ctx);
+		return sp.getBoolean("phone_landscape_split", false);
+	}
+
+	public void setPhoneLandscapeSplit(boolean enabled){
+		SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(ctx);
+		boolean changed = !sp.contains("phone_landscape_split")
+				|| sp.getBoolean("phone_landscape_split", false) != enabled;
+		SharedPreferences.Editor editor = sp.edit().putBoolean("phone_landscape_split", enabled);
+		if(changed) putNextStartupConfigVersion(sp, editor);
+		editor.apply();
+	}
+
 	public int getNumpadAnchor(){
 		SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(ctx);
 		return Integer.parseInt(sp.getString("numpad_anchor", "0"));
@@ -708,6 +764,8 @@ public class LIMEPreferenceManager {
 			case "show_arrow_key":
 			case "split_keyboard_mode":
 			case "one_hand_mode":
+			case "phone_portrait_keyboard_mode":
+			case "phone_landscape_split":
 			case "numpad_anchor":
 			case "keyboard_theme":
 			case "language_mode":
@@ -737,7 +795,7 @@ public class LIMEPreferenceManager {
 		return next;
 	}
 
-	private long putNextStartupConfigVersion(SharedPreferences sp, SharedPreferences.Editor editor){
+	static long putNextStartupConfigVersion(SharedPreferences sp, SharedPreferences.Editor editor){
 		long current = sp.getLong(STARTUP_CONFIG_VERSION, 0L);
 		long next = Math.max(System.currentTimeMillis(), current + 1L);
 		editor.putLong(STARTUP_CONFIG_VERSION, next);

--- a/LimeStudio/app/src/main/java/org/limeime/global/PreferenceBackupAdapter.java
+++ b/LimeStudio/app/src/main/java/org/limeime/global/PreferenceBackupAdapter.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 
 import androidx.preference.PreferenceManager;
 
+import org.limeime.keyboard.PhoneKeyboardModePolicy;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -46,6 +47,11 @@ public final class PreferenceBackupAdapter {
         add("show_arrow_key", Type.INTEGER_AS_STRING);
         add("split_keyboard_mode", Type.INTEGER_AS_STRING);
         add("one_hand_mode", Type.INTEGER_AS_STRING);
+        // Issue #169: integrated phone portrait mode + phone landscape split.
+        // Kept alongside the legacy tablet/iPad keys so a backup restored across
+        // form factors preserves both the phone and tablet profiles.
+        add("phone_portrait_keyboard_mode", Type.INTEGER_AS_STRING);
+        add("phone_landscape_split", Type.BOOLEAN);
         add("numpad_anchor", Type.INTEGER_AS_STRING);
         add("vibrate_on_keypress", Type.BOOLEAN);
         add("vibrate_level", Type.INTEGER_AS_STRING);
@@ -143,6 +149,31 @@ public final class PreferenceBackupAdapter {
                 restoreValue(editor, key, dynamicSpec.type, values.get(key));
             }
         }
+        // Issue #169: an old backup has only the separate split/one-hand keys. Derive the
+        // canonical phone profile during restore even if this installation already persisted
+        // new-key defaults. Old iOS split belonged to iPad, so only an Android source may infer
+        // phone split from split_keyboard_mode.
+        boolean hasLegacyGeometry = values.has("split_keyboard_mode") || values.has("one_hand_mode");
+        boolean targetIsPhone = context.getResources().getConfiguration().smallestScreenWidthDp < 600;
+        if (hasLegacyGeometry && targetIsPhone) {
+            int legacySplit = values.optInt("split_keyboard_mode", 0);
+            int legacyOneHand = values.optInt("one_hand_mode", 0);
+            boolean legacyPhoneSplitSupported = !"ios".equalsIgnoreCase(root.optString("sourcePlatform"));
+            if (!values.has("phone_portrait_keyboard_mode")) {
+                editor.putString("phone_portrait_keyboard_mode", Integer.toString(
+                        PhoneKeyboardModePolicy.migratePortraitMode(
+                                legacyOneHand, legacySplit, legacyPhoneSplitSupported)));
+            }
+            if (!values.has("phone_landscape_split")) {
+                editor.putBoolean("phone_landscape_split",
+                        PhoneKeyboardModePolicy.migrateLandscapeSplit(
+                                legacySplit, legacyPhoneSplitSupported));
+            }
+        }
+        // A restore may change active phone/tablet geometry while the IME process is alive.
+        // Invalidate its startup snapshot in the same transaction as the restored values.
+        LIMEPreferenceManager.putNextStartupConfigVersion(
+                PreferenceManager.getDefaultSharedPreferences(context), editor);
         return editor.commit();
     }
 

--- a/LimeStudio/app/src/main/java/org/limeime/keyboard/LIMEBaseKeyboard.java
+++ b/LimeStudio/app/src/main/java/org/limeime/keyboard/LIMEBaseKeyboard.java
@@ -782,6 +782,14 @@ public class LIMEBaseKeyboard {
      * @param modeId         keyboard mode identifier
      */
     public LIMEBaseKeyboard(Context context, int xmlLayoutResId, int modeId, float keySizeScale, int showArrowKeys, int splitKeyboard, boolean splitEligible) {
+        this(context, xmlLayoutResId, modeId, keySizeScale, showArrowKeys, splitKeyboard, splitEligible, false);
+    }
+
+    // SPLIT_ONE_HAND_KB / issue #169: phoneSplitForced carries the phone split
+    // decision already resolved by PhoneKeyboardModePolicy in LIMEKeyboardSwitcher
+    // (integrated portrait mode + separate landscape split). Tablets ignore it and
+    // keep the legacy value-based, orientation-gated decision below.
+    public LIMEBaseKeyboard(Context context, int xmlLayoutResId, int modeId, float keySizeScale, int showArrowKeys, int splitKeyboard, boolean splitEligible, boolean phoneSplitForced) {
         DisplayMetrics dm = context.getResources().getDisplayMetrics();
         // Issue #47: use the actual usable window width (excluding system bars and
         // display cutout insets) so percentage-based key widths don't overflow the
@@ -817,14 +825,21 @@ public class LIMEBaseKeyboard {
         //Jeremy '12,5,26 reserve  columns in the middle for arrow keys in landscape mode.
         //Jeremy '12,5,27 read splitkeyboard setting from preference.
         //Jeremy '12,6,19  add orientation consideration on split keyboard
-        // SPLIT_ONE_HAND_KB: on phones split renders in landscape only, whatever the
-        // stored value — portrait phone split keys fall below SPLIT_KEY_MIN_MM and
-        // portrait geometry belongs to one-hand mode (spec eligibility matrix).
+        // SPLIT_ONE_HAND_KB / issue #169: tablets keep the legacy value-based,
+        // orientation-gated split decision. Phones use the integrated portrait mode
+        // + separate landscape split, resolved into phoneSplitForced by
+        // PhoneKeyboardModePolicy in LIMEKeyboardSwitcher (portrait split is honored;
+        // landscape split uses phone_landscape_split unless Android arrow keys force the
+        // centre split required by the legacy arrow-key layout).
         boolean tablet = context.getResources().getConfiguration().smallestScreenWidthDp >= 600;
-        mSplitKeyboard = splitEligible
-                && ((mLandScape && mShowArrowKeys != 0)
-                || (mLandScape && splitKeyboard == SPLIT_KEYBOARD_LANDSCAPD_ONLY)
-                || (splitKeyboard == SPLIT_KEYBOARD_ALWAYS && (tablet || mLandScape)));
+        if (tablet) {
+            mSplitKeyboard = splitEligible
+                    && ((mLandScape && mShowArrowKeys != 0)
+                    || (mLandScape && splitKeyboard == SPLIT_KEYBOARD_LANDSCAPD_ONLY)
+                    || (splitKeyboard == SPLIT_KEYBOARD_ALWAYS && (tablet || mLandScape)));
+        } else {
+            mSplitKeyboard = splitEligible && phoneSplitForced;
+        }
 
         loadKeyboard(context, context.getResources().getXml(xmlLayoutResId));
     }

--- a/LimeStudio/app/src/main/java/org/limeime/keyboard/LIMEKeyboard.java
+++ b/LimeStudio/app/src/main/java/org/limeime/keyboard/LIMEKeyboard.java
@@ -89,7 +89,13 @@ public class LIMEKeyboard extends LIMEBaseKeyboard {
    // }
 
     public LIMEKeyboard(Context context, int xmlLayoutResId, int mode, float keySizeScale, int showArrowKeys, int splitKeyboard, boolean splitEligible ) {
-        super(context, xmlLayoutResId, mode, keySizeScale, showArrowKeys, splitKeyboard, splitEligible);
+        this(context, xmlLayoutResId, mode, keySizeScale, showArrowKeys, splitKeyboard, splitEligible, false);
+    }
+
+    // SPLIT_ONE_HAND_KB / issue #169: phoneSplitForced = phone split decision from
+    // PhoneKeyboardModePolicy (see LIMEKeyboardSwitcher.getKeyboard).
+    public LIMEKeyboard(Context context, int xmlLayoutResId, int mode, float keySizeScale, int showArrowKeys, int splitKeyboard, boolean splitEligible, boolean phoneSplitForced ) {
+        super(context, xmlLayoutResId, mode, keySizeScale, showArrowKeys, splitKeyboard, splitEligible, phoneSplitForced);
         if(DEBUG)
             Log.i(TAG, "LIMEKeyboard()");
         //Resources mRes = context.getResources();

--- a/LimeStudio/app/src/main/java/org/limeime/keyboard/PhoneKeyboardModePolicy.java
+++ b/LimeStudio/app/src/main/java/org/limeime/keyboard/PhoneKeyboardModePolicy.java
@@ -1,0 +1,48 @@
+package org.limeime.keyboard;
+
+/** Shared phone keyboard geometry semantics for migration and rendering. */
+public final class PhoneKeyboardModePolicy {
+    public static final int PORTRAIT_STANDARD = 0;
+    public static final int PORTRAIT_SPLIT = 1;
+    public static final int PORTRAIT_ONE_HAND_LEFT = 2;
+    public static final int PORTRAIT_ONE_HAND_RIGHT = 3;
+
+    private PhoneKeyboardModePolicy() {}
+
+    /**
+     * Issue #169: whether the integrated phone controls (直向鍵盤模式 /
+     * 橫向分離鍵盤 and one-hand rendering) apply. They apply to EVERY phone and
+     * NEVER to tablets — there is no screen-width or physical-size gate. Tablets
+     * (Android smallestScreenWidthDp &gt;= 600, iPad) use split_keyboard_mode /
+     * numpad_anchor instead.
+     */
+    public static boolean phoneControlsApply(boolean isTablet) {
+        return !isTablet;
+    }
+
+    public static int migratePortraitMode(int legacyOneHand, int legacySplit,
+                                          boolean legacyPhoneSplitSupported) {
+        if (legacyOneHand == 1) return PORTRAIT_ONE_HAND_LEFT;
+        if (legacyOneHand == 2) return PORTRAIT_ONE_HAND_RIGHT;
+        if (legacyPhoneSplitSupported && legacySplit == 1) return PORTRAIT_SPLIT;
+        return PORTRAIT_STANDARD;
+    }
+
+    public static boolean migrateLandscapeSplit(int legacySplit,
+                                                boolean legacyPhoneSplitSupported) {
+        return legacyPhoneSplitSupported && legacySplit != 0;
+    }
+
+    public static boolean phoneSplitActive(boolean landscape, boolean splitEligible,
+                                           int portraitMode, boolean landscapeSplit) {
+        if (!splitEligible) return false;
+        return landscape ? landscapeSplit : portraitMode == PORTRAIT_SPLIT;
+    }
+
+    public static int oneHandAnchorMode(boolean landscape, int portraitMode) {
+        if (landscape) return 0;
+        if (portraitMode == PORTRAIT_ONE_HAND_LEFT) return 1;
+        if (portraitMode == PORTRAIT_ONE_HAND_RIGHT) return 2;
+        return 0;
+    }
+}

--- a/LimeStudio/app/src/main/java/org/limeime/keyboard/ReachGeometry.java
+++ b/LimeStudio/app/src/main/java/org/limeime/keyboard/ReachGeometry.java
@@ -14,7 +14,6 @@ public final class ReachGeometry {
     public static final float SPLIT_KEY_MAX_MM = 13f;
     public static final float SPLIT_ROW_MAX_MM = 12f;
     public static final float ONE_HAND_MAX_W_MM = 60f;
-    public static final float ONE_HAND_GATE_MARGIN_MM = 4f;
     public static final float NUMPAD_KEY_MM = 14f;
     public static final float NUMPAD_ANCHOR_MAX_FRACTION = 0.40f;
 
@@ -34,12 +33,6 @@ public final class ReachGeometry {
         capped = Math.max(mmToPx(SPLIT_KEY_MIN_MM, xdpi),
                  Math.min(capped, mmToPx(SPLIT_KEY_MAX_MM, xdpi)));
         return Math.min(legacy, capped);
-    }
-
-    /** Gate: show/apply one-hand mode only when shrinking is meaningful (≈5.5"+). */
-    public static boolean oneHandAvailable(int screenWidthPx, float xdpi) {
-        return xdpi > 0
-                && screenWidthPx > mmToPx(ONE_HAND_MAX_W_MM + ONE_HAND_GATE_MARGIN_MM, xdpi);
     }
 
     public static int oneHandWidth(int displayWidthPx, float xdpi) {

--- a/LimeStudio/app/src/main/java/org/limeime/ui/LIMEPreference.java
+++ b/LimeStudio/app/src/main/java/org/limeime/ui/LIMEPreference.java
@@ -176,6 +176,16 @@ public class LIMEPreference extends AppCompatActivity {
 
 		@Override
 		public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+			// Issue #169: migrate the two phone geometry keys before XML inflation can persist
+			// their defaults and mask legacy split/one-hand values.
+			if (ctx == null) {
+				ctx = requireActivity().getApplicationContext();
+			}
+			mLIMEPref = new LIMEPreferenceManager(ctx);
+			boolean isTablet = getResources().getConfiguration().smallestScreenWidthDp >= 600;
+			if (!isTablet) {
+				mLIMEPref.ensurePhoneKeyboardPreferencesMigrated();
+			}
 			// Load the preferences from an XML resource (scoped to rootKey for nested PreferenceScreen drill-down)
 			setPreferencesFromResource(R.xml.preference, rootKey);
 
@@ -201,10 +211,6 @@ public class LIMEPreference extends AppCompatActivity {
 				}
 			}
 
-			if (ctx == null) {
-				ctx = requireActivity().getApplicationContext();
-			}
-			mLIMEPref = new LIMEPreferenceManager(ctx);
 			SearchSrv = new SearchServer(ctx);
 			configureReverseLookupPreferenceEntries();
 
@@ -217,13 +223,20 @@ public class LIMEPreference extends AppCompatActivity {
 				}
 			}
 
-			// SPLIT_ONE_HAND_KB: 單手鍵盤 = gated phones only; 數字鍵盤位置 = tablets only.
-			android.util.DisplayMetrics rdm = getResources().getDisplayMetrics();
-			boolean isTablet = getResources().getConfiguration().smallestScreenWidthDp >= 600;
-			androidx.preference.Preference oneHandPref = findPreference("one_hand_mode");
-			if (oneHandPref != null)
-				oneHandPref.setVisible(!isTablet && org.limeime.keyboard.ReachGeometry.oneHandAvailable(
-						Math.min(rdm.widthPixels, rdm.heightPixels), rdm.xdpi));
+			// Issue #169: phone portrait mode + phone landscape split apply to EVERY
+			// phone regardless of screen width (no width gate). Tablets
+			// (smallestScreenWidthDp >= 600) use split_keyboard_mode + numpad_anchor only.
+			boolean phoneControls =
+					org.limeime.keyboard.PhoneKeyboardModePolicy.phoneControlsApply(isTablet);
+			androidx.preference.Preference portraitModePref = findPreference("phone_portrait_keyboard_mode");
+			if (portraitModePref != null)
+				portraitModePref.setVisible(phoneControls);
+			androidx.preference.Preference landscapeSplitPref = findPreference("phone_landscape_split");
+			if (landscapeSplitPref != null)
+				landscapeSplitPref.setVisible(phoneControls);
+			androidx.preference.Preference splitPref = findPreference("split_keyboard_mode");
+			if (splitPref != null)
+				splitPref.setVisible(isTablet);
 			androidx.preference.Preference numpadAnchorPref = findPreference("numpad_anchor");
 			if (numpadAnchorPref != null)
 				numpadAnchorPref.setVisible(isTablet);

--- a/LimeStudio/app/src/main/java/org/limeime/ui/view/SegmentedHanPreference.java
+++ b/LimeStudio/app/src/main/java/org/limeime/ui/view/SegmentedHanPreference.java
@@ -96,33 +96,46 @@ public class SegmentedHanPreference extends Preference {
      * threshold. Shared by the 喜好設定 page and the keyboard long-press menu.
      */
     public static void stackIfClipped(@NonNull MaterialButtonToggleGroup group) {
-        group.post(() -> {
-            boolean clipped = false;
-            for (int i = 0; i < group.getChildCount(); i++) {
-                View child = group.getChildAt(i);
-                if (child instanceof Button) {
-                    android.text.Layout layout = ((Button) child).getLayout();
-                    if (layout != null) {
-                        int lines = layout.getLineCount();
-                        if (lines > 0 && layout.getEllipsisCount(lines - 1) > 0) {
-                            clipped = true;
-                            break;
-                        }
-                    }
-                }
+        group.post(() -> stackIfClippedNow(group));
+    }
+
+    public static void stackIfClippedNow(@NonNull MaterialButtonToggleGroup group) {
+        int requiredWidth = 0;
+        for (int i = 0; i < group.getChildCount(); i++) {
+            View child = group.getChildAt(i);
+            if (child instanceof Button && child.getVisibility() == View.VISIBLE) {
+                Button button = (Button) child;
+                requiredWidth += Math.ceil(button.getPaint().measureText(button.getText().toString()))
+                        + button.getCompoundPaddingLeft() + button.getCompoundPaddingRight();
             }
-            if (!clipped || group.getOrientation() == LinearLayout.VERTICAL) return;
-            group.setOrientation(LinearLayout.VERTICAL);
-            for (int i = 0; i < group.getChildCount(); i++) {
-                View child = group.getChildAt(i);
-                LinearLayout.LayoutParams lp =
-                        (LinearLayout.LayoutParams) child.getLayoutParams();
-                lp.width = LinearLayout.LayoutParams.MATCH_PARENT;
-                lp.height = LinearLayout.LayoutParams.WRAP_CONTENT;
-                lp.weight = 0;
-                child.setLayoutParams(lp);
+        }
+        if (requiredWidth <= group.getWidth() || group.getOrientation() == LinearLayout.VERTICAL) return;
+        if (group.getParent() instanceof LinearLayout) {
+            LinearLayout row = (LinearLayout) group.getParent();
+            if (row.getOrientation() == LinearLayout.HORIZONTAL) {
+                row.setOrientation(LinearLayout.VERTICAL);
+                LinearLayout.LayoutParams groupParams =
+                        (LinearLayout.LayoutParams) group.getLayoutParams();
+                float density = group.getResources().getDisplayMetrics().density;
+                groupParams.width = LinearLayout.LayoutParams.MATCH_PARENT;
+                groupParams.weight = 0;
+                groupParams.setMarginStart(0);
+                groupParams.topMargin = Math.round(10 * density);
+                group.setLayoutParams(groupParams);
+                group.post(() -> stackIfClippedNow(group));
+                return;
             }
-        });
+        }
+        group.setOrientation(LinearLayout.VERTICAL);
+        for (int i = 0; i < group.getChildCount(); i++) {
+            View child = group.getChildAt(i);
+            LinearLayout.LayoutParams lp =
+                    (LinearLayout.LayoutParams) child.getLayoutParams();
+            lp.width = LinearLayout.LayoutParams.MATCH_PARENT;
+            lp.height = LinearLayout.LayoutParams.WRAP_CONTENT;
+            lp.weight = 0;
+            child.setLayoutParams(lp);
+        }
     }
 
     private int buttonIdFor(String value) {

--- a/LimeStudio/app/src/main/res/layout/keyboard_menu_panel.xml
+++ b/LimeStudio/app/src/main/res/layout/keyboard_menu_panel.xml
@@ -64,7 +64,6 @@
                 android:id="@+id/han_toggle_group"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="44dp"
                 android:layout_marginTop="10dp"
                 app:singleSelection="true"
                 app:selectionRequired="true"
@@ -172,7 +171,6 @@
                 android:id="@+id/split_toggle_group"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="44dp"
                 android:layout_marginTop="10dp"
                 app:singleSelection="true"
                 app:selectionRequired="true"
@@ -241,7 +239,7 @@
             android:id="@+id/menu_portrait_mode_block"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
+            android:orientation="horizontal"
             android:visibility="gone"
             android:paddingStart="20dp"
             android:paddingEnd="20dp"
@@ -249,7 +247,7 @@
             android:paddingBottom="10dp">
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
@@ -272,10 +270,10 @@
 
             <com.google.android.material.button.MaterialButtonToggleGroup
                 android:id="@+id/portrait_mode_toggle_group"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="44dp"
-                android:layout_marginTop="10dp"
+                android:layout_marginStart="12dp"
+                android:layout_weight="1"
                 app:singleSelection="true"
                 app:selectionRequired="true"
                 xmlns:app="http://schemas.android.com/apk/res-auto">
@@ -391,7 +389,6 @@
                 android:id="@+id/landscape_split_toggle_group"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="44dp"
                 android:layout_marginTop="10dp"
                 app:singleSelection="true"
                 app:selectionRequired="true"
@@ -476,7 +473,6 @@
                 android:id="@+id/numpad_anchor_toggle_group"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="44dp"
                 android:layout_marginTop="10dp"
                 app:singleSelection="true"
                 app:selectionRequired="true"

--- a/LimeStudio/app/src/main/res/layout/keyboard_menu_panel.xml
+++ b/LimeStudio/app/src/main/res/layout/keyboard_menu_panel.xml
@@ -233,12 +233,12 @@
 
         </LinearLayout>
 
-        <!-- 單手鍵盤 — inline segmented control (關閉 / 靠左 / 靠右). Hidden unless the
-             screen is wide enough for one-hand shrinking to be meaningful (phones
-             only; ReachGeometry.oneHandAvailable gates it). -->
+        <!-- 直向鍵盤模式 — integrated phone portrait control (標準 / 分離 / 靠左 / 靠右),
+             issue #169. 分離 hidden for numpad layouts. Shown on every phone in portrait
+             regardless of screen width (no width gate). Phones only. -->
         <!-- ponytail: reuse split icon; swap for dedicated icons if ever drawn -->
         <LinearLayout
-            android:id="@+id/menu_onehand_block"
+            android:id="@+id/menu_portrait_mode_block"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
@@ -265,13 +265,13 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/one_hand_mode"
+                    android:text="@string/phone_portrait_keyboard_mode"
                     android:textAppearance="@style/LIME.Body" />
 
             </LinearLayout>
 
             <com.google.android.material.button.MaterialButtonToggleGroup
-                android:id="@+id/onehand_toggle_group"
+                android:id="@+id/portrait_mode_toggle_group"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="44dp"
@@ -281,7 +281,7 @@
                 xmlns:app="http://schemas.android.com/apk/res-auto">
 
                 <com.google.android.material.button.MaterialButton
-                    android:id="@+id/onehand_opt_off"
+                    android:id="@+id/portrait_opt_standard"
                     style="?attr/materialButtonOutlinedStyle"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -294,11 +294,11 @@
                     android:paddingStart="2dp"
                     android:paddingEnd="2dp"
                     android:maxLines="1"
-                    android:text="@string/one_hand_off"
+                    android:text="@string/portrait_mode_standard"
                     android:textAllCaps="false" />
 
                 <com.google.android.material.button.MaterialButton
-                    android:id="@+id/onehand_opt_left"
+                    android:id="@+id/portrait_opt_split"
                     style="?attr/materialButtonOutlinedStyle"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -311,11 +311,11 @@
                     android:paddingStart="2dp"
                     android:paddingEnd="2dp"
                     android:maxLines="1"
-                    android:text="@string/one_hand_left"
+                    android:text="@string/portrait_mode_split"
                     android:textAllCaps="false" />
 
                 <com.google.android.material.button.MaterialButton
-                    android:id="@+id/onehand_opt_right"
+                    android:id="@+id/portrait_opt_left"
                     style="?attr/materialButtonOutlinedStyle"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -328,7 +328,107 @@
                     android:paddingStart="2dp"
                     android:paddingEnd="2dp"
                     android:maxLines="1"
-                    android:text="@string/one_hand_right"
+                    android:text="@string/portrait_mode_left"
+                    android:textAllCaps="false" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/portrait_opt_right"
+                    style="?attr/materialButtonOutlinedStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:insetTop="0dp"
+                    android:insetBottom="0dp"
+                    android:minWidth="0dp"
+                    android:insetLeft="0dp"
+                    android:insetRight="0dp"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:maxLines="1"
+                    android:text="@string/portrait_mode_right"
+                    android:textAllCaps="false" />
+
+            </com.google.android.material.button.MaterialButtonToggleGroup>
+
+        </LinearLayout>
+
+        <!-- 橫向分離鍵盤 — binary phone landscape split (關閉 / 開啟), issue #169.
+             Independent of the portrait mode; hidden for numpad layouts. Phones only. -->
+        <LinearLayout
+            android:id="@+id/menu_landscape_split_block"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone"
+            android:paddingStart="20dp"
+            android:paddingEnd="20dp"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginEnd="20dp"
+                    android:tint="?attr/colorPrimary"
+                    android:src="@drawable/ic_split_24"
+                    android:contentDescription="@null" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/phone_landscape_split"
+                    android:textAppearance="@style/LIME.Body" />
+
+            </LinearLayout>
+
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/landscape_split_toggle_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="44dp"
+                android:layout_marginTop="10dp"
+                app:singleSelection="true"
+                app:selectionRequired="true"
+                xmlns:app="http://schemas.android.com/apk/res-auto">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/landscape_split_opt_off"
+                    style="?attr/materialButtonOutlinedStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:insetTop="0dp"
+                    android:insetBottom="0dp"
+                    android:minWidth="0dp"
+                    android:insetLeft="0dp"
+                    android:insetRight="0dp"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:maxLines="1"
+                    android:text="@string/split_keyboard_off"
+                    android:textAllCaps="false" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/landscape_split_opt_on"
+                    style="?attr/materialButtonOutlinedStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:insetTop="0dp"
+                    android:insetBottom="0dp"
+                    android:minWidth="0dp"
+                    android:insetLeft="0dp"
+                    android:insetRight="0dp"
+                    android:paddingStart="2dp"
+                    android:paddingEnd="2dp"
+                    android:maxLines="1"
+                    android:text="@string/split_keyboard_on"
                     android:textAllCaps="false" />
 
             </com.google.android.material.button.MaterialButtonToggleGroup>

--- a/LimeStudio/app/src/main/res/values/strings_settings.xml
+++ b/LimeStudio/app/src/main/res/values/strings_settings.xml
@@ -655,6 +655,14 @@
     <string name="one_hand_off">關閉</string>
     <string name="one_hand_left">靠左</string>
     <string name="one_hand_right">靠右</string>
+    <!-- Issue #169: integrated phone portrait keyboard mode (直向鍵盤模式) and phone
+         landscape split (橫向分離鍵盤). Phones only; no screen-width gate. -->
+    <string name="phone_portrait_keyboard_mode">直向鍵盤模式</string>
+    <string name="portrait_mode_standard">標準</string>
+    <string name="portrait_mode_split">分離</string>
+    <string name="portrait_mode_left">靠左</string>
+    <string name="portrait_mode_right">靠右</string>
+    <string name="phone_landscape_split">橫向分離鍵盤</string>
     <string name="numpad_anchor">數字鍵盤位置</string>
     <string name="numpad_anchor_fit">滿版</string>
     <string name="numpad_anchor_left">靠左</string>
@@ -709,6 +717,19 @@
         <item>0</item>
         <item>1</item>
         <item>2</item>
+    </string-array>
+    <!-- Issue #169: 直向鍵盤模式 (0=標準 1=分離 2=靠左 3=靠右). Phones only. -->
+    <string-array name="phone_portrait_keyboard_mode_options">
+        <item>@string/portrait_mode_standard</item>
+        <item>@string/portrait_mode_split</item>
+        <item>@string/portrait_mode_left</item>
+        <item>@string/portrait_mode_right</item>
+    </string-array>
+    <string-array name="phone_portrait_keyboard_mode_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
     </string-array>
     <string-array name="numpad_anchor_options">
         <item>@string/numpad_anchor_fit</item>

--- a/LimeStudio/app/src/main/res/xml/preference.xml
+++ b/LimeStudio/app/src/main/res/xml/preference.xml
@@ -85,15 +85,21 @@
             app:useSimpleSummaryProvider="true"
             android:layout="@layout/preference_value_chevron"
             android:title="@string/split_keyboard" />
+        <!-- Issue #169: integrated phone portrait mode + phone landscape split.
+             Phones only (gated in LIMEPreference), no screen-width gate. -->
         <ListPreference
             android:defaultValue="0"
-            android:dialogTitle="@string/one_hand_mode"
-            android:entries="@array/one_hand_mode_options"
-            android:entryValues="@array/one_hand_mode_values"
-            android:key="one_hand_mode"
+            android:dialogTitle="@string/phone_portrait_keyboard_mode"
+            android:entries="@array/phone_portrait_keyboard_mode_options"
+            android:entryValues="@array/phone_portrait_keyboard_mode_values"
+            android:key="phone_portrait_keyboard_mode"
             app:useSimpleSummaryProvider="true"
             android:layout="@layout/preference_value_chevron"
-            android:title="@string/one_hand_mode" />
+            android:title="@string/phone_portrait_keyboard_mode" />
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="phone_landscape_split"
+            android:title="@string/phone_landscape_split" />
         <ListPreference
             android:defaultValue="0"
             android:dialogTitle="@string/numpad_anchor"

--- a/LimeStudio/app/src/test/java/org/limeime/PhoneKeyboardModePolicyTest.java
+++ b/LimeStudio/app/src/test/java/org/limeime/PhoneKeyboardModePolicyTest.java
@@ -1,0 +1,97 @@
+package org.limeime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.limeime.keyboard.PhoneKeyboardModePolicy;
+
+public class PhoneKeyboardModePolicyTest {
+
+    @Test
+    public void androidMigrationRestoresLegacyPortraitSplit() {
+        assertEquals(PhoneKeyboardModePolicy.PORTRAIT_SPLIT,
+                PhoneKeyboardModePolicy.migratePortraitMode(0, 1, true));
+    }
+
+    @Test
+    public void explicitLegacyOneHandWinsOverLegacySplit() {
+        assertEquals(PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_LEFT,
+                PhoneKeyboardModePolicy.migratePortraitMode(1, 1, true));
+        assertEquals(PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_RIGHT,
+                PhoneKeyboardModePolicy.migratePortraitMode(2, 1, true));
+    }
+
+    @Test
+    public void landscapeOnlyDoesNotBecomePortraitSplit() {
+        assertEquals(PhoneKeyboardModePolicy.PORTRAIT_STANDARD,
+                PhoneKeyboardModePolicy.migratePortraitMode(0, 2, true));
+    }
+
+    @Test
+    public void iosMigrationDoesNotInventLegacyPhoneSplit() {
+        assertEquals(PhoneKeyboardModePolicy.PORTRAIT_STANDARD,
+                PhoneKeyboardModePolicy.migratePortraitMode(0, 1, false));
+        assertFalse(PhoneKeyboardModePolicy.migrateLandscapeSplit(1, false));
+    }
+
+    @Test
+    public void androidLandscapeMigrationPreservesEitherLegacySplitMode() {
+        assertTrue(PhoneKeyboardModePolicy.migrateLandscapeSplit(1, true));
+        assertTrue(PhoneKeyboardModePolicy.migrateLandscapeSplit(2, true));
+        assertFalse(PhoneKeyboardModePolicy.migrateLandscapeSplit(0, true));
+    }
+
+    @Test
+    public void portraitModesAreMutuallyExclusiveRenderingInputs() {
+        assertTrue(PhoneKeyboardModePolicy.phoneSplitActive(
+                false, true, PhoneKeyboardModePolicy.PORTRAIT_SPLIT, false));
+        assertFalse(PhoneKeyboardModePolicy.phoneSplitActive(
+                false, true, PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_LEFT, true));
+        assertEquals(1, PhoneKeyboardModePolicy.oneHandAnchorMode(
+                false, PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_LEFT));
+        assertEquals(2, PhoneKeyboardModePolicy.oneHandAnchorMode(
+                false, PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_RIGHT));
+        assertEquals(0, PhoneKeyboardModePolicy.oneHandAnchorMode(
+                false, PhoneKeyboardModePolicy.PORTRAIT_SPLIT));
+    }
+
+    @Test
+    public void landscapeUsesOnlyPhoneLandscapeSplit() {
+        assertTrue(PhoneKeyboardModePolicy.phoneSplitActive(
+                true, true, PhoneKeyboardModePolicy.PORTRAIT_STANDARD, true));
+        assertFalse(PhoneKeyboardModePolicy.phoneSplitActive(
+                true, true, PhoneKeyboardModePolicy.PORTRAIT_SPLIT, false));
+    }
+
+    @Test
+    public void numpadNeverSplitsButCanUsePortraitOneHand() {
+        assertFalse(PhoneKeyboardModePolicy.phoneSplitActive(
+                false, false, PhoneKeyboardModePolicy.PORTRAIT_SPLIT, true));
+        assertEquals(2, PhoneKeyboardModePolicy.oneHandAnchorMode(
+                false, PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_RIGHT));
+    }
+
+    // Issue #169: the integrated phone controls apply to EVERY phone and NEVER to
+    // tablets — there is no screen-width/physical-size gate anywhere.
+    @Test
+    public void phoneControlsApplyToEveryPhoneNeverTablets() {
+        assertTrue(PhoneKeyboardModePolicy.phoneControlsApply(false));
+        assertFalse(PhoneKeyboardModePolicy.phoneControlsApply(true));
+    }
+
+    // A narrow phone (previously below the removed one-hand width gate) still
+    // resolves its portrait one-hand anchor purely from the stored mode: width is
+    // not an input to any decision here.
+    @Test
+    public void narrowPhoneStillResolvesPortraitOneHandWithoutWidthGate() {
+        assertTrue(PhoneKeyboardModePolicy.phoneControlsApply(false));
+        assertEquals(1, PhoneKeyboardModePolicy.oneHandAnchorMode(
+                false, PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_LEFT));
+        assertEquals(2, PhoneKeyboardModePolicy.oneHandAnchorMode(
+                false, PhoneKeyboardModePolicy.PORTRAIT_ONE_HAND_RIGHT));
+        assertTrue(PhoneKeyboardModePolicy.phoneSplitActive(
+                false, true, PhoneKeyboardModePolicy.PORTRAIT_SPLIT, false));
+    }
+}

--- a/LimeStudio/app/src/test/java/org/limeime/ReachGeometryTest.java
+++ b/LimeStudio/app/src/test/java/org/limeime/ReachGeometryTest.java
@@ -27,18 +27,17 @@ public class ReachGeometryTest {
         assertEquals(Math.round(2560f / 17f), ReachGeometry.splitKeyWidth(2560, 10, 7, 0f));
     }
 
-    // 6.7"-class portrait: 1290 px @ 460 xdpi ≈ 71 mm wide → gate (64 mm) passes,
-    // one-hand width = 60 mm.
+    // 6.7"-class portrait: one-hand width = 60 mm.
     @Test
-    public void oneHandGateAndWidth() {
-        assertTrue(ReachGeometry.oneHandAvailable(1290, 460f));
+    public void oneHandWidthCapsLargePhoneAtSixtyMillimetres() {
         assertEquals(ReachGeometry.mmToPx(60f, 460f), ReachGeometry.oneHandWidth(1290, 460f));
     }
 
-    // mini-class: 1080 px @ 440 xdpi ≈ 62.3 mm → below the 64 mm gate.
+    // Every phone supports the mode. On a phone narrower than 60 mm, geometry clamps safely
+    // to the full available width rather than using a visibility/application gate.
     @Test
-    public void oneHandGateExcludesNarrowPhones() {
-        assertFalse(ReachGeometry.oneHandAvailable(1080, 440f));
+    public void oneHandWidthClampsToNarrowPhoneWidth() {
+        assertEquals(900, ReachGeometry.oneHandWidth(900, 440f));
     }
 
     // Large tablet: 5 × 14 mm = 70 mm wins under the 40% cap; small tablet: the

--- a/docs/#169_ISSUE.md
+++ b/docs/#169_ISSUE.md
@@ -77,9 +77,14 @@ preserves one-hand but never invents a legacy iPhone split).
   two prefs in `loadSettings()`.
 - Rendering (`KeyboardViewController` layout): iPhone split from `PhoneKeyboardModePolicy.splitActive`;
   one-hand anchor from `oneHandAnchor`. **`oneHandAvailable` gate removed** — `oneHandWidth` still
-  clamps. Chevron restore resets the portrait mode to standard.
+  clamps. Chevron restore resets the portrait mode to standard. Phone split key width follows
+  Android's reserved-column model (2 portrait / 3 landscape); the existing iPad 66 mm reach cap
+  is unchanged.
 - Globe menu: 直向鍵盤模式 (portrait) / 橫向分離鍵盤 (landscape) on every iPhone; iPad split / numpad
-  anchor unchanged.
+  anchor unchanged. Segmented rows render horizontally on iPhone landscape so the short keyboard
+  can show the complete menu; portrait and iPad retain stacked rows.
+- Dual-label split keys choose top/bottom versus left/right from their actual rendered half width,
+  so tall narrow phone keys keep the Latin hint above the Chinese label.
 - Transport: `PrefInbox` + `RelayPrefState` carry `phonePortraitMode` / `phoneLandscapeSplit`; the
   FA-off text relay carries `pp=` / `pls=` and `RelayPrefSync.apply` writes them cold so a globe-menu
   change reaches the settings app with Full Access off.
@@ -100,10 +105,11 @@ preserves one-hand but never invents a legacy iPhone split).
   Android/iOS migration, startup-cache invalidation, and tablet profile isolation.
 - Phone and simulated `smallestScreenWidthDp >= 600` settings visibility were verified from live
   emulator UI dumps.
-- iOS source and Xcode project-reference contracts pass. **Swift/Xcode compilation was not
-  available on this Linux host**; iPhone/iPad XCTest and visual verification remain CI/device gates.
+- iOS focused XCTest passed on the LimeTest-iPhone16 simulator: 12 `ReachGeometryTests` plus the
+  landscape-menu and split dual-label regression tests (14 total, 0 failed). Device layout was
+  manually verified by the user; automated visual verification was intentionally skipped.
 
 ## Non-goals
 
-Geometry only. No emoji-panel width change, no per-orientation memory, no new iPad email/URL
-layouts. Tablet split reach-cap and numpad anchoring (Features A/C) are unchanged by this issue.
+No emoji-panel width change, no per-orientation memory, no new iPad email/URL layouts. Tablet split
+reach-cap and numpad anchoring (Features A/C) are unchanged by this issue.

--- a/docs/#169_ISSUE.md
+++ b/docs/#169_ISSUE.md
@@ -1,0 +1,109 @@
+# Issue #169 — Integrated phone portrait keyboard model (no width gate)
+
+Branch: `fix/169-integrated-phone-portrait-mode`
+Last updated: 2026-07-19
+
+## Problem
+
+v6.1.33 exposed `split_keyboard_mode` and `one_hand_mode` as two independent phone settings and
+made phone split landscape-only. That broke the legacy portrait-split contract and allowed
+contradictory stored choices (split + one-hand both "on"). An earlier redesign also gated the
+one-hand option behind a screen-width threshold (`ReachGeometry.oneHandAvailable`, ≈5.5"+), so the
+control silently disappeared on narrower phones.
+
+## Authoritative requirement (supersedes the earlier ≈5.5"+ gate)
+
+- **Remove ALL phone-width / physical-size gating** for the integrated phone preference and
+  one-hand application.
+- The integrated phone preferences apply to **every Android phone and every iPhone**, regardless
+  of screen width. The phone controls are always shown on phone-class devices.
+- Android devices classified as tablets (`smallestScreenWidthDp >= 600`, ≈7"+) use the existing
+  tablet mode only — never the phone controls.
+- Every iPad uses the existing iPad split / numpad model only — never the phone controls.
+- `ReachGeometry.oneHandWidth` keeps clamping to the available width. The old
+  `ReachGeometry.oneHandAvailable` gate is removed rather than retained as dormant policy.
+
+## Canonical shared keys/values (Android ↔ iOS identical)
+
+| Key | Type / values | Scope |
+|---|---|---|
+| `phone_portrait_keyboard_mode` | int: 0 standard, 1 split, 2 one-hand left, 3 one-hand right | every phone |
+| `phone_landscape_split` | bool | every phone |
+| `split_keyboard_mode` | int: 0 off, 1 always, 2 landscape-only | Android tablet ≥600dp / iPad only |
+| `numpad_anchor` | int: 0 fit, 1 left, 2 right, 3 center | Android tablet ≥600dp / iPad only |
+
+`split_keyboard_mode` / `numpad_anchor` are the tablet/iPad profile keys and are **never**
+rewritten by phone changes. `one_hand_mode` / legacy `split_keyboard_mode` remain migration input
+only.
+
+## Shared policy
+
+`PhoneKeyboardModePolicy` is implemented twice with identical semantics so phone behaviour and key
+values align across platforms:
+
+- Android: `LimeStudio/app/src/main/java/org/limeime/keyboard/PhoneKeyboardModePolicy.java`
+- iOS: `LimeIME-iOS/Shared/Models/PhoneKeyboardModePolicy.swift` (pure logic, no UIKit; added to
+  the LimeIME app, LimeKeyboard extension, and LimeTests targets)
+
+Functions: `migratePortraitMode`, `migrateLandscapeSplit`, `splitActive`, `oneHandAnchor`,
+`phoneControlsApply(isTablet/isPad)`.
+
+Migration precedence (both platforms): legacy one-hand left/right wins → else legacy split
+`always` (Android only) → else standard. `legacyPhoneSplitSupported` is **true** on Android
+(legacy portrait split existed) and **false** on iOS (iPhone split was never shipped, so migration
+preserves one-hand but never invents a legacy iPhone split).
+
+## Delivery
+
+### Android
+- `PhoneKeyboardModePolicy.java` + one-time migration accessors in `LIMEPreferenceManager`
+  (`getPhonePortraitKeyboardMode` / `getPhoneLandscapeSplit`, writing canonical keys on first read).
+- Rendering: `LIMEKeyboardSwitcher.getKeyboard` resolves phone vs tablet; phone split + one-hand
+  anchor come from the policy. `LIMEBaseKeyboard` gained a `phoneSplitForced` constructor param;
+  tablets keep the legacy value-based split. **The `oneHandAvailable` helper and render gate were removed.**
+- In-keyboard menu (`LIMEService.handleOptions`): 直向鍵盤模式 (4-seg, 分離 hidden for numpad) in
+  phone portrait; 橫向分離鍵盤 (binary) in phone landscape; tablet split / numpad anchor unchanged.
+  **No width gate.** Chevron restore sets `phone_portrait_keyboard_mode = 0`.
+- Settings: `preference.xml` replaces the one-hand ListPreference with a 直向鍵盤模式 ListPreference
+  + a 橫向分離鍵盤 switch; `LIMEPreference` shows phone controls on every phone (no width gate) and
+  gates `split_keyboard_mode` / `numpad_anchor` to tablets. Strings/arrays in `strings_settings.xml`.
+- Backup: `PreferenceBackupAdapter` adds `phone_portrait_keyboard_mode` + `phone_landscape_split`.
+- Tests: `PhoneKeyboardModePolicyTest` (10 unit tests incl. narrow-phone no-gate),
+  `PhoneKeyboardPreferenceMigrationTest` (instrumentation), `ReachGeometryTest` (6).
+
+### iOS
+- `PhoneKeyboardModePolicy.swift` + cold accessors in `LIMEPreferenceManager.swift`.
+- Hot store: `seededHotInt(_:cold:migrate:)` / `seededHotBool(_:cold:migrate:)` seed + migrate the
+  two prefs in `loadSettings()`.
+- Rendering (`KeyboardViewController` layout): iPhone split from `PhoneKeyboardModePolicy.splitActive`;
+  one-hand anchor from `oneHandAnchor`. **`oneHandAvailable` gate removed** — `oneHandWidth` still
+  clamps. Chevron restore resets the portrait mode to standard.
+- Globe menu: 直向鍵盤模式 (portrait) / 橫向分離鍵盤 (landscape) on every iPhone; iPad split / numpad
+  anchor unchanged.
+- Transport: `PrefInbox` + `RelayPrefState` carry `phonePortraitMode` / `phoneLandscapeSplit`; the
+  FA-off text relay carries `pp=` / `pls=` and `RelayPrefSync.apply` writes them cold so a globe-menu
+  change reaches the settings app with Full Access off.
+- Settings (`PreferencesTabView`): 直向鍵盤模式 Picker + 橫向分離鍵盤 Toggle gated `!= .pad` only
+  (no width gate); cold migration in `migrateRemovedPreferences`.
+- Backup/restore: `PreferenceBackupAdapter` specs, hot→cold flush (`TableSyncEngine`), restore push
+  (`DBManagerView.pushRestoredPrefsToInbox`).
+- Tests: `ReachGeometryTests` (policy contract + narrow-phone no-gate + `phoneControlsApply`),
+  `RelayPayloadTest` + `SyncContractTest` (phone-pref round-trips + `RelayPrefSync.apply`).
+
+## Verification status
+
+- Android full gate passed on the Pixel 9 Pro AVD:
+  - `:app:testDebugUnitTest`
+  - `:app:lintDebug`
+  - `:app:connectedDebugAndroidTest` (1,207 executed test cases, 8 skipped, 0 failed)
+- Focused phone migration + backup/restore instrumentation: 14 tests passed, including legacy
+  Android/iOS migration, startup-cache invalidation, and tablet profile isolation.
+- Phone and simulated `smallestScreenWidthDp >= 600` settings visibility were verified from live
+  emulator UI dumps.
+- iOS source and Xcode project-reference contracts pass. **Swift/Xcode compilation was not
+  available on this Linux host**; iPhone/iPad XCTest and visual verification remain CI/device gates.
+
+## Non-goals
+
+Geometry only. No emoji-panel width change, no per-orientation memory, no new iPad email/URL
+layouts. Tablet split reach-cap and numpad anchoring (Features A/C) are unchanged by this issue.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5,6 +5,19 @@ Public backlog for confirmed unresolved fixes and product work. Issue-specific i
 Last reviewed: 2026-07-19
 
 ## Pending fixes
+
+- fix#169 Android+iOS integrated phone portrait keyboard model: implemented on branch
+  `fix/169-integrated-phone-portrait-mode`. Replaces the v6.1.33 contradictory
+  `split_keyboard_mode` + `one_hand_mode` phone pair with one integrated
+  `phone_portrait_keyboard_mode` (0 標準 / 1 分離 / 2 靠左 / 3 靠右) plus a separate
+  `phone_landscape_split` boolean shared between Android and iOS. All phone-width/physical-size
+  gating is removed: the phone controls apply to every Android phone
+  (`smallestScreenWidthDp < 600`) and every iPhone. Android tablets
+  (`smallestScreenWidthDp >= 600`) and every iPad keep the independent tablet split / numpad
+  profile. Covers migration, settings UI, in-keyboard menus, rendering, chevron restore,
+  backup/restore, and iOS cold/hot PrefInbox + relay transport. The full Android unit/lint/device
+  gate passes; iPhone/iPad XCTest and visual validation remain pending because Swift/Xcode is not
+  available on the Linux host. See `docs/#169_ISSUE.md` and `docs/SPLIT_ONE_HAND_KB.md`.
 - fix#161 Android+iOS follow-up: the reporter confirmed Android GitHub APK v6.1.33 fixes escaped `pword` prefix search and immediate related-candidate refresh after manual add/update/delete. PR #168 merged the separate Android filtered-management-list deletion refresh fix as `285b9fde57384203c074f9b16094f2bdc757a3c6`, but v6.1.33 predates that merge, so Android remains pending a newer APK/Google Play build and reporter verification of the deletion flow. iOS source includes the corresponding management/runtime/cache-reset changes but still needs corrected-source XCTest/Xcode Cloud validation and a verified newer TestFlight/App Store build. See `docs/#161_ISSUE.md`.
 
 ## Product work

--- a/docs/SPLIT_ONE_HAND_KB.md
+++ b/docs/SPLIT_ONE_HAND_KB.md
@@ -10,8 +10,10 @@ can actually reach.
    (two-thumb) operation. Current iPad split keys are too wide — key width should be computed
    from the area an ordinary thumb can reach while gripping the device left and right, both
    horizontally and vertically, for 7" / 11" / 13" classes.
-2. Larger phones (≈5.5"+): add a one-handed layout option that shrinks and anchors the keyboard
-   left or right, sized to the one-thumb reach zone.
+2. Phones: add a one-handed layout option that shrinks and anchors the keyboard left or right,
+   sized to the one-thumb reach zone. (Originally scoped to ≈5.5"+ phones; issue #169 removed
+   that width gate — the option now applies to **every** phone, and the width helper only clamps
+   the block to the available screen width.)
 3. Tablet/iPad numpad-based layouts (phone numpad, computer numpad, restricted numeric fields):
    these are one-handed by nature and should get an anchor option — left / right / center /
    fit (current full-width style) — with key size from real one-hand reach geometry.
@@ -31,9 +33,12 @@ proposal, all shipped:
   current keyboard without dismissing the IME (`LIMEService.applyGeometryChangeInPlace()` +
   `LIMEKeyboardSwitcher.rebuildCurrentKeyboard()`; originally `handleClose()` was called, which
   `requestHideSelf`'d the whole keyboard).
-- **Phone split is landscape-only** (render gate in `LIMEBaseKeyboard`), and the keyboard menu is
-  orientation-gated on phones: portrait shows 單手鍵盤 only, landscape shows 分離鍵盤 only as a
-  binary 關閉/開啟. See the eligibility matrix below.
+- **Phone geometry is being corrected after #169**. v6.1.33 made phone split landscape-only and
+  exposed `split_keyboard_mode` and `one_hand_mode` as independent settings. That broke the legacy
+  portrait split contract and allowed contradictory stored choices. The replacement design uses
+  one integrated, mutually exclusive portrait mode plus a separate phone-landscape split boolean.
+  Tablet split remains in its existing portable tablet preference. See the migration and
+  eligibility sections below.
 - **iOS split partition matches Android** — `SplitPartition.partition` (`KeyLayout.swift`) splits
   at floor(columns/2) standard columns and clones a border-crossing wide key (space) onto both
   halves, replacing the old 50%-cumulative rule that put the whole space bar in the left half.
@@ -96,7 +101,7 @@ expect tuning after on-device trials; do not scatter the numbers):
 | `SPLIT_KEY_MIN_MM` / `SPLIT_KEY_MAX_MM` | 9 / 13 | clamp for alphabetic split key width |
 | `SPLIT_ROW_MAX_MM` | 12 | split-mode row-height cap (vertical thumb sweep, 4 rows ≤ ~50 mm) |
 | `REACH_ONE_HAND_MM` | 60 | comfortable one-thumb zone radius from a bottom-corner grip |
-| `ONE_HAND_MAX_W_MM` | 60 | = `REACH_ONE_HAND_MM` — the far column center of 10 columns sits at ≈ 9.5/10 × 60 = 57 mm, inside the 60 mm zone; the earlier 63 + the 4 mm gate margin would have excluded 6.1" phones (~65 mm) that the acceptance criteria include |
+| `ONE_HAND_MAX_W_MM` | 60 | = `REACH_ONE_HAND_MM` — target one-hand block width. `oneHandWidth` clamps this to the available screen width, so a narrow phone simply renders full width. This is a **width clamp only, never a gate**: the one-hand mode is offered and applied on every phone regardless of screen width (issue #169). |
 | `NUMPAD_KEY_MM` | 14 | tap-target size for anchored numpad keys (finger tap, not thumb grip) |
 | `NUMPAD_ANCHOR_MAX_FRACTION` | 0.40 | anchored numpad never exceeds 40% of screen width |
 
@@ -138,9 +143,13 @@ Platform notes:
   (`KeyboardViewController.swift:1618-1670`) — observe the #139 geometry-change rules in
   `docs/IOS_KB_HEIGHT.md`; no new height writers.
 
-## Feature B — phone one-handed mode (≈5.5"+)
+## Feature B — integrated phone portrait geometry (all phones)
 
-New pref `one_hand_mode`: `0` off (default), `1` left, `2` right. Phone only.
+Canonical pref `phone_portrait_keyboard_mode`: `0` standard (default), `1` split, `2` one-hand
+left, `3` one-hand right. **Every phone, no screen-width gate** (issue #169) — applies to every
+Android phone (`smallestScreenWidthDp < 600`) and every iPhone regardless of width. These are
+mutually exclusive because split and one-hand both own the same horizontal key geometry and
+candidate insets.
 
 Behavior: the key area shrinks horizontally to `mm2units(ONE_HAND_MAX_W_MM)` and anchors to the
 chosen edge. Horizontal-only transform: keyboard height, candidate bar width, and emoji panel are
@@ -150,27 +159,32 @@ width and the setting persists.
 
 UI style — replicate the iOS built-in one-handed keyboard: the vacated strip shows a single
 chevron arrow (`❮` when anchored right, `❯` when anchored left), vertically centered, pointing
-toward the empty side. Tapping the arrow restores full width by setting `one_hand_mode = 0`
-(persisted — on iOS written to the hot store exactly like a globe-menu change, so the choice
-survives keyboard restarts and relays back to the settings app). The strip is otherwise plain
-keyboard background. Same style on both platforms.
+toward the empty side. Tapping the arrow restores full width by setting
+`phone_portrait_keyboard_mode = 0` (persisted — on iOS written to the hot store exactly like a
+globe-menu change, so the choice survives keyboard restarts and relays back to the settings app).
+The strip is otherwise plain keyboard background. Same style on both platforms.
 
-Availability is self-gating by geometry, not by a device whitelist: show the option (and apply the
-mode) only when `screenWidthMm ≥ ONE_HAND_MAX_W_MM + 4`. In practice that is ≈5.5"+ phones
-(iPhone Plus/Pro Max class, 6.1"+ standard iPhones, most 5.5"+ Androids) and naturally excludes
-iPhone mini/SE-width devices where shrinking would be pointless.
+Availability: shown and applied on **every phone**, with **no screen-width or physical-size
+gate** (issue #169). The one-hand width helper (`ReachGeometry.oneHandWidth`) still clamps the
+block to the available width, so on a narrow phone the block simply renders full width (empty
+strip = 0, no chevron) while the mode is always honored. There is no separate availability helper.
+Device class is the only distinction: Android tablets (`smallestScreenWidthDp >= 600`, ≈7"+) and every iPad use the
+tablet split / numpad-anchor model instead and never show the phone controls.
 
 Example: 6.7" phone, screen ~71 mm wide → key block ~60 mm (~85%), leaving a ~11 mm reach-relief
 strip; 10-column key width drops to ~6 mm so the far column center lands inside the 60 mm
-one-thumb zone.
+one-thumb zone. On a narrow 4.7" phone the 60 mm target exceeds the screen, so the block clamps
+to full width and the mode is a no-op visually — but it is still offered and stored, never gated.
 
-Scope on phone: applies to **all** layouts, including numpad-based ones (they shrink and anchor
-the same way). Precedence: if Android split is active (phone landscape), split wins and one-hand
-is ignored for that keyboard instance.
+Scope on phone: one-hand applies to **all portrait layouts**, including numpad-based ones. Portrait
+split applies only to split-eligible alphabetic/per-IM layouts; numpad layouts remain unsplit.
+Landscape never reads the portrait mode: it uses `phone_landscape_split`, and numpad layouts remain
+excluded. No precedence rule is needed because one keyboard instance reads only one canonical mode.
 
 Platform notes:
 
-- **Android**: apply as a width scale + x-offset at keyboard build time in `LIMEBaseKeyboard`
+- **Android**: migrate the legacy `one_hand_mode` / `split_keyboard_mode` pair once, then apply the
+  integrated portrait mode at keyboard build time in `LIMEBaseKeyboard`
   (same shape as the split right-half shift: scale each key's width/x by
   `oneHandWidth / displayWidth`, then add `displayWidth − oneHandWidth` when anchored right).
   Recreate keyboards on pref change like `LIMEService.java:912/1042` does for split.
@@ -213,59 +227,87 @@ for these layouts). `numpad_anchor` is the only geometry pref that applies to th
 
 | Device / layout | Alphabetic & per-IM layouts | Numpad-based layouts |
 |---|---|---|
-| Phone < gate width | (unchanged) | (unchanged) |
-| Phone ≥ gate width | portrait `one_hand_mode`; landscape split | portrait `one_hand_mode`; landscape split |
-| Tablet / iPad | `split_keyboard_mode` (reach-capped, Feature A) | `numpad_anchor` (Feature C); split ignored |
+| **Any phone** (Android `smallestScreenWidthDp < 600`, every iPhone) | portrait `phone_portrait_keyboard_mode`; landscape `phone_landscape_split` | portrait standard/one-hand only; landscape full width |
+| **Android tablet** (`smallestScreenWidthDp >= 600`, ≈7"+) / **iPad** | `split_keyboard_mode` (reach-capped, Feature A) | `numpad_anchor` (Feature C); split ignored |
 
-Phone split renders in **landscape only**, whatever `split_keyboard_mode` holds — a stored
-開啟 (always) behaves like 僅橫向. Portrait phone split keys would fall below `SPLIT_KEY_MIN_MM`;
-phone portrait geometry belongs to one-hand mode. Stored values are honored, not migrated.
+There is **no phone-width gate**: every phone shows and applies the phone controls. The only
+distinction is device class (phone vs Android tablet ≥600dp vs iPad). Phones never expose
+`split_keyboard_mode` / `numpad_anchor`; tablets/iPads never expose the phone controls.
+
+Phone portrait split remains available for backward compatibility. The integrated mode makes it
+mutually exclusive with one-hand. Phone landscape split is independent. A portrait split user may
+therefore keep the legacy two-thumb layout, while a one-hand user chooses an anchored side without
+creating a conflicting pair of enabled preferences.
 
 ## Preferences and surfaces
 
-Two new prefs, both exposed in app settings and the in-keyboard menu:
+Shared Android/iOS canonical geometry prefs exposed in app settings and the in-keyboard menu:
 
 | Key | Values | Shown when |
 |---|---|---|
-| `one_hand_mode` | 0 off / 1 left / 2 right | phone with `screenWidthMm ≥ ONE_HAND_MAX_W_MM + 4` |
+| `phone_portrait_keyboard_mode` | 0 standard / 1 split / 2 left / 3 right | every phone (no width gate) |
+| `phone_landscape_split` | false / true | every phone (no width gate) |
+| `split_keyboard_mode` | 0 off / 1 always / 2 landscape-only | Android tablet ≥600dp / iPad only |
 | `numpad_anchor` | 0 fit / 1 left / 2 right / 3 center | tablet / iPad |
 
-Presentation: `one_hand_mode` replicates the existing `split_keyboard_mode` presentation
-everywhere — same list-preference style in the settings app (Android `preference.xml` entry,
-iOS LimeSettings row) and same segmented-row style in the keyboard-side popup menu.
+Presentation: phone portrait uses one integrated list/segmented control named **直向鍵盤模式**
+(標準/分離/靠左/靠右). Phone landscape uses a binary **橫向分離鍵盤** control.
 `numpad_anchor` uses the same segmented style with four options.
 
 Keyboard-side menu exclusivity — split and anchor are never shown together; the menu keys off
 the **currently active layout**, not just the device:
 
 - Ordinary (alphabetic / per-IM) layout active → tablet: 分離鍵盤 (tri-state); phone
-  portrait: 單手鍵盤 only (gated); phone landscape: 分離鍵盤 only, as a **binary**
-  關閉/開啟 control (split renders landscape-only on phones, so 開啟 ≡ 僅橫向; a stored
-  僅橫向 lights 開啟). Hide 數字鍵盤位置.
-- Numpad-based layout active → show 數字鍵盤位置 only; hide 分離鍵盤. On phones there is no
-  `numpad_anchor` — the numpad follows `one_hand_mode`, so the phone 單手鍵盤 row stays.
+  portrait: 直向鍵盤模式 (standard/split/left/right); phone landscape: 橫向分離鍵盤
+  (off/on). Hide 數字鍵盤位置.
+- Numpad-based layout active → show 數字鍵盤位置 only on tablets and hide split. On phones there
+  is no `numpad_anchor`: portrait exposes the integrated mode without the split choice, and
+  landscape stays full width because numpads are split-ineligible.
 
 The settings app shows all prefs applicable to the device (it has no "active layout" context);
 the exclusivity rule is a keyboard-menu rule only.
 
-- **Android**: entries in `res/xml/preference.xml` next to `split_keyboard_mode` (`:81-87`);
-  accessors in `LIMEPreferenceManager`; segmented rows in `handleOptions()` following the
-  存在的 分離鍵盤 block pattern (`LIMEService.java:3733-3750`), gated per the table above; applied
+- **Android**: device-scoped entries in `res/xml/preference.xml`; accessors and one-time migration
+  in `LIMEPreferenceManager`; integrated segmented rows in `handleOptions()`, gated per the table
+  above; applied
   on dialog dismiss via `applyGeometryChangeInPlace()` — an in-place rebuild
   (`rebuildCurrentKeyboard()`), NOT `handleClose()`, which would dismiss the IME.
-- **iOS**: both are **cold/hot prefs** — clone the `split_keyboard_mode` wiring end to end:
-  cold in App Group defaults + LimeSettings UI; hot via `seededHotInt` next to `:1260`; add
-  `oneHandMode` / `numpadAnchor` fields to `PrefInbox` and `drainPrefInbox()`
-  (`KeyboardViewController.swift:1164-1198`); write back through `relay-prefs.json`; segmented
-  entries in `showGlobeMenu` next to 分離鍵盤 (`:4432-4439`), with `one_hand_mode` gated
-  `!isOnPad` (+ width gate) and `numpad_anchor` gated `isOnPad`.
+- **iOS**: use the same key names and values as Android. Both phone keys are **cold/hot prefs**:
+  App Group defaults + LimeSettings UI, hot via `seededHotInt`, app→keyboard `PrefInbox` drain,
+  and keyboard→app relay writeback. iPhone uses the same portrait and landscape choices as an
+  Android phone. iPad continues to use `split_keyboard_mode` and `numpad_anchor`.
 
-User-facing names — the two prefs are deliberately named differently so the tablet numpad
-option is never confused with the real phone one-handed mode:
+User-facing names:
 
-- `one_hand_mode` → **單手鍵盤** (關/靠左/靠右), phones only.
+- `phone_portrait_keyboard_mode` → **直向鍵盤模式** (標準/分離/靠左/靠右), phones only.
+- `phone_landscape_split` → **橫向分離鍵盤** (關閉/開啟), phones only.
+- `split_keyboard_mode` → **分離鍵盤**, tablets/iPads only.
 - `numpad_anchor` → **數字鍵盤位置** (滿版/靠左/置中/靠右), tablets only; 滿版 is the
   fit/current-style default.
+
+### Migration and portability
+
+The old pair is migration input only on phones:
+
+```text
+split_keyboard_mode = 0 off / 1 always / 2 landscape-only
+one_hand_mode       = 0 off / 1 left / 2 right
+```
+
+When `phone_portrait_keyboard_mode` is absent, migrate once with deterministic precedence:
+
+1. old one-hand left/right → new left/right
+2. otherwise old split `always` → new portrait split
+3. otherwise → standard
+
+When `phone_landscape_split` is absent, Android derives it from old split being nonzero. iOS
+defaults it off because iPhone split did not previously exist. Migration writes both canonical
+keys even when they hold defaults, so key presence is the migration marker.
+
+Phone changes never rewrite `split_keyboard_mode`: that key belongs to the tablet/iPad profile.
+Backups include all four canonical keys. Phone keys remain dormant on tablets, and tablet keys
+remain dormant on phones, so restoring the same backup between form factors preserves both
+profiles without trying to map one-hand geometry onto a tablet.
 
 ## Chrome alignment with the anchored block
 
@@ -297,14 +339,19 @@ When the key block is horizontally anchored (one-hand mode, numpad anchor):
 - 11" and 13" iPad landscape split halves are ≤ 66 mm physical with 13 mm keys; iPad mini split
   changes only marginally; no regression when split is off.
 - Android xlarge-land split keys land in the 9–13 mm band (verify at 160/240/320 dpi buckets).
-- One-hand mode on a 6.1"+ phone anchors correctly left and right, is unavailable (hidden) on
-  narrow phones, and never coexists with an active split.
+- The integrated portrait mode offers standard/split/left/right as mutually exclusive choices on
+  Android and iOS phones. All four choices are available on **every** phone regardless of screen
+  width — there is no gate. On a narrow phone the one-hand block clamps to full width (no visible
+  shrink) but the choice is still offered, stored, and honored.
+- Device class is the only distinction: Android tablets (`smallestScreenWidthDp >= 600`) and every
+  iPad use the tablet split / numpad-anchor model and never show the phone controls.
 - One-hand empty strip shows the restore chevron (iOS built-in style); tapping it sets
-  `one_hand_mode = 0`, persists (iOS hot store + relay), and restores full width immediately.
-- Keyboard-side menu exclusivity: ordinary layout shows split (or one-hand) and never anchor;
-  numpad-based layout shows anchor and never split.
-- `one_hand_mode` UI matches `split_keyboard_mode` presentation in both the settings app and
-  the keyboard menu.
+  `phone_portrait_keyboard_mode = 0`, persists through each platform's normal preference transport,
+  and restores full width immediately.
+- Keyboard-side menu exclusivity: phone portrait uses one integrated mode control; tablet/iPad
+  numpad layouts show anchor and never split.
+- Phone portrait and landscape controls use the same names, values, and persisted keys on Android
+  and iOS. Tablet/iPad split and numpad preferences remain independent and portable.
 - Anchored numpad on iPad: left/right/center/fit all render, keys ≈14 mm square, `fit`
   pixel-identical to today.
 - Numpad-based layouts never render split regardless of `split_keyboard_mode`.
@@ -333,9 +380,9 @@ Phase 3 — Feature C (numpad anchoring, tablets)
 - [x] Menu entries: Android options panel row; iOS globe menu segmented (iPad-gated), shown
       only when the active layout is numpad-based (split row hidden in that case)
 
-Phase 4 — Feature B (phone one-hand)
-- [x] `one_hand_mode` pref both platforms (iOS cold/hot clone), geometry-gated visibility,
-      settings-app UI replicating the `split_keyboard_mode` row
+Phase 4 — Feature B original v6.1.33 implementation (superseded by Phase 6)
+- [x] Original separate `one_hand_mode` pref on both platforms; replaced by the integrated
+      all-phone model in Phase 6
 - [x] Width scale + anchor at keyboard build (Android) / container inset (iOS); phone split is
       landscape-only so portrait always belongs to one-hand
 - [x] Restore chevron in the empty strip (both platforms): tap → `one_hand_mode = 0`, persist +
@@ -351,3 +398,21 @@ Phase 5 — verification
 - [ ] Android tablet AVD: split reach-cap + numpad anchors
 - [x] iOS: build gate + unit gate (`ReachGeometryTests` incl. split-partition tests) PASS
 - [ ] iOS: `ios-visual-verify` on iPhone and iPad simulators, Full-Access-off pref transport check
+
+Phase 6 — #169 integrated phone model correction (width gate removed — every phone, no gate)
+- [x] Shared policy `PhoneKeyboardModePolicy` (Android + Swift), RED/GREEN unit tests incl.
+      narrow-phone no-gate proof (`phoneControlsApply`, `oneHandAnchor` width-independent)
+- [x] Android: RED/GREEN migration tests (legacy split-only → portrait split + landscape split;
+      one-hand wins; landscape-only ≠ portrait split; conflicting/default); tablet split key never
+      rewritten (`PhoneKeyboardModePolicyTest`, `PhoneKeyboardPreferenceMigrationTest`)
+- [x] Android: replaced phone settings/menu rows with 直向鍵盤模式 (4-seg) and 橫向分離鍵盤
+      (binary); `split_keyboard_mode` gated to tablets; **no width gate** anywhere
+- [x] Android: removed `ReachGeometry.oneHandAvailable` gating from render (`LIMEKeyboardSwitcher`),
+      menu (`handleOptions`), and settings visibility (`LIMEPreference`)
+- [x] iOS: matching canonical keys/values, migration (legacyPhoneSplitSupported: false),
+      LimeSettings UI (no width gate), hot/inbox/relay transport (incl. FA-off text relay
+      `pp=`/`pls=` + `RelayPrefSync.apply`), iPhone split/one-hand rendering + chevron restore
+- [x] Shared backup manifests preserve phone and tablet/iPad profiles without cross-writing
+      (Android `PreferenceBackupAdapter`, iOS `PreferenceBackupAdapter` + hot→cold flush + restore push)
+- [ ] Android phone device verification and iPhone/iPad Xcode Cloud/unit verification (on-device
+      only; Linux CI ran Android unit tests + iOS source contracts)

--- a/docs/SPLIT_ONE_HAND_KB_PLAN.md
+++ b/docs/SPLIT_ONE_HAND_KB_PLAN.md
@@ -1,5 +1,10 @@
 ﻿# Split & One-Handed Keyboard Implementation Plan (goal-mode)
 
+> **Historical plan:** Issue #169 supersedes every `oneHandAvailable` and phone-size-gate
+> instruction below. `SPLIT_ONE_HAND_KB.md` is authoritative: every phone uses the integrated
+> phone profile, while Android tablets at `smallestScreenWidthDp >= 600` and every iPad retain
+> independent tablet split and numpad-anchor profiles.
+
 > **For agentic workers:** This plan is written for a single autonomous **goal-mode** run that
 > finishes ALL tasks and ALL test gates in one session, without user checkpoints. Use
 > superpowers:executing-plans (inline) or superpowers:subagent-driven-development. Steps use

--- a/docs/superpowers/plans/2026-07-19-android-portrait-menu-responsive-row.md
+++ b/docs/superpowers/plans/2026-07-19-android-portrait-menu-responsive-row.md
@@ -1,0 +1,76 @@
+# Android Portrait Menu Responsive Row Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the Android keyboard side menu's portrait-mode title and choices on one line when they fit, with full-width zero-indent fallbacks for every segmented menu control.
+
+**Architecture:** Put the portrait title and control in one row by default. The existing helper compares visible label widths with the measured group width, moves a constrained group below its title at full width, and stacks its buttons only if full width still cannot fit them; other title-above controls are full width directly in XML.
+
+**Tech Stack:** Android XML, Java 11, Material `MaterialButtonToggleGroup`, AndroidX instrumentation tests.
+
+## Global Constraints
+
+- Keep the existing icon, labels, selected-value mapping, persistence, and numpad-only hidden split option.
+- Add no dependency or new production component.
+- Edited XML must be UTF-8 with BOM; Java must remain UTF-8 without BOM.
+
+---
+
+### Task 1: Responsive portrait-mode menu row
+
+**Files:**
+- Modify: `LimeStudio/app/src/main/res/layout/keyboard_menu_panel.xml:63`
+- Modify: `LimeStudio/app/src/main/java/org/limeime/ui/view/SegmentedHanPreference.java:98`
+- Create: `LimeStudio/app/src/androidTest/java/org/limeime/PortraitModeMenuLayoutTest.java`
+
+**Interfaces:**
+- Consumes: `SegmentedHanPreference.stackIfClipped(MaterialButtonToggleGroup)` and `R.layout.keyboard_menu_panel`.
+- Produces: `SegmentedHanPreference.stackIfClippedNow(MaterialButtonToggleGroup group)`, which preserves a horizontal row when labels fit, otherwise uses the full content width before vertically stacking buttons.
+
+- [ ] **Step 1: Write the failing instrumentation test**
+
+Create `PortraitModeMenuLayoutTest.java`. Inflate `keyboard_menu_panel`, assert the portrait control stays horizontal at a wide width, assert its narrow fallback moves below the title at full width with zero indentation, and assert every similar title-above control has zero indentation.
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run:
+
+```bash
+./LimeStudio/gradlew -p LimeStudio connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=org.limeime.PortraitModeMenuLayoutTest
+```
+
+Expected: FAIL because the existing helper's ellipsis signal does not implement the measured-width rule.
+
+- [ ] **Step 3: Implement the minimal responsive row**
+
+In `keyboard_menu_panel.xml`, place the portrait title and group in one row and remove the 44dp indentation from every title-above segmented group. In `SegmentedHanPreference.java`, sum visible label widths and padding; when constrained, move the group below the title at full width with zero indentation, then stack buttons only if needed.
+
+```java
+group.post(() -> stackIfClippedNow(group));
+```
+
+- [ ] **Step 4: Run focused and regression checks**
+
+Run:
+
+```bash
+./LimeStudio/gradlew -p LimeStudio connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=org.limeime.PortraitModeMenuLayoutTest
+./LimeStudio/gradlew -p LimeStudio testDebugUnitTest assembleDebug
+```
+
+Expected: focused test PASS; unit tests and debug build succeed.
+
+- [ ] **Step 5: Visually verify both layouts**
+
+Manual Samsung-phone verification is left to the user by explicit request.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add LimeStudio/app/src/main/res/layout/keyboard_menu_panel.xml \
+  LimeStudio/app/src/main/java/org/limeime/ui/view/SegmentedHanPreference.java \
+  LimeStudio/app/src/androidTest/java/org/limeime/PortraitModeMenuLayoutTest.java
+git commit -m "fix(android): adapt portrait menu row to width"
+```

--- a/docs/superpowers/specs/2026-07-19-android-portrait-menu-responsive-row-design.md
+++ b/docs/superpowers/specs/2026-07-19-android-portrait-menu-responsive-row-design.md
@@ -1,0 +1,20 @@
+# Android Portrait Menu Responsive Row
+
+## Goal
+
+Show the Android keyboard side menu's `直向鍵盤模式` title and segmented choices on one line whenever they fit, matching the iPhone behavior. Stack them only when the available width cannot show the controls without clipping.
+
+## Design
+
+Keep the existing title, icon, buttons, selection behavior, and preference persistence. Change only the portrait-mode block layout:
+
+- The icon/title area and `MaterialButtonToggleGroup` share one horizontal container by default.
+- After layout, measure whether the complete row fits without clipped button labels.
+- If it does not fit, switch the container to vertical orientation and give the toggle group the existing indented, full-width stacked placement.
+- Reuse and minimally extend the existing `SegmentedHanPreference` responsive-layout helper instead of adding a new component or dependency.
+
+The numpad-specific hidden `分離` option remains supported; fit is evaluated from the buttons that are visible for the current keyboard.
+
+## Verification
+
+Add one focused Android layout/helper check that fails while the portrait block is permanently vertical and passes when it defaults to horizontal with a responsive fallback. Run the focused test, the relevant Android unit tests, and an Android build. Visually verify a normal phone width stays on one line and a constrained width or enlarged font stacks without clipped labels.

--- a/docs/superpowers/specs/2026-07-19-android-portrait-menu-responsive-row-design.md
+++ b/docs/superpowers/specs/2026-07-19-android-portrait-menu-responsive-row-design.md
@@ -2,19 +2,21 @@
 
 ## Goal
 
-Show the Android keyboard side menu's `直向鍵盤模式` title and segmented choices on one line whenever they fit, matching the iPhone behavior. Stack them only when the available width cannot show the controls without clipping.
+Show the Android keyboard side menu's `直向鍵盤模式` title and segmented choices on one line whenever they fit, matching the iPhone behavior. Adapt only when the available width cannot show them without clipping.
 
 ## Design
 
 Keep the existing title, icon, buttons, selection behavior, and preference persistence. Change only the portrait-mode block layout:
 
-- The icon/title area and `MaterialButtonToggleGroup` share one horizontal container by default.
-- After layout, measure whether the complete row fits without clipped button labels.
-- If it does not fit, switch the container to vertical orientation and give the toggle group the existing indented, full-width stacked placement.
+- Keep the icon/title and `MaterialButtonToggleGroup` in one horizontal row while the choices fit.
+- If they do not fit, move the choices below the title and stretch them across the full content width without the old icon indentation.
+- If the choices still do not fit at full width, stack the buttons vertically.
 - Reuse and minimally extend the existing `SegmentedHanPreference` responsive-layout helper instead of adding a new component or dependency.
+
+All other segmented controls in the keyboard menu use the full content width when shown below their titles, in portrait and landscape.
 
 The numpad-specific hidden `分離` option remains supported; fit is evaluated from the buttons that are visible for the current keyboard.
 
 ## Verification
 
-Add one focused Android layout/helper check that fails while the portrait block is permanently vertical and passes when it defaults to horizontal with a responsive fallback. Run the focused test, the relevant Android unit tests, and an Android build. Visually verify a normal phone width stays on one line and a constrained width or enlarged font stacks without clipped labels.
+Add focused Android checks for the wide one-line row, the full-width fallback, and every similar segmented control's zero-indent layout. Run them on Samsung and Pixel, then run the relevant Android unit tests and an Android build.


### PR DESCRIPTION
## Summary
- replace conflicting phone split/one-hand preferences with one shared portrait mode on Android phones and iPhones
- restore legacy Android phone portrait split through one-time migration while preserving existing one-hand choices
- add a separate phone landscape split preference; remove all phone-width gates
- keep Android tablets (`smallestScreenWidthDp >= 600`) and iPads on their independent split/numpad profile
- align settings, in-keyboard menus, rendering, chevron restore, backup/restore, and iOS hot/cold relay transport
- update `SPLIT_ONE_HAND_KB.md`, issue notes, and regression coverage

## Preference model

| Context | Active preferences |
|---|---|
| Phone portrait | `phone_portrait_keyboard_mode`: standard / split / left / right |
| Phone landscape | `phone_landscape_split` |
| Android tablet / iPad keyboard | `split_keyboard_mode` |
| Android tablet / iPad numpad | `numpad_anchor` |

Phone and tablet/iPad profile changes never rewrite each other. Backups preserve both profiles and the inactive profile remains dormant.

## Compatibility
- Android legacy one-hand wins over legacy split during migration.
- Android legacy `split_keyboard_mode = 1` restores phone portrait split.
- iOS preserves legacy one-hand but does not infer an iPhone split from the old iPad split key.
- Opening Android settings cannot persist new defaults before migration.
- Legacy backup restore migrates phone geometry only on phone-class targets and invalidates the live keyboard configuration snapshot.

## Verification
- `:app:testDebugUnitTest`
- `:app:lintDebug`
- `:app:connectedDebugAndroidTest` — 1,207 executed test cases, 8 skipped, 0 failed
- focused migration/backup instrumentation — 14 passed
- live Android phone settings visibility — passed
- simulated Android `smallestScreenWidthDp >= 600` settings visibility — passed
- iOS source and Xcode project-reference contracts — passed
- independent second-pass Android and iOS blocker reviews — approved
- `git diff --check`

Swift/Xcode is unavailable on the Linux host; the added iPhone/iPad XCTest coverage remains for macOS CI.

Supersedes the narrower Android-only approach in #170.

Fixes #169
