### PR TITLE
fix(android): stack portrait split key labels (#169)

### DIFF
--- a/LimeStudio/app/src/main/java/org/limeime/keyboard/KeyLabelFit.java
+++ b/LimeStudio/app/src/main/java/org/limeime/keyboard/KeyLabelFit.java
@@ -9,4 +9,9 @@ public final class KeyLabelFit {
         float heightScale = contentHeight > 0 ? availableHeight / contentHeight : 1f;
         return Math.max(minimumScale, Math.min(1f, Math.min(widthScale, heightScale)));
     }
+
+    public static boolean useVerticalLabels(boolean portrait, int keyWidth, int keyHeight,
+                                            int subLabelLength, boolean hasSecondSubLabel) {
+        return portrait || keyHeight > keyWidth || subLabelLength > 2 || hasSecondSubLabel;
+    }
 }

--- a/LimeStudio/app/src/main/java/org/limeime/keyboard/LIMEKeyboardBaseView.java
+++ b/LimeStudio/app/src/main/java/org/limeime/keyboard/LIMEKeyboardBaseView.java
@@ -34,6 +34,7 @@ package org.limeime.keyboard;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
@@ -1059,6 +1060,8 @@ public class LIMEKeyboardBaseView extends View implements PointerTracker.UIProxy
             final int kbdPaddingTop = getPaddingTop();
             final Key[] keys = mKeys;
             final Key invalidKey = mInvalidatedKey;
+            final boolean portrait = getResources().getConfiguration().orientation
+                    == Configuration.ORIENTATION_PORTRAIT;
 
 
             boolean drawSingleKey = false;
@@ -1149,7 +1152,8 @@ public class LIMEKeyboardBaseView extends View implements PointerTracker.UIProxy
                     final int drawableWidth = Math.max(1, key.width - padding.left - padding.right);
                     final int drawableHeight = Math.max(1, key.height - padding.top - padding.bottom);
                     final boolean verticalLabels = hasSubLabel
-                            && (key.height > key.width || subLabel.length() > 2 || hasSecondSubLabel);
+                            && KeyLabelFit.useVerticalLabels(portrait, key.width, key.height,
+                                    subLabel.length(), hasSecondSubLabel);
                     final int labelWidthLimit = hasSubLabel && !verticalLabels
                             ? drawableWidth / 2 : drawableWidth;
                     final int labelHeightLimit = verticalLabels ? drawableHeight / 2 : drawableHeight;
@@ -1224,7 +1228,7 @@ public class LIMEKeyboardBaseView extends View implements PointerTracker.UIProxy
                         }
 
                         //portrait keyboard
-                        if (key.height > key.width || subLabel.length() > 2 || hasSecondSubLabel) {
+                        if (verticalLabels) {
                             // Anchor sub-label from top and main label from bottom; split the
                             // leftover vertical space as top : gap : bottom = 1 : 1 : 1 so the
                             // inter-text gap scales with free space instead of being the residual

--- a/LimeStudio/app/src/test/java/org/limeime/KeyLabelFitTest.java
+++ b/LimeStudio/app/src/test/java/org/limeime/KeyLabelFitTest.java
@@ -1,6 +1,8 @@
 package org.limeime;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.limeime.keyboard.KeyLabelFit;
@@ -12,5 +14,13 @@ public class KeyLabelFitTest {
         assertEquals(0.5f, KeyLabelFit.scale(50, 40, 100, 20, 0.5f), 0.001f);
         assertEquals(0.6f, KeyLabelFit.scale(100, 30, 50, 100, 0.6f), 0.001f);
         assertEquals(1f, KeyLabelFit.scale(100, 40, 80, 30, 0.5f), 0.001f);
+    }
+
+    @Test
+    public void portraitSplitKeysKeepLabelsStackedEvenWhenKeysAreWiderThanTall() {
+        assertTrue(KeyLabelFit.useVerticalLabels(true, 66, 64, 2, false));
+        assertFalse(KeyLabelFit.useVerticalLabels(false, 66, 64, 2, false));
+        assertTrue(KeyLabelFit.useVerticalLabels(false, 66, 64, 3, false));
+        assertTrue(KeyLabelFit.useVerticalLabels(false, 66, 64, 2, true));
     }
 }


### PR DESCRIPTION
## Summary

- render dual-label keys vertically when the device is in portrait orientation
- preserve horizontal dual-label rendering in landscape
- prevent portrait split-key labels such as `q / 1↑` from crowding or clipping at the key edges

## Verification

- `KeyLabelFitTest` and `PhoneKeyboardModePolicyTest` pass
- Android unit tests, lint, and Android-test compilation pass
- full connected instrumentation suite: 1,211 tests executed, 8 skipped, 0 failed
- emulator runtime check with the portrait split Array layout confirms vertically stacked labels without edge clipping or overlap; the full-width portrait arrow row is unchanged

Relates to #169. The issue should remain open until reporter/device confirmation.
