### PR TITLE
test(iOS): diagnose #244 production-seam timeouts

### DIFF
--- a/LimeIME-iOS/LimeTests/DBServerTest.swift
+++ b/LimeIME-iOS/LimeTests/DBServerTest.swift
@@ -60,6 +60,25 @@ private final class ThreadSafeError: @unchecked Sendable {
     }
 }
 
+private final class ProductionSeamTrace: @unchecked Sendable {
+    private let lock = NSLock()
+    private let startedAt = ProcessInfo.processInfo.systemUptime
+    private var phases: [String] = []
+
+    func mark(_ phase: String) {
+        let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+        lock.lock()
+        phases.append(String(format: "%.3fs %@", elapsed, phase))
+        lock.unlock()
+    }
+
+    var summary: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return phases.joined(separator: " -> ")
+    }
+}
+
 // MARK: - DBServerTest
 final class DBServerTest: XCTestCase {
 
@@ -608,9 +627,12 @@ final class DBServerTest: XCTestCase {
         try FileManager.default.createDirectory(at: hotDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: hotDir) }
 
+        let trace = ProductionSeamTrace()
+        trace.mark("hot bootstrap starting")
         let server = DBServer(_testDatabaseDirectory: hotDir, tracksHotLearning: true)
         let context = try server.prepareKeyboardRuntimeDatabase()
         let ss = context.searchServer
+        trace.mark("hot bootstrap completed")
 
         // Drive learning the way the keyboard does: commit two candidates, then the
         // dismiss path (postFinishInput) performs the related-phrase learning write.
@@ -621,11 +643,20 @@ final class DBServerTest: XCTestCase {
                              recordType: Mapping.RecordType.exactMatchToCode)
         ss.learnRelatedPhraseAndUpdateScore(first)
         ss.learnRelatedPhraseAndUpdateScore(second)
+        trace.mark("hot learning submitted")
 
         let finished = expectation(description: "postFinishInput learning completed")
-        ss.postFinishInput { finished.fulfill() }
-        wait(for: [finished], timeout: 60.0)
+        ss.postFinishInput {
+            trace.mark("hot completion callback")
+            finished.fulfill()
+        }
+        trace.mark("hot finish enqueued")
+        let waitResult = XCTWaiter.wait(for: [finished], timeout: 60.0)
+        XCTAssertEqual(waitResult, .completed,
+                       "hot production seam did not complete; phases: \(trace.summary)")
+        guard waitResult == .completed else { return }
 
+        trace.mark("hot inspection starting")
         let queue = try DatabaseQueue(path: hotDir.appendingPathComponent("lime.db").path)
         defer { try? queue.close() }
         let journaled = try queue.read { db -> [String] in
@@ -636,7 +667,7 @@ final class DBServerTest: XCTestCase {
                 .map { "\($0["tbl"] as String? ?? "")|\($0["k1"] as String? ?? "")|\($0["k2"] as String? ?? "")" }
         }
         XCTAssertTrue(journaled.contains("related|甲|乙"),
-                      "keyboard-role learning through the production DBServer→SearchServer seam must journal learn_outbox; got \(journaled)")
+                      "keyboard-role learning through the production DBServer→SearchServer seam must journal learn_outbox; got \(journaled); phases: \(trace.summary)")
     }
 
     func testAppRoleRuntimeDoesNotCreateLearnOutbox() throws {
@@ -647,9 +678,12 @@ final class DBServerTest: XCTestCase {
         try FileManager.default.createDirectory(at: coldDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: coldDir) }
 
+        let trace = ProductionSeamTrace()
+        trace.mark("cold bootstrap starting")
         let server = DBServer(_testDatabaseDirectory: coldDir)
         let context = try server.prepareKeyboardRuntimeDatabase()
         let ss = context.searchServer
+        trace.mark("cold bootstrap completed")
         ss.candidateSuggestion = true
         ss.learnRelatedPhraseAndUpdateScore(
             Mapping(id: 0, code: "aa", word: "甲", score: 0, baseScore: 0,
@@ -657,14 +691,24 @@ final class DBServerTest: XCTestCase {
         ss.learnRelatedPhraseAndUpdateScore(
             Mapping(id: 0, code: "bb", word: "乙", score: 0, baseScore: 0,
                     recordType: Mapping.RecordType.exactMatchToCode))
+        trace.mark("cold learning submitted")
         let finished = expectation(description: "postFinishInput learning completed")
-        ss.postFinishInput { finished.fulfill() }
-        wait(for: [finished], timeout: 60.0)
+        ss.postFinishInput {
+            trace.mark("cold completion callback")
+            finished.fulfill()
+        }
+        trace.mark("cold finish enqueued")
+        let waitResult = XCTWaiter.wait(for: [finished], timeout: 60.0)
+        XCTAssertEqual(waitResult, .completed,
+                       "cold production seam did not complete; phases: \(trace.summary)")
+        guard waitResult == .completed else { return }
 
+        trace.mark("cold inspection starting")
         let queue = try DatabaseQueue(path: coldDir.appendingPathComponent("lime.db").path)
         defer { try? queue.close() }
         let outboxExists = try queue.read { db in try db.tableExists("learn_outbox") }
-        XCTAssertFalse(outboxExists, "cold-role datasource must not create learn_outbox")
+        XCTAssertFalse(outboxExists,
+                       "cold-role datasource must not create learn_outbox; phases: \(trace.summary)")
     }
 
     func testDBServerGetInstanceWithoutContext() {

--- a/docs/#244_ISSUE.md
+++ b/docs/#244_ISSUE.md
@@ -34,6 +34,16 @@ Xcode Cloud run 52 executed the required full `LimeTests` action at `1a2a781bc41
 - Both 60-second tests passed once on one iOS 26.5 simulator from the exact `v6.1.38` tag.
 - Xcode Cloud run 60 passed its required TEST and ARCHIVE actions at PR #243 head `a4c7b5869c678c5adedff98493e70b7382f28fd7`; these two tests were unchanged from `v6.1.38`.
 
+### 2026-08-21 local remediation evidence
+
+The exact `origin/master` head `8724ffb97d8eb8f85b9c688b3328dd00cb675905` was exercised on the project macOS host with Xcode 26.6 and an iOS 26.5 iPhone 17 Pro simulator:
+
+- With process relaunch enabled for every repetition, both tests passed in 19 completed iterations. Xcode then failed before the twentieth iteration because the cloned simulator could not launch `org.limeime`. The result was an XCTest host-launch failure, not either production-seam timeout.
+- With one test process and 20 repetitions, both tests passed all 20 iterations. The cold-role test ranged from 0.346 to 3.399 seconds, and the hot-role test ranged from 0.310 to 0.433 seconds.
+- The first remediation slice adds thread-safe phase tracing around bootstrap, learning submission, finish enqueue, completion callback, and database inspection. Timeout failures now report the last completed phase rather than only a generic XCTest timeout. Production code and the 60-second deadlock guard remain unchanged while evidence is gathered.
+
+This local run does not reproduce the historical Xcode Cloud completion timeout. It does establish a separate simulator relaunch boundary and provides the diagnostics needed to distinguish Cloud queue non-execution from bootstrap or inspection delay on the next failing run.
+
 A later green run does not erase the earlier cross-destination timeout or prove repeatability. It does narrow this issue to synchronization and test-environment reliability unless an independent production reproduction is found.
 
 ## Architecture preflight


### PR DESCRIPTION
## Scope

First diagnostic slice for #244. This keeps the production cold/hot learning contract unchanged and makes the two production-seam test failures identify their last completed phase.

## Changes

- add a thread-safe test trace for bootstrap, learning submission, finish enqueue, completion callback, and database inspection
- use `XCTWaiter` so timeout failures include the phase trace and stop before misleading downstream database assertions
- record the exact local reproduction evidence in `docs/#244_ISSUE.md`

## Evidence

- Historical controlled RED: Xcode Cloud run 52 timed out at 10 seconds across multiple destinations
- Exact `origin/master` `8724ffb97d8eb8f85b9c688b3328dd00cb675905`: 19 relaunch iterations completed with both tests passing, then Xcode failed to launch the cloned simulator test host before iteration 20
- This branch: both tests passed 20 of 20 repetitions in one iOS 26.5 simulator test process using Xcode 26.6
- Exact diagnostic test file: full `DBServerTest` passed 101 of 101 tests on the same simulator
- Linux issue-209 production-seam source contract: 10 of 10 tests passed
- Independent architecture-aware review: APPROVE with no blockers
- `git diff --check`: pass

## Current status

This draft does not claim the historical Xcode Cloud root cause is fixed. The local run did not reproduce that timeout. The diagnostic slice is intended to distinguish queue non-execution from bootstrap or inspection delay on the next failing Cloud run.

Production code, queue QoS, assertions, and the 60-second deadlock guard are unchanged. Issue #242, PR #243, and the unrelated `pinyin.zip` fixture defect remain out of scope.

Refs #244
